### PR TITLE
Show navigation links when current page is Account

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -35,18 +35,17 @@
                 = link_to t(".account_root"), new_session_path(User), class: %w[rf-link rf-fi-account-line]
     %nav#navigation-709.rf-nav.rf-modal{"aria-label" => "Menu principal", role: "navigation"}
       %button.rf-link--close.rf-link{"aria-controls" => "navigation-709"} Fermer
-      - unless controller.class.module_parent == Account
-        %ul.rf-nav__list
-          - klass = controller.controller_name == 'homepages' ? 'rf-nav__item--active' : nil
-          %li.rf-nav__item{class: klass}
-            = link_to "Accueil", root_path, class: 'rf-nav__link'
+      %ul.rf-nav__list
+        - klass = controller.controller_name == 'homepages' ? 'rf-nav__item--active' : nil
+        %li.rf-nav__item{class: klass}
+          = link_to "Accueil", root_path, class: 'rf-nav__link'
 
-          - klass = controller.controller_name == 'job_offers' && controller.action_name == 'index' ? 'rf-nav__item--active' : nil
-          %li.rf-nav__item{class: klass}
-            = link_to "Nos offres", job_offers_path, class: 'rf-nav__link'
+        - klass = controller.controller_name == 'job_offers' && controller.action_name == 'index' ? 'rf-nav__item--active' : nil
+        %li.rf-nav__item{class: klass}
+          = link_to "Nos offres", job_offers_path, class: 'rf-nav__link'
 
-          - spontaneous = JobOffer.find_by(spontaneous: true)
-          - if spontaneous
-            - klass = controller.controller_name == 'job_offers' && controller.action_name == 'show' ? 'rf-nav__item--active' : nil
-            %li.rf-nav__item{class: klass}
-              = link_to "Candidature spontanée", spontaneous, class: 'rf-nav__link'
+        - spontaneous = JobOffer.find_by(spontaneous: true)
+        - if spontaneous
+          - klass = controller.controller_name == 'job_offers' && controller.action_name == 'show' ? 'rf-nav__item--active' : nil
+          %li.rf-nav__item{class: klass}
+            = link_to "Candidature spontanée", spontaneous, class: 'rf-nav__link'


### PR DESCRIPTION
Sur la page "Mon espace candidat", on affiche les liens qui permettent de naviguer vers l'accueil / nos offres / candidature spontanée.

https://erecrutement-cvd-staging-pr1613.osc-fr1.scalingo.io/

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/442d0bf6-49fb-49a1-b0fe-551721964382)



closes #1597