### PR TITLE
Add missing env vars to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
           DATABASE_URL_TEST: postgresql://circleci:@127.0.0.1:5432/civilsdeladefense_test
           SMTP_URL: smtp://hello%40localhost@localhost
           LOCKBOX_MASTER_KEY: 0000000000000000000000000000000000000000000000000000000000000000
+          DEFAULT_FROM: hello@localhost
+          DEFAULT_HOST: http://localhost:3000
+          CI: true
+          FRANCE_CONNECT_HOST: not.a.real.host.test-franceconnect.fr
       - image: circleci/postgres:11.5-alpine-ram
         environment:
           POSTGRES_USER: circleci


### PR DESCRIPTION
# Description

Add missing env vars to CircleCI config, in order to fix it.

# Links

Closes #1617

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/46c442fb-0da2-422e-9f14-867308bf2c50)

