### PR TITLE
🚸 Show "no raison" when archived with no reason

### DIFF
--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -35,10 +35,11 @@
             = "#{job_offer.aasm.human_state}"
           - if job_offer.state_date
             = I18n.l(job_offer.state_date.to_date)
-          - if job_offer.archiving_reason.present?
-            = job_offer.archiving_reason.name
-          - else
-            = t("job_offers.job_offer.archiving_reasons.no_reason")
+          - if job_offer.archived?
+            - if job_offer.archiving_reason.present?
+              = job_offer.archiving_reason.name
+            - else
+              = t("job_offers.job_offer.archiving_reasons.no_reason")
         %ul.list-inline.mb-0.actions.mt-2.mt-md-0
           %li.list-inline-item.d-none
             = link_to '#' do

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -37,6 +37,8 @@
             = I18n.l(job_offer.state_date.to_date)
           - if job_offer.archiving_reason.present?
             = job_offer.archiving_reason.name
+          - else
+            = t("job_offers.job_offer.archiving_reasons.no_reason")
         %ul.list-inline.mb-0.actions.mt-2.mt-md-0
           %li.list-inline-item.d-none
             = link_to '#' do

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -137,6 +137,8 @@ fr:
     job_offer:
       show: "Voir le détail de l'offre"
       published_date: 'Publiée il y a %{time_ago_in_words}'
+      archiving_reasons:
+        no_reason: Aucune raison
     job_offer_content:
       apply: "Je postule"
       description: "Descriptif des missions"


### PR DESCRIPTION
Quand une offre est archivée sans raison, alors on affiche "Aucune raison" dans la liste des offres archivées.

Closes #1515

![image](https://github.com/betagouv/civilsdeladefense/assets/1193334/236bdc45-97a4-4123-acbb-da5271708e91)


Cette modification est testable sur la review app : https://erecrutement-cvd-staging-pr1576.osc-fr1.scalingo.io/