### PR TITLE
:bug: Fix foreign language levels order and destroy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           DEFAULT_FROM: hello@localhost
           DEFAULT_HOST: http://localhost:3000
           FRANCE_CONNECT_HOST: not.a.real.host.test-franceconnect.fr
+          SECURE_CONTENT: true
 
       - name: Upload Capybara screenshots
         if: failure()

--- a/app/models/concerns/securable.rb
+++ b/app/models/concerns/securable.rb
@@ -8,7 +8,7 @@ module Securable
 
     after_commit -> { SecureContentJob.set(wait: 15.seconds).perform_later(id: id) },
       unless: -> { secured? },
-      if: -> { content.present? && pdf? }
+      if: -> { content.present? && pdf? && ENV.fetch("SECURE_CONTENT", false) }
   end
 
   def document_content

--- a/app/models/foreign_language_level.rb
+++ b/app/models/foreign_language_level.rb
@@ -1,5 +1,5 @@
 class ForeignLanguageLevel < ApplicationRecord
-  has_many :profile_foreign_languages, dependent: :nullify
+  has_many :profile_foreign_languages, dependent: :destroy
 end
 
 # == Schema Information

--- a/app/models/foreign_language_level.rb
+++ b/app/models/foreign_language_level.rb
@@ -1,4 +1,9 @@
 class ForeignLanguageLevel < ApplicationRecord
+  acts_as_list
+  default_scope -> { order(position: :asc) }
+
+  validates :name, presence: true, uniqueness: true
+
   has_many :profile_foreign_languages, dependent: :destroy
 end
 
@@ -11,4 +16,9 @@ end
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_foreign_language_levels_on_name      (name) UNIQUE
+#  index_foreign_language_levels_on_position  (position)
 #

--- a/db/migrate/20240326144840_add_uniqueness_index_to_foreign_language_level.rb
+++ b/db/migrate/20240326144840_add_uniqueness_index_to_foreign_language_level.rb
@@ -1,0 +1,5 @@
+class AddUniquenessIndexToForeignLanguageLevel < ActiveRecord::Migration[7.1]
+  def change
+    add_index :foreign_language_levels, :name, unique: true
+  end
+end

--- a/db/migrate/20240326144904_add_position_index_to_foreign_language_level.rb
+++ b/db/migrate/20240326144904_add_position_index_to_foreign_language_level.rb
@@ -1,0 +1,5 @@
+class AddPositionIndexToForeignLanguageLevel < ActiveRecord::Migration[7.1]
+  def change
+    add_index :foreign_language_levels, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_08_164350) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_144904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -284,6 +284,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_08_164350) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_foreign_language_levels_on_name", unique: true
+    t.index ["position"], name: "index_foreign_language_levels_on_position"
   end
 
   create_table "foreign_languages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/foreign_language_levels.rb
+++ b/spec/factories/foreign_language_levels.rb
@@ -15,3 +15,8 @@ end
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+# Indexes
+#
+#  index_foreign_language_levels_on_name      (name) UNIQUE
+#  index_foreign_language_levels_on_position  (position)
+#

--- a/spec/models/foreign_language_level_spec.rb
+++ b/spec/models/foreign_language_level_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe ForeignLanguageLevel do
+  describe "associations" do
+    it { is_expected.to have_many(:profile_foreign_languages).dependent(:destroy) }
+  end
+end

--- a/spec/models/foreign_language_level_spec.rb
+++ b/spec/models/foreign_language_level_spec.rb
@@ -4,4 +4,24 @@ RSpec.describe ForeignLanguageLevel do
   describe "associations" do
     it { is_expected.to have_many(:profile_foreign_languages).dependent(:destroy) }
   end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 end
+
+# == Schema Information
+#
+# Table name: foreign_language_levels
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_foreign_language_levels_on_name      (name) UNIQUE
+#  index_foreign_language_levels_on_position  (position)
+#


### PR DESCRIPTION
# Description

On règle ici les problèmes décrits dans #1685 : 

1/ la suppression d'un niveau de langue étrangère provoquait un crash. C'était à cause d'une erreur d'association : un `ProfileForeignLanguage` ne peut pas avoir son `foreign_language_level_id` à `null`. On supprime donc le `ProfileForeignLanguage` lorsque le `ForeignLanguageLevel` est supprimé.

2/ le déplacement vers le haut ou le bas d'un niveau de langue étrangère provoquait un crash. C'était à cause du fait d'un oubli, probablement : le modèle `ForeignLanguageLevel` n'implémentait pas `act_as_list`. C'est corrigé ici.

# :warning: Post mise en production

Les `ForeignLanguageLevel` de production ont leur champ `position` à null. Il faut leur attribuer une valeur : 

```rb
ForeignLanguageLevel.pluck(:position)
ForeignLanguageLevel.all.each_with_index {|fll, index| fll.update!(position: index + 1) }
```

À partir de là seulement ils pourront être déplacés vers le haut ou le bas.

# Review app

https://erecrutement-cvd-staging-pr1686.osc-fr1.scalingo.io

# Links

Closes #1685
