### PR TITLE
🐛 Fix headers link active state

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,4 +46,12 @@ module ApplicationHelper
     end
     super(object, *(args << options), &block)
   end
+
+  def header_offers_active?(controller_name, action_name, job_offer: nil)
+    controller_name == "job_offers" && (action_name == "index" || (action_name == "show" && !job_offer.spontaneous?))
+  end
+
+  def header_spontaneous_active?(controller_name, action_name, job_offer: nil)
+    controller_name == "job_offers" && action_name == "show" && job_offer&.spontaneous?
+  end
 end

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -40,12 +40,12 @@
         %li.rf-nav__item{class: klass}
           = link_to "Accueil", root_path, class: 'rf-nav__link'
 
-        - klass = controller.controller_name == 'job_offers' && controller.action_name == 'index' ? 'rf-nav__item--active' : nil
+        - klass = header_offers_active?(controller.controller_name, controller.action_name, job_offer: @job_offer) ? 'rf-nav__item--active' : nil
         %li.rf-nav__item{class: klass}
           = link_to "Nos offres", job_offers_path, class: 'rf-nav__link'
 
         - spontaneous = JobOffer.find_by(spontaneous: true)
         - if spontaneous
-          - klass = controller.controller_name == 'job_offers' && controller.action_name == 'show' ? 'rf-nav__item--active' : nil
+          - klass = header_spontaneous_active?(controller.controller_name, controller.action_name, job_offer: @job_offer) ? 'rf-nav__item--active' : nil
           %li.rf-nav__item{class: klass}
             = link_to "Candidature spontanée", spontaneous, class: 'rf-nav__link'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#header_offers_active?" do
+    subject { helper.header_offers_active?(controller_name, action_name, job_offer: job_offer) }
+
+    context "when controller_name is job_offers and action_name is index" do
+      let(:controller_name) { "job_offers" }
+      let(:action_name) { "index" }
+      let(:job_offer) { nil }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when controller_name is job_offers and action_name is show and job_offer is not spontaneous" do
+      let(:controller_name) { "job_offers" }
+      let(:action_name) { "show" }
+      let(:job_offer) { instance_double(JobOffer, spontaneous?: false) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when controller_name is job_offers and action_name is show and job_offer is spontaneous" do
+      let(:controller_name) { "job_offers" }
+      let(:action_name) { "show" }
+      let(:job_offer) { instance_double(JobOffer, spontaneous?: true) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when controller_name is not job_offers" do
+      let(:controller_name) { "other" }
+      let(:action_name) { "index" }
+      let(:job_offer) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "#header_spontaneous_active?" do
+    subject { helper.header_spontaneous_active?(controller_name, action_name, job_offer: job_offer) }
+
+    context "when controller_name is job_offers and action_name is show and job_offer is spontaneous" do
+      let(:controller_name) { "job_offers" }
+      let(:action_name) { "show" }
+      let(:job_offer) { instance_double(JobOffer, spontaneous?: true) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when controller_name is job_offers and action_name is show and job_offer is not spontaneous" do
+      let(:controller_name) { "job_offers" }
+      let(:action_name) { "show" }
+      let(:job_offer) { instance_double(JobOffer, spontaneous?: false) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when controller_name is not job_offers" do
+      let(:controller_name) { "other" }
+      let(:action_name) { "index" }
+      let(:job_offer) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Lorsqu'on descendait dans une offre, le lien de header "Candidature spontanée" était activé.
Désormais, le lien de header "Nos offres" est activé.

# Review app

https://erecrutement-cvd-staging-pr1644.osc-fr1.scalingo.io

# Links

Closes #1601

# Screenshots

[Capture vidéo du 2024-02-15 15-47-02.webm](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/a97086c4-e2b2-4fba-9842-c872966bcc13)
