### PR TITLE
Headline job offer: make the whole card clickable

### DIFF
--- a/app/views/homepages/_job_offer_headline_card.html.haml
+++ b/app/views/homepages/_job_offer_headline_card.html.haml
@@ -1,12 +1,13 @@
 .rf-col-12.rf-col-md-6.rf-col-lg-4
   .rf-card.rounded-lg
-    .rf-card__body
-      %h4.rf-card__title
-        = link_to job_offer.title, job_offer, class: "rf-card__link"
-      %p.rf-card__desc
-        = job_offer_contract_type_display(job_offer)
-        %br
-        = job_offer.location
-      - if job_offer.published_at.present?
-        .rf-card__detail
-          = t('job_offers.job_offer.published_date', time_ago_in_words: time_ago_in_words(job_offer.published_at))
+    = link_to job_offer do
+      .rf-card__body
+        %h4.rf-card__title
+          = job_offer.title
+        %p.rf-card__desc
+          = job_offer_contract_type_display(job_offer)
+          %br
+          = job_offer.location
+        - if job_offer.published_at.present?
+          .rf-card__detail
+            = t('job_offers.job_offer.published_date', time_ago_in_words: time_ago_in_words(job_offer.published_at))


### PR DESCRIPTION
# Description

Pour les offres à la une, la flèche n'était pas cliquable, tel que décrit par #1620.
À cause de la version du DSFR incluse dans le projet, il n'est pas possible de rendre la flèche seule cliquable.
On rend donc toute la card cliquable.

# Review app

https://erecrutement-cvd-staging-pr1626.osc-fr1.scalingo.io

# Links

Closes #1620

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/895b6fd6-30a7-4d3a-a2bd-d634126b928a)

