### PR TITLE
🐛 Deactivate never signed in admins 

### DIFF
--- a/app/models/concerns/deactivation_flow.rb
+++ b/app/models/concerns/deactivation_flow.rb
@@ -6,55 +6,67 @@ module DeactivationFlow
 
   # Deactivation management class method
   module ClassMethods
-    def deactivate_when_too_old
-      target_date = days_notice_period_before_deactivation.days.ago.to_date
-      where("marked_for_deactivation_on < ?", target_date)
-        .where("last_sign_in_at < ?", days_inactivity_period_before_deactivation.days.ago)
-        .find_each do |administrator|
-          administrator.deactivate
-          DeactivationMailer.notice(administrator).deliver_now
-        end
+    def deactivate_when_too_old!
+      deactivate_admins!(inactive_and_marked_for_deactivation_admins)
+      deactivate_admins!(never_signed_in_and_marked_for_deactivation_admins)
+      mark_admins_for_deactivation!(inactive_and_not_marked_for_deactivation_admin)
+      mark_admins_for_deactivation!(never_signed_in_and_not_marked_for_deactivation_admins)
+    end
 
+    private
+
+    def deactivate_admins!(scope) = scope.find_each { deactivate_admin!(_1) }
+
+    def mark_admins_for_deactivation!(scope) = scope.find_each { mark_admin_for_deactivation!(_1) }
+
+    def deactivate_admin!(administrator)
+      administrator.deactivate
+      DeactivationMailer.notice(administrator).deliver_now
+    end
+
+    def mark_admin_for_deactivation!(administrator)
+      administrator.mark_for_deactivation!
+      DeactivationMailer.period_before(administrator).deliver_now
+    end
+
+    def inactive_and_marked_for_deactivation_admins
+      where("marked_for_deactivation_on < ?", days_notice_period_before_deactivation.days.ago.to_date)
+        .where("last_sign_in_at < ?", days_inactivity_period_before_deactivation.days.ago)
+    end
+
+    def never_signed_in_and_marked_for_deactivation_admins
+      where("marked_for_deactivation_on < ?", days_notice_period_before_deactivation.days.ago.to_date)
+        .where(last_sign_in_at: nil)
+        .where("created_at < ?", days_inactivity_period_before_deactivation.days.ago)
+    end
+
+    def inactive_and_not_marked_for_deactivation_admin
       where("last_sign_in_at < ?", notice_period_target_date)
         .where(marked_for_deactivation_on: nil)
-        .find_each do |administrator|
-        administrator.mark_for_deactivation!
-        DeactivationMailer.period_before(administrator).deliver_now
-      end
+    end
+
+    def never_signed_in_and_not_marked_for_deactivation_admins
+      where(last_sign_in_at: nil)
+        .where(marked_for_deactivation_on: nil)
+        .where("created_at < ?", notice_period_target_date)
     end
 
     def notice_period_target_date
-      days_diff = days_inactivity_period_before_deactivation -
-        days_notice_period_before_deactivation
-      days_diff.days.ago
+      (days_inactivity_period_before_deactivation - days_notice_period_before_deactivation).days.ago
     end
 
-    def days_inactivity_period_before_deactivation
-      ENV["DAYS_INACTIVITY_PERIOD_BEFORE_DEACTIVATION"].to_i
-    end
+    def days_inactivity_period_before_deactivation = ENV["DAYS_INACTIVITY_PERIOD_BEFORE_DEACTIVATION"].to_i
 
-    def days_notice_period_before_deactivation
-      ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"].to_i
-    end
+    def days_notice_period_before_deactivation = ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"].to_i
   end
 
-  def mark_for_deactivation!
-    update_column(:marked_for_deactivation_on, Time.zone.now.to_date) # rubocop:disable Rails/SkipsModelValidations
-  end
+  def mark_for_deactivation! = update_column(:marked_for_deactivation_on, Time.zone.now.to_date) # rubocop:disable Rails/SkipsModelValidations
 
-  def active?
-    deleted_at.blank?
-  end
+  def active? = deleted_at.blank?
 
-  def inactive?
-    deleted_at.present?
-  end
+  def inactive? = deleted_at.present?
 
-  def deactivate
-    update_attribute(:deleted_at, Time.current) # rubocop:disable Rails/SkipsModelValidations
-  end
+  def deactivate = update_attribute(:deleted_at, Time.current) # rubocop:disable Rails/SkipsModelValidations
 
-  def reactivate
-    update_attribute(:deleted_at, nil) # rubocop:disable Rails/SkipsModelValidations
-  end
+  def reactivate = update_attribute(:deleted_at, nil) # rubocop:disable Rails/SkipsModelValidations
 end

--- a/clock.rb
+++ b/clock.rb
@@ -34,7 +34,7 @@ module Clockwork
   cond &&= ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"].present?
   if cond
     every 1.day, "purge_administrators", at: "11:00" do
-      Administrator.deactivate_when_too_old
+      Administrator.deactivate_when_too_old!
     end
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,5 @@
 default: &default
+  adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
@@ -8,7 +9,6 @@ development:
 
 test:
   <<: *default
-  adapter: postgresql
   url: <%= ENV['DATABASE_URL_TEST'] %>
 
 production:

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -160,18 +160,12 @@ RSpec.describe Administrator do
     end
   end
 
-  it "computes notice period difference in days" do
-    ENV["DAYS_INACTIVITY_PERIOD_BEFORE_DEACTIVATION"] = "100"
-    ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"] = "20"
-    expect(described_class.notice_period_target_date.to_date).to eq(80.days.ago.to_date)
-  end
-
   describe "automatic deactivation" do
     before do
       ENV["DAYS_INACTIVITY_PERIOD_BEFORE_DEACTIVATION"] = "100"
       ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"] = "20"
       administrator.reload
-      described_class.deactivate_when_too_old
+      described_class.deactivate_when_too_old!
       administrator.reload
     end
 

--- a/spec/models/concerns/deactivation_flow_spec.rb
+++ b/spec/models/concerns/deactivation_flow_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe DeactivationFlow do
+  describe ".deactivate_when_too_old!" do
+    subject(:deactivate) { Administrator.deactivate_when_too_old! }
+
+    before do
+      allow(Administrator).to receive_messages(
+        days_inactivity_period_before_deactivation: 30,
+        days_notice_period_before_deactivation: 7
+      )
+      allow(DeactivationMailer).to receive(:notice).and_call_original
+      allow(DeactivationMailer).to receive(:period_before).and_call_original
+    end
+
+    describe "deactivating" do
+      let!(:matching_1) { create(:administrator, last_sign_in_at: 40.days.ago) } # Inactive
+      let!(:matching_2) { create(:administrator, last_sign_in_at: nil, created_at: 40.days.ago) } # Never signed in
+      let!(:unmatching_1) { create(:administrator, last_sign_in_at: 40.days.ago) } # Not marked for deactivation
+      let!(:unmatching_2) { create(:administrator, last_sign_in_at: 40.days.ago) } # Marked for deactivation (but not old enough)
+
+      before do
+        # rubocop:disable Rails/SkipsModelValidations
+        # Because marked_for_deactivation_on is set to nil in a before_save callback
+        matching_1.update_columns(marked_for_deactivation_on: 10.days.ago)
+        matching_2.update_columns(marked_for_deactivation_on: 10.days.ago)
+        unmatching_2.update_columns(marked_for_deactivation_on: 5.days.ago)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      describe "deleted_at attribute" do
+        it { expect { deactivate }.to change { matching_1.reload.deleted_at }.from(nil) }
+
+        it { expect { deactivate }.to change { matching_2.reload.deleted_at }.from(nil) }
+
+        it { expect { deactivate }.not_to change { unmatching_1.reload.deleted_at } }
+
+        it { expect { deactivate }.not_to change { unmatching_2.reload.deleted_at } }
+      end
+
+      describe "mailing" do
+        before { deactivate }
+
+        it { expect(DeactivationMailer).to have_received(:notice).with(matching_1) }
+
+        it { expect(DeactivationMailer).to have_received(:notice).with(matching_2) }
+      end
+    end
+
+    describe "marking for deactivation" do
+      let!(:matching_1) { create(:administrator, last_sign_in_at: 40.days.ago) }
+      let!(:matching_2) { create(:administrator, last_sign_in_at: nil, created_at: 40.days.ago) }
+      let!(:unmatching_1) { create(:administrator, last_sign_in_at: 20.days.ago) }
+      let!(:unmatching_2) { create(:administrator, last_sign_in_at: 40.days.ago) }
+
+      before do
+        # rubocop:disable Rails/SkipsModelValidations
+        # Because marked_for_deactivation_on is set to nil in a before_save callback
+        unmatching_2.update_columns(marked_for_deactivation_on: 1.day.ago)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      describe "marked_for_deactivation_on attribute" do
+        it { expect { deactivate }.to change { matching_1.reload.marked_for_deactivation_on }.from(nil).to(Date.current) }
+
+        it { expect { deactivate }.to change { matching_2.reload.marked_for_deactivation_on }.from(nil).to(Date.current) }
+
+        it { expect { deactivate }.not_to change { unmatching_1.reload.marked_for_deactivation_on } }
+
+        it { expect { deactivate }.not_to change { unmatching_2.reload.marked_for_deactivation_on } }
+      end
+
+      describe "mailing" do
+        before { deactivate }
+
+        it { expect(DeactivationMailer).to have_received(:period_before).with(matching_1) }
+
+        it { expect(DeactivationMailer).to have_received(:period_before).with(matching_2) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Certains admins inactif·ves n'étaient jamais désactivé·es, tel que décrit par https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/1003#issuecomment-1904012969

C'était dû à l'algorithme qui marque les admins à désactiver et qui désactive les admins marqué·es : **il oubliait de traiter les admins qui ne se sont jamais connecté**. Les autres admins inactif·ves (celleux qui se sont connecté mais il y a longtemps) étaient bien traité·es par l'algo.

C'est corrigé ici.

# Review app

https://erecrutement-cvd-staging-pr1652.osc-fr1.scalingo.io

# Links

Closes #1003

https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/1003#issuecomment-1904012969
