### PR TITLE
Normalize and validate phone number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "will_paginate"
 gem "working_hours", "~> 1.4"
 gem "sidekiq" # Async jobs
 gem "rorvswild" # Errors tracking
+gem "phony_rails" # Normalize phone numbers
 
 gem "clockwork" # simulate cron on Scalingo
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,10 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    phony (2.20.11)
+    phony_rails (0.15.0)
+      activesupport (>= 3.0)
+      phony (>= 2.18.12)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -581,6 +585,7 @@ DEPENDENCIES
   omniauth_openid_connect (~> 0.4.0)
   pg (>= 0.18, < 2.0)
   pg_search
+  phony_rails
   puma
   rack-cors
   rack-rewrite

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,11 +39,14 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :department_users, reject_if: :all_blank
 
+  phony_normalize :phone, default_country_code: "FR"
+
   mount_uploader :photo, PhotoUploader, mount_on: :photo_file_name
   validates :photo,
     file_size: {less_than: 1.megabytes}
 
   validates :first_name, :last_name, presence: true
+  validates_plausible_phone :phone
   validates :phone, :current_position, presence: true, allow_nil: true
   validates :terms_of_service, :certify_majority, acceptance: true
   validate :password_complexity

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1221,3 +1221,4 @@ fr:
       content_type_allowlist_error: "Mauvais format. Seuls sont acceptés les formats PDF pour les documents et PNG/JPG pour les photos."
       carrierwave_integrity_error: is not an allowed file type
       france_connect: Une erreur est survenue, veuillez réessayer.
+      improbable_phone: "Veuillez saisir un numéro de téléphone valide (0606060606)"

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::UsersController do
     }
 
     context "with valid params" do
-      let(:user_params) { {phone: "07"} }
+      let(:user_params) { {phone: "0712345678"} }
 
       context "when format is HTML" do
         let(:format) { :html }
@@ -28,7 +28,7 @@ RSpec.describe Admin::UsersController do
         it "updates the requested user" do
           update
           user.reload
-          expect(user.phone).to eq("07")
+          expect(user.phone).to eq("+33712345678")
         end
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Admin::UsersController do
         it "updates the requested user" do
           update
           user.reload
-          expect(user.phone).to eq("07")
+          expect(user.phone).to eq("+33712345678")
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     current_position { "CEO" }
-    phone { "06" }
+    phone { "0612345678" }
     website_url { "MyString" }
     email { Faker::Internet.unique.safe_email }
     password { "f4k3p455w0rD!" }


### PR DESCRIPTION
# Description

On normalise et on valide les numéros de téléphones des utilisateur·rices.

On s'appuie pour cela sur la [gem phony_rails](https://github.com/joost/phony_rails), qui est largement éprouvée.

Le principe de normalisation est le suivant :
- la personne inscrit son numéro (par exemple "06.12.34.56.78")
- phony_rails enlève les espaces, les points, slashs, etc, et ajoute l'indicatif (on arrive donc au résultat "+33612345678")

La France est le pays par défaut, donc c'est l'indicatif "+33" qui est utilisé. Toutefois, une personne peut tout à fait utiliser un autre indicatif, qui sera alors conservé (par exemple "+44 123 123456" sera transformé en "+44123123456").

Ensuite, la validation opérée par phone_rails s'appuie sur un ensemble d'heuristiques : 
- il faut que le numéro soit présent, on ne peut pas laisser le champ vide
- il faut que le numéro soit plausible

Par exemple, "toto" ou "123456789123456789" ne sont pas considérés comme plausibles dont ils ne passent pas la validation.

# Review app

https://erecrutement-cvd-staging-pr1645.osc-fr1.scalingo.io

# Links

Closes #1602

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/9eccf6b6-1039-445c-9302-14170ca446aa)


[Capture vidéo du 2024-02-15 16-59-03.webm](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/4fefd10a-bcc4-47d3-a7ae-73d4d6d59132)
