### PR TITLE
🐛 Don't crash when destroying experience level

### DIFF
--- a/app/helpers/job_offers_helper.rb
+++ b/app/helpers/job_offers_helper.rb
@@ -24,7 +24,7 @@ module JobOffersHelper
     when :location
       job_offer.location
     when :study_level, :category, :experience_level
-      job_offer.send(attribute).name
+      job_offer.send(attribute)&.name.presence || "-"
     when :salary
       job_offer_salary_display(job_offer)
     when :benefits

--- a/app/models/experience_level.rb
+++ b/app/models/experience_level.rb
@@ -9,6 +9,7 @@ class ExperienceLevel < ApplicationRecord
 
   has_many :job_offers, dependent: :nullify
   has_many :salary_ranges, dependent: :destroy
+  has_many :profiles, dependent: :nullify
 end
 
 # == Schema Information

--- a/app/views/job_offers/_job_offer_head.html.haml
+++ b/app/views/job_offers/_job_offer_head.html.haml
@@ -1,7 +1,7 @@
 - attributes = %i[contract_type contract_start_on location study_level category experience_level salary benefits is_remote_possible]
 - attributes.each_with_index do |attribute, index|
-  .d-flex{class: index == 0 ? nil : 'rf-mt-1w'}
-    = fa_icon job_offer_icon_for_attribute(attribute)
+  .d-flex.align-items-center.mb-2{class: index == 0 ? nil : 'rf-mt-1w'}
+    = fa_icon job_offer_icon_for_attribute(attribute), class: 'mr-3'
     .d-flex.flex-column.rf-ml-1w
       %strong
         = JobOffer.human_attribute_name(attribute)

--- a/spec/helpers/job_offers_helper_spec.rb
+++ b/spec/helpers/job_offers_helper_spec.rb
@@ -18,4 +18,91 @@ RSpec.describe JobOffersHelper do
       it { is_expected.to eq("duration") }
     end
   end
+
+  describe ".job_offer_value_for_attribute" do
+    subject { job_offer_value_for_attribute(job_offer, attribute) }
+
+    let(:job_offer) { create(:job_offer) }
+
+    context "when the attribute is :contract_type" do
+      let(:attribute) { :contract_type }
+
+      it { is_expected.to eq("CDI duration") }
+    end
+
+    context "when the attribute is :contract_start_on" do
+      let(:attribute) { :contract_start_on }
+
+      it { is_expected.to eq(I18n.l(job_offer.contract_start_on)) }
+    end
+
+    context "when the attribute is :location" do
+      let(:attribute) { :location }
+
+      it { is_expected.to eq(job_offer.location) }
+    end
+
+    context "when the attribute is :study_level" do
+      let(:attribute) { :study_level }
+
+      it { is_expected.to eq(job_offer.study_level.name) }
+
+      context "when the job offer doesn't have a study level" do
+        before do
+          job_offer.study_level.destroy!
+          job_offer.reload
+        end
+
+        it { is_expected.to eq("-") }
+      end
+    end
+
+    context "when the attribute is :category" do
+      let(:attribute) { :category }
+
+      it { is_expected.to eq(job_offer.category.name) }
+
+      context "when the job offer doesn't have a category" do
+        before do
+          job_offer.category.destroy!
+          job_offer.reload
+        end
+
+        it { is_expected.to eq("-") }
+      end
+    end
+
+    context "when the attribute is :experience_level" do
+      let(:attribute) { :experience_level }
+
+      it { is_expected.to eq(job_offer.experience_level.name) }
+
+      context "when the job offer doesn't have an experience level" do
+        before do
+          job_offer.experience_level.destroy!
+          job_offer.reload
+        end
+
+        it { is_expected.to eq("-") }
+      end
+    end
+
+    context "when the attribute is :salary" do
+      let(:attribute) { :salary }
+
+      it { is_expected.to eq(job_offer_salary_display(job_offer)) }
+    end
+
+    context "when the attribute is :benefits" do
+      let(:attribute) { :benefits }
+
+      it { is_expected.to eq(job_offer_benefits_display(job_offer)) }
+    end
+
+    context "when the attribute is :is_remote_possible" do
+      let(:attribute) { :is_remote_possible }
+
+      it { is_expected.to eq("Non") }
+    end
+  end
 end

--- a/spec/models/experience_level_spec.rb
+++ b/spec/models/experience_level_spec.rb
@@ -3,9 +3,16 @@
 require "rails_helper"
 
 RSpec.describe ExperienceLevel do
-  it { is_expected.to validate_presence_of(:name) }
-end
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 
+  describe "associations" do
+    it { is_expected.to have_many(:job_offers).dependent(:nullify) }
+    it { is_expected.to have_many(:salary_ranges).dependent(:destroy) }
+    it { is_expected.to have_many(:profiles).dependent(:nullify) }
+  end
+end
 # == Schema Information
 #
 # Table name: experience_levels


### PR DESCRIPTION
# Description

On corrige deux crash : la destruction de l'`ExperienceLevel`, tel que décrit par #1666. Ensuite, si une offre était liée à un `ExperienceLevel` détruit, on ne pouvait plus l'ouvrir. C'est corrigé également.

# Review app

https://erecrutement-cvd-staging-pr1674.osc-fr1.scalingo.io

# Links

Closes #1666
