### PR TITLE
🐛 Fix dropdown menu after state change

### DIFF
--- a/app/views/admin/archives/create.js.erb
+++ b/app/views/admin/archives/create.js.erb
@@ -5,6 +5,10 @@
   var html = '<%= j render(partial: '/admin/job_offers/job_offer', locals: { job_offer: @job_offer }) %>'
   var frag = document.createRange().createContextualFragment(html)
   jobOffer.replaceWith(frag)
+
+  window.BSN.initCallback()
+
   Snackbar.show({showAction: false, text: '<%= @notification %>'})
+
   new window.BSN.Modal('#modal').hide()
 <% end %>

--- a/app/views/admin/job_offers/state_change.js.erb
+++ b/app/views/admin/job_offers/state_change.js.erb
@@ -12,4 +12,7 @@ var jobOffer = document.getElementById('<%= dom_id(@job_offer) %>')
 var html = '<%= j render(partial: 'job_offer', locals: { job_offer: @job_offer }) %>'
 var frag = document.createRange().createContextualFragment(html)
 jobOffer.replaceWith(frag)
+
+window.BSN.initCallback()
+
 Snackbar.show({showAction: false, text: '<%= @notification %>'})


### PR DESCRIPTION
closes #1504 

Le dropdown menu fonctionne même après un changement d'état : 

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/f433ef40-86da-4652-b9bb-dfd107dd83cf)
