### PR TITLE
Spontaneous link is available only when job offer is published

### DIFF
--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -151,6 +151,10 @@ class JobOffer < ApplicationRecord
     end
   end
 
+  def self.spontaneous? = spontaneous_job_offer.present?
+
+  def self.spontaneous_job_offer = published.where(spontaneous: true).first
+
   # Return an hash where keys are regions and values are counties inside it
   # All regions and counties got job_offers associated
   def self.regions

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -44,8 +44,7 @@
         %li.rf-nav__item{class: klass}
           = link_to "Nos offres", job_offers_path, class: 'rf-nav__link'
 
-        - spontaneous = JobOffer.find_by(spontaneous: true)
-        - if spontaneous
+        - if JobOffer.spontaneous?
           - klass = header_spontaneous_active?(controller.controller_name, controller.action_name, job_offer: @job_offer) ? 'rf-nav__item--active' : nil
           %li.rf-nav__item{class: klass}
-            = link_to "Candidature spontanée", spontaneous, class: 'rf-nav__link'
+            = link_to "Candidature spontanée", JobOffer.spontaneous_job_offer, class: 'rf-nav__link'

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -13,6 +13,50 @@ RSpec.describe JobOffer do
     it { is_expected.to have_many(:"job_offer_#{role}_actors").inverse_of(:job_offer) }
   end
 
+  describe ".spontaneous?" do
+    subject { described_class.spontaneous? }
+
+    context "when there is at least one published spontaneous job offer" do
+      before { create(:job_offer, spontaneous: true, state: :published) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when there is no spontaneous job offer" do
+      before { create(:job_offer, spontaneous: false, state: :published) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when there is a spontaneous job offer but it's not published" do
+      before { create(:job_offer, spontaneous: true, state: :draft) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".spontaneous_job_offer" do
+    subject { described_class.spontaneous_job_offer }
+
+    context "when there is at least one published spontaneous job offer" do
+      let!(:job_offer) { create(:job_offer, spontaneous: true, state: :published) }
+
+      it { is_expected.to eq(job_offer) }
+    end
+
+    context "when there is no spontaneous job offer" do
+      before { create(:job_offer, spontaneous: false, state: :published) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is a spontaneous job offer but it's not published" do
+      before { create(:job_offer, spontaneous: true, state: :draft) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "pep or bne" do
     let(:job_offer) do
       build(


### PR DESCRIPTION
# Description

Pour éviter le problème décrit dans #1631, on n'affiche le lien "Candidature spontanée" que s'il y a une offre tagguée CS **et qu'elle est publiée**.

# Review app

https://erecrutement-cvd-staging-pr1680.osc-fr1.scalingo.io

# Links

Closes #1631
