### PR TITLE
:bug: Fix crash when adding a message from admin job application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,10 +67,6 @@ gem "faker", require: false
 gem "omniauth_openid_connect", "~> 0.4.0"
 gem "omniauth-rails_csrf_protection"
 
-group :development do
-  gem "letter_opener"
-end
-
 group :development, :test do
   gem "brakeman", require: false
 
@@ -94,6 +90,8 @@ group :development, :test do
 end
 
 group :development do
+  gem "debug"
+  gem "letter_opener"
   gem "annotate"
 
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
       activesupport (>= 4.2)
     crass (1.0.6)
     date (3.3.3)
+    debug (1.8.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -214,6 +217,9 @@ GEM
       responders (>= 2, < 4)
     invisible_captcha (2.0.0)
       rails (>= 5.0)
+    io-console (0.7.2)
+    irb (1.7.4)
+      reline (>= 0.3.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -249,7 +255,6 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.1)
     multi_json (1.15.0)
@@ -264,8 +269,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.4)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -374,6 +378,8 @@ GEM
     redis-client (0.17.0)
       connection_pool
     regexp_parser (2.8.3)
+    reline (0.4.2)
+      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -538,7 +544,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   aasm
@@ -555,6 +561,7 @@ DEPENDENCIES
   charlock_holmes
   clockwork
   counter_culture
+  debug
   devise
   dotenv-rails
   factory_bot_rails

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -17,7 +17,7 @@
       "cwe_id": [
         1104
       ],
-      "note": "Must fix later by upgrading to a newer Ruby version"
+      "note": "Waiting for a Ruby upgrade in the project (needs CircleCI upgrade, NodeJS upgrade, Webpacker upgrade)"
     },
     {
       "warning_type": "Cross-Site Scripting",

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -480,8 +480,7 @@ fr:
         success: "Les emails ont été envoyés !"
     messages:
       create:
-        success: "Message envoyé !"
-      create:
+        success: "Message enregistré !"
         failure: "Une erreur est survenue, veuillez réessayer."
     shared:
       navbar:


### PR DESCRIPTION
# Description

Quand on ajoutait un message ("activité et commentaire") à une candidature (en back office), il semblait ne rien se passer. En réalité le message était bien enregistré, mais une erreur dans la récupération de la notification flash faisait planter le rendu en front.

# Review app

https://erecrutement-cvd-staging-pr1627.osc-fr1.scalingo.io

# Links

Closes #1624

# Screenshots

## Erreur rencontrée

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/296f3d1c-22c6-4cce-8dfe-1474c7df4622)

## Après correctif

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/3349d66c-b7f0-49e5-a2c4-b1073364d0e1)
