### PR TITLE
:bug: Don't build default user department

### DIFF
--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -52,7 +52,6 @@ class JobOffersController < ApplicationController
     else
       @job_application = JobApplication.new
       @job_application.user = user_signed_in? ? current_user : User.new
-      @job_application.user.department_users.build
       @job_application.build_profile
     end
   end

--- a/app/javascript/css/application.scss
+++ b/app/javascript/css/application.scss
@@ -129,7 +129,7 @@ label {
 }
 
 .d-none {
-  display: none;
+  display: none !important;
 }
 
 .d-block {


### PR DESCRIPTION
# Description

Le premier choix géographique n'était pas enregistré. C'est parce qu'il n'était pas prévu pour être affiché (c'est un support qui sert à la duplication quand on fait "Ajouter un souhait géographique").

Ici on corrige le problème en ne l'affichant pas.

# Review app

https://erecrutement-cvd-staging-pr1649.osc-fr1.scalingo.io

# Links

Closes #1623

