### PR TITLE
:bug: Fix error messages on new job offer

### DIFF
--- a/app/javascript/controllers/trix_errors_controller.js
+++ b/app/javascript/controllers/trix_errors_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { 
+    modelName: String,
+    inputs: Array
+  }
+
+  connect() {
+    this.inputsValue.forEach((inputName) => {
+      const trixInput = this.element.querySelector(`[input='${this.modelNameValue}_${inputName}']`)
+      if (trixInput && trixInput.parentElement) {
+        trixInput.parentElement.classList.add("is-invalid")
+      }
+    })
+  }
+}

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -73,12 +73,12 @@
                         = f.input :contract_start_on, as: :string
                     .row
                       .col-12.col-md-3
-                        = f.input :pep_value
+                        = f.input :pep_value, input_html: { class: @job_offer.errors[:base].any? { _1.include?("PEP") } ? "is-invalid" : "" }
                       .col-12.col-md-6
                         = f.input :pep_date, as: :string
                     .row
                       .col-12.col-md-3
-                        = f.input :bne_value
+                        = f.input :bne_value, input_html: { class: @job_offer.errors[:base].any? { _1.include?("BNE") } ? "is-invalid" : "" }
                       .col-12.col-md-6
                         = f.input :bne_date, as: :string
                     .row

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -6,7 +6,6 @@
     .col-12.px-0
       = simple_form_for([:admin, @job_offer], data: {controller: "form-save", form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData"}) do |f|
         = f.error_notification
-        = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
         - if @job_offer.errors.any?
           .alert.alert-danger.pt-0
             %ul.mb-0

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -4,7 +4,7 @@
 .container-fluid{data: { controller: "job-offer-management"}}
   .row
     .col-12.px-0
-      = simple_form_for([:admin, @job_offer], data: {controller: "form-save", form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData"}) do |f|
+      = simple_form_for([:admin, @job_offer], data: {controller: "form-save trix-errors", trix_errors_model_name_value: "job_offer", trix_errors_inputs_value: @job_offer.errors.attribute_names, form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData"}) do |f|
         = f.error_notification
         - if @job_offer.errors.any?
           .alert.alert-danger.pt-0

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1090,7 +1090,7 @@ fr:
         job_offer:
           attributes:
             base:
-              pep_or_bne: "PEP et/ou BNE doit être remplis"
+              pep_or_bne: "PEP et/ou BNE doit être rempli(e)"
             title:
               brackets: "ne doit pas contenir de parenthèse"
               f_h: "doit finir par F/H"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1157,6 +1157,7 @@ fr:
         state/archived: "Archivée"
         contract_type: "Type de contrat"
         contract_start_on: "Début du contrat"
+        contract_duration: "Durée du contrat"
         location: "Localisation"
         study_level: "Niveau d'études"
         category: "Domaine professionnel"
@@ -1166,6 +1167,7 @@ fr:
         benefits: "Avantages en nature"
         is_remote_possible: "Télétravail"
         organization_description: "Descriptif de l'organisation"
+        required_profile: "Profil recherché"
       job_offer_actor/role:
         employer: "Employeur"
         grand_employer: "Grand Employeur"


### PR DESCRIPTION
# Description

On réalise les corrections concernant les messages d'erreur affichés lors de la publication d'une offre, tel que décrit dans #1513.

1/ Les messages d'erreur ne sont plus dupliqués : 

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/f178099b-7a1b-4a9c-944c-25c51608129b)

2/ On corrige quelques fautes d'orthographe

3/ On ajoute les traductions manquantes pour que tous les messages soient affichés en français

4/ On affiche les erreurs même pour les éditeurs riches (trix) : 

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/7585e97e-fef0-406e-82e9-438d825e91e0)

5/ On indique que les champs PEP / BNE sont en erreur quand nécessaire (il faut que l'un des deux champs soit rempli) : 

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/41fad38d-6035-4151-bc7e-91097e4881b3)


# Test

https://erecrutement-cvd-staging-pr1568.osc-fr1.scalingo.io/admin/offresdemploi

# Liens

Closes #1513 