### PR TITLE
🐛 Fix crash when searching for administrators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           DEFAULT_FROM: hello@localhost
           DEFAULT_HOST: http://localhost:3000
           FRANCE_CONNECT_HOST: not.a.real.host.test-franceconnect.fr
+          SECURE_CONTENT: true
 
       - name: Upload Capybara screenshots
         if: failure()

--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -8,7 +8,7 @@ module Securable
 
     after_commit -> { SecureContentJob.set(wait: 15.seconds).perform_later(id: id) },
       unless: -> { secured? },
-      if: -> { content.present? && pdf? }
+      if: -> { content.present? && pdf? && ENV.fetch("SECURE_CONTENT", false) }
   end
 
   def document_content

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,16 @@
+# ransack has not been updated to work with 7.1 as of yet. Version 4.0.0 docs state:
+#     Ransack is supported for Rails 7.0, 6.1 on Ruby 2.7 and later.
+# Your issue in particular is this one line:
+#     table = attr.arel_attribute.relation.table_name
+# attr.arel_attribute.relation will return an Arel::Table.
+# In Rails 7.0 and prior Arel::Table#table_name was an alias for Arel::Table#name;
+# however in 7.1 this was removed because the method is never used in the rails code base.
+#
+# Here we monkey patch Arel::Table to put the alias back in.
+#
+# https://stackoverflow.com/a/77180853/12437303
+module Arel
+  class Table
+    alias_method :table_name, :name
+  end
+end


### PR DESCRIPTION
# Description

Le passage à Rails 7.1 a cassé Ransack (la gem chargée de la recherche). En effet, pour le moment : 

> Ransack is supported for Rails 7.0, 6.1 on Ruby 2.7 and later.

Comme discuté dans [ce ticket](https://stackoverflow.com/a/77180853/12437303) sur Stack Overflow : 

> Rails 7.0 and prior Arel::Table#table_name was an alias for Arel::Table#name; however in 7.1 this was [removed](https://github.com/rails/rails/commit/1d98bc563a8a7faf26238eaaa54a3257a95d644d) because the method is never used in the rails code base.

Pour régler le problème, on monkey patch la gem.

Un correctif a été importé dans Ransack 4.1 (on est actuellement en 3.2.1), donc ce patch pourra être supprimé à l'avenir. Mais la version 4 de Ransack introduit des changements non rétrocompatibles, donc ce sera pour une prochaine PR, ce n'est pas utile de le faire maintenant.

# Review app

https://erecrutement-cvd-staging-pr1677.osc-fr1.scalingo.io

# Links

Closes #1675