### PR TITLE
Allow langage and level to be blank

### DIFF
--- a/app/javascript/css/application.scss
+++ b/app/javascript/css/application.scss
@@ -129,7 +129,7 @@ label {
 }
 
 .d-none {
-  display: none;
+  display: none !important;
 }
 
 .d-block {

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,7 +13,8 @@ class Profile < ApplicationRecord
   belongs_to :availability_range, optional: true
   belongs_to :age_range, optional: true
   has_many :profile_foreign_languages, dependent: :destroy
-  accepts_nested_attributes_for :profile_foreign_languages
+  accepts_nested_attributes_for :profile_foreign_languages,
+    reject_if: proc { |attrs| attrs["foreign_language_id"].blank? || attrs["foreign_language_level_id"].blank? }
 
   #####################################
   # Validations

--- a/app/views/profile_foreign_languages/_form.html.haml
+++ b/app/views/profile_foreign_languages/_form.html.haml
@@ -5,11 +5,11 @@
         .rf-col-6
           - name = "job_application[profile_attributes][profile_foreign_languages_attributes][index][foreign_language_id]"
           = label_tag name, t("simple_form.labels.defaults.foreign_language")
-          = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name"), class: "rf-select"
+          = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name"), class: "rf-select", include_blank: true
         .rf-col-6
           - name = "job_application[profile_attributes][profile_foreign_languages_attributes][index][foreign_language_level_id]"
           = label_tag name, t("simple_form.labels.defaults.foreign_language_level")
-          = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name"), class: "rf-select"
+          = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name"), class: "rf-select", include_blank: true
     .rf-col-1.text-center.rf-mt-4w
       %button.blank_button.rf-fi-delete-line{data: { action: 'click->duplicator#remove' }}
   %div{ data: { duplicator: { target: :root }}}
@@ -20,11 +20,11 @@
             .rf-col-6
               - name = "job_application[profile_attributes][profile_foreign_languages_attributes][#{index}][foreign_language_id]"
               = label_tag name, t("simple_form.labels.defaults.foreign_language")
-              = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name", selected: profile_foreign_language.foreign_language_id), class: "rf-select"
+              = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name", selected: profile_foreign_language.foreign_language_id), class: "rf-select", include_blank: true
             .rf-col-6
               - name = "job_application[profile_attributes][profile_foreign_languages_attributes][#{index}][foreign_language_level_id]"
               = label_tag name, t("simple_form.labels.defaults.foreign_language_level")
-              = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name", selected: profile_foreign_language.foreign_language_level_id), class: "rf-select"
+              = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name", selected: profile_foreign_language.foreign_language_level_id), class: "rf-select", include_blank: true
         .rf-col-1.text-center.rf-mt-4w
           %button.blank_button.rf-fi-delete-line{data: { action: 'click->duplicator#remove' }}
 


### PR DESCRIPTION
# Description

Les champs "Langue étrangère" et "Niveau de langue" étaient préremplis.

Désormais, on fait en sorte que le·a postulant·e puisse les laisser vide.

# Review app

https://erecrutement-cvd-staging-pr1647.osc-fr1.scalingo.io

# Links

Closes #1621

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/0ec45b8a-71e4-4639-8bd3-352c5e92ea6f)

