### PR TITLE
Rename "BANT" role into "admin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ admin = Administrator.new(
   last_name: 'Nom',
   password: '8 caractères minimum (1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial)',
   very_first_account: true,
-  role: 'bant', # superadmin
+  role: 'admin',
   organization: organization
 )
 admin.skip_confirmation_notification!

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -94,7 +94,7 @@ class Admin::JobOffersController < Admin::BaseController
 
     @job_offer = JobOffer.new_from_source(params[:job_offer_id])
     @job_offer ||= JobOffer.new_from_scratch(current_administrator)
-    @job_offer.employer = current_administrator.employer unless current_administrator.bant?
+    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.organization = current_organization
   end
 
@@ -107,7 +107,7 @@ class Admin::JobOffersController < Admin::BaseController
   def create
     @job_offer.owner = current_administrator
     @job_offer.organization = current_organization
-    @job_offer.employer = current_administrator.employer unless current_administrator.bant?
+    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.cleanup_actor_administrator_dep(current_administrator, current_organization)
 
     respond_to do |format|

--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -146,13 +146,13 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
 
   def permitted_fields
     ary = %i[title first_name last_name email]
-    ary += %i[employer_id] if current_administrator.bant?
-    ary += %i[role] if current_administrator.bant? || current_administrator.employer?
+    ary += %i[employer_id] if current_administrator.admin?
+    ary += %i[role] if current_administrator.admin? || current_administrator.employer?
     ary
   end
 
   def set_role_and_employer
-    @administrator.employer = current_administrator.employer unless current_administrator.bant?
+    @administrator.employer = current_administrator.employer unless current_administrator.admin?
   end
 
   def permitted_params

--- a/app/controllers/concerns/job_offer_state_actions.rb
+++ b/app/controllers/concerns/job_offer_state_actions.rb
@@ -8,7 +8,7 @@ module JobOfferStateActions
     @job_offer = JobOffer.new(job_offer_params)
     @job_offer.owner = current_administrator
     @job_offer.organization = current_organization
-    @job_offer.employer = current_administrator.employer unless current_administrator.bant?
+    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.job_offer_actors.each do |job_offer_actor|
       if job_offer_actor.administrator
         job_offer_actor.administrator.inviter ||= current_administrator

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,12 +16,12 @@ class Ability
     can :read, EmailTemplate
     cannot :manage, PreferredUsersList
     case administrator.role
-    when "bant"
-      ability_bant(administrator)
+    when "admin"
+      ability_admin(administrator)
     when "employer"
       ability_employer(administrator)
     else
-      # if neither BANT or Employer, it's BRH or CMG which have the same rights
+      # if neither Admin or Employer, it's BRH or CMG which have the same rights
       can :read, JobOffer, job_offer_actors: {administrator_id: administrator.id}
       can :read, JobApplication, job_application_read_query(administrator)
       can :manage, JobApplication, brh_job_application_manage_query(administrator)
@@ -33,7 +33,7 @@ class Ability
 
   private
 
-  def ability_bant(administrator)
+  def ability_admin(administrator)
     can :manage, :all
     can :manage, PreferredUsersList, administrator_id: administrator.id
   end

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -90,7 +90,7 @@ class Administrator < ApplicationRecord
   #####################################
   # Enums
   enum role: {
-    bant: 0,
+    admin: 0,
     employer: 1
   }
 
@@ -170,7 +170,7 @@ class Administrator < ApplicationRecord
   end
 
   def authorized_roles_to_confer
-    if bant?
+    if admin?
       self.class.roles.map(&:first)
     elsif employer?
       %w[employer]

--- a/app/models/daily_summary.rb
+++ b/app/models/daily_summary.rb
@@ -18,8 +18,8 @@ class DailySummary
     end
   end
 
-  def all_bants
-    @all_bants ||= Administrator.where(role: :bant).all
+  def all_admins
+    @all_admins ||= Administrator.where(role: :admin).all
   end
 
   def prepare(organization)
@@ -147,7 +147,7 @@ class DailySummary
       administrators = job_offer.grand_employer_actors
       administrators += job_offer.supervisor_employer_actors
       administrators += job_offer.brh_actors
-      administrators += all_bants
+      administrators += all_admins
     end
     administrators.uniq
   end
@@ -157,7 +157,7 @@ class DailySummary
     administrators += job_offer.grand_employer_actors
     administrators += job_offer.supervisor_employer_actors
     administrators += job_offer.brh_actors
-    administrators += all_bants
+    administrators += all_admins
     administrators.uniq
   end
 end

--- a/app/views/admin/job_applications/_filter_employer.html.haml
+++ b/app/views/admin/job_applications/_filter_employer.html.haml
@@ -13,7 +13,7 @@
           = option.first
           %ul
             - for sub_option in option.last
-              - if current_administrator.bant? || @employer_ids.include?(sub_option.id)
+              - if current_administrator.admin? || @employer_ids.include?(sub_option.id)
                 - input_id = dom_id(sub_option)
                 %li
                   .form-check.form-check-inline.w-100

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -32,7 +32,7 @@
                         - grouped_options = nested_set_options(Category, @category) {|i| "#{'-' * i.level} #{i.name}" }
                         = f.association :category, collection: grouped_options, disabled: Category.all.select{|x| x.children.count != 0}.map(&:id), input_html: {class: 'custom-select'}
                       .col-12.col-md-3
-                        - if current_administrator.bant?
+                        - if current_administrator.admin?
                           - grouped_options = Employer.roots.map{|x| [x.name, x.children]}
                           = f.association :employer, collection: grouped_options, as: :grouped_select, group_method: :last, input_html: {class: 'custom-select'}
                         - else
@@ -51,7 +51,7 @@
                         = f.input :region, as: :hidden, input_html: { 'data-autocomplete-city-target' => :region }
                         .d-none
                           .autocomplete{ 'data-autocomplete-city-target' => :query }
-                      - if current_administrator.bant?
+                      - if current_administrator.admin?
                         .col-12.col-md-6
                           = f.input :spontaneous
                     = f.input :organization_description, as: :trix_editor_custom
@@ -111,10 +111,10 @@
                           .col-12
                             - estimate_monthly_salary_net = salary_range.try(:estimate_monthly_salary_net)
                             - hint = estimate_monthly_salary_net ? t('.estimate_monthly_salary_net_html', value: estimate_monthly_salary_net) : t('.estimate_monthly_salary_net_none_html')
-                            = f.input :estimate_monthly_salary_net, readonly: !current_administrator.bant?, hint: hint
+                            = f.input :estimate_monthly_salary_net, readonly: !current_administrator.admin?, hint: hint
                           .col-12
                             - estimate_annual_salary_gross = salary_range.try(:estimate_annual_salary_gross)
                             - hint = estimate_annual_salary_gross ? t('.estimate_annual_salary_gross_html', value: estimate_annual_salary_gross) : t('.estimate_annual_salary_gross_none_html')
-                            = f.input :estimate_annual_salary_gross, readonly: !current_administrator.bant?, hint: hint
+                            = f.input :estimate_annual_salary_gross, readonly: !current_administrator.admin?, hint: hint
         = render partial: "form_actors", locals: {f: f}
         = render partial: "form_submit", locals: {f: f}

--- a/app/views/admin/settings/administrators/_form.html.haml
+++ b/app/views/admin/settings/administrators/_form.html.haml
@@ -17,7 +17,7 @@
           .col-12.col-md-6
             = f.input :title, required: false
           .col-12.col-md-6
-            - if current_administrator.bant?
+            - if current_administrator.admin?
               - grouped_options = Employer.roots.map{|x| [x.name, x.children]}
               = f.association :employer, collection: grouped_options, as: :grouped_select, group_method: :last, input_html: {class: 'custom-select', id: :administrator_employer_id}
               = f.association :employer, collection: Employer.roots, label: t("simple_form.labels.administrator.grand_employer"), input_html: {class: 'custom-select', id: :administrator_grand_employer_id}

--- a/app/views/admin/shared/_navbar.html.haml
+++ b/app/views/admin/shared/_navbar.html.haml
@@ -1,6 +1,6 @@
 - nav_items = [[:job_offers], [:users]]
 - nav_items << [:stats, :root]
-- nav_items << [:settings, :root] if current_administrator.bant?
+- nav_items << [:settings, :root] if current_administrator.admin?
 %nav.navbar.navbar-expand-md.navbar-light.bg-white.fixed-top
   %button.navbar-toggler.p-0.border-0{type: :button, data: {toggle: 'offcanvas'}}
     %span.navbar-toggler-icon= fa_icon "bars", style: "width:1.5em;height:auto;"
@@ -32,7 +32,7 @@
         .d-flex.flex-column.justify-content-center.align-items-end
           %span.font-weight-bold= current_administrator.full_name
           - ary = current_administrator.role? ? [Administrator.human_attribute_name("role.#{current_administrator.role}")] : []
-          - ary.unshift(current_administrator.employer.code) if !current_administrator.bant? && current_administrator.employer?
+          - ary.unshift(current_administrator.employer.code) if !current_administrator.admin? && current_administrator.employer?
           %small.text-muted= ary.join(' - ')
       %li.nav-item.dropdown
         = button_tag(class: "nav-link dropdown-toggle py-0 btn mb-0", role: :button, data: {toggle: :dropdown}, aria: {haspopup: true, expanded: false}) do

--- a/app/views/devise/confirmations/show.html.haml
+++ b/app/views/devise/confirmations/show.html.haml
@@ -4,7 +4,7 @@
       = @page_title = t('.title')
       - if resource.is_a?(Administrator)
         %small.d-block
-          - if %w(bant employer).include?(resource.role)
+          - if %w(admin employer).include?(resource.role)
             = Administrator.human_attribute_name("role.#{resource.role}")
           - if resource.employer
             .d-inline

--- a/app/views/legals/notice.html.erb
+++ b/app/views/legals/notice.html.erb
@@ -21,7 +21,7 @@ Le site <%= root_url %> est réalisé par la startup d’Etat « Civils de la D
 
 
     2. Direction de la publication
-La direction de la publication du Site <%= root_url %> relève du Bureau des Agents Non Titulaires (BANT), Service des Ressources Humaines Civiles du Ministère des Armées.
+La direction de la publication du Site <%= root_url %> relève du Service des Ressources Humaines Civiles du Ministère des Armées.
 
 Toute correspondance à son attention doit être adressée :
     • Par courriel à l’adresse e-mail suivante :

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1109,7 +1109,7 @@ fr:
         confirmed: "Confirmé"
         unconfirmed: "Non confirmé"
       administrator/role:
-        bant: "BANT"
+        admin: "Administrateur"
         employer: "Employeur"
         grand_employer: "Grand Employeur"
         brh: "RH"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,24 +96,24 @@ organization.save!
 employer_parent = Employer.create!(name: "EMA", code: "EMA")
 employer = Employer.create!(name: "DIRISI", code: "DRI", parent: employer_parent)
 
-bant_admin = Administrator.new(
-  email: "cvd_bant@example.com",
-  first_name: "Pipo",
-  last_name: "Molo",
+super_admin = Administrator.new(
+  email: "admin@example.com",
+  first_name: "Admin",
+  last_name: "e-recrutement",
   password: ENV["SEED_PASSWORD"],
   password_confirmation: ENV["SEED_PASSWORD"],
   very_first_account: true,
-  role: "bant",
+  role: "admin",
   organization: organization
 )
-bant_admin.skip_confirmation_notification!
-bant_admin.save!
-bant_admin.confirm
+super_admin.skip_confirmation_notification!
+super_admin.save!
+super_admin.confirm
 
 employer_admin_1 = Administrator.new(
-  email: "cvd_employer1@example.com",
-  first_name: "employer",
-  last_name: "Molo",
+  email: "employeur1@example.com",
+  first_name: "Employeur 1",
+  last_name: "e-recrutement",
   password: ENV["SEED_PASSWORD"],
   password_confirmation: ENV["SEED_PASSWORD"],
   very_first_account: true,
@@ -126,9 +126,9 @@ employer_admin_1.save!
 employer_admin_1.confirm
 
 employer_admin_2 = Administrator.new(
-  email: "cvd_employer2@example.com",
-  first_name: "employer",
-  last_name: "Molo",
+  email: "employeur2@example.com",
+  first_name: "Employeur 2",
+  last_name: "e-recrutement",
   password: ENV["SEED_PASSWORD"],
   password_confirmation: ENV["SEED_PASSWORD"],
   very_first_account: true,
@@ -141,9 +141,9 @@ employer_admin_2.save!
 employer_admin_2.confirm
 
 brh_admin = Administrator.new(
-  email: "cvd_brh@example.com",
-  first_name: "brh",
-  last_name: "Molo",
+  email: "brh@example.com",
+  first_name: "BRH",
+  last_name: "e-recrutement",
   password: ENV["SEED_PASSWORD"],
   password_confirmation: ENV["SEED_PASSWORD"],
   very_first_account: true,
@@ -311,7 +311,7 @@ JobApplicationFileType.create!(
 
 job_offer = JobOffer.new { |j|
   j.organization = organization
-  j.owner = bant_admin
+  j.owner = super_admin
   j.title = "Ingénieur expert en systemes d’information - Chef de section F/H"
   j.category = sub_sub_informatique
   j.professional_category = ProfessionalCategory.first
@@ -461,13 +461,13 @@ job_application.job_application_files.build(
 )
 job_application.save!
 
-Audited.audit_class.as_user(bant_admin) do
+Audited.audit_class.as_user(super_admin) do
   4.times do
     Email.create!(
       subject: "subject",
       body: Faker::Lorem.paragraph(sentence_count: 2),
       job_application: job_application,
-      sender: bant_admin
+      sender: super_admin
     )
   end
 end
@@ -544,12 +544,12 @@ JobOffer.where.not(contract_duration_id: nil).where.not(id: [job_offer4.id, job_
     job_application.save!
 
     3.times do
-      Audited.audit_class.as_user(bant_admin) do
+      Audited.audit_class.as_user(super_admin) do
         Email.create!(
           subject: "About your application",
           body: Faker::Lorem.paragraph(sentence_count: 2),
           job_application: job_application,
-          sender: bant_admin
+          sender: super_admin
         )
       end
       Audited.audit_class.as_user(user) do
@@ -581,12 +581,12 @@ JobOffer.where.not(contract_duration_id: nil).where.not(id: [job_offer4.id, job_
   job_application.save!
 
   3.times do
-    Audited.audit_class.as_user(bant_admin) do
+    Audited.audit_class.as_user(super_admin) do
       Email.create!(
         subject: "About your application",
         body: Faker::Lorem.paragraph(sentence_count: 2),
         job_application: job_application,
-        sender: bant_admin
+        sender: super_admin
       )
     end
     Audited.audit_class.as_user(user_candidate_of_all) do

--- a/spec/controllers/admin/job_applications_controller_spec.rb
+++ b/spec/controllers/admin/job_applications_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::JobApplicationsController do
 
   let!(:job_application) { create(:job_application) }
 
-  context "when logged in as BANT administrator" do
+  context "when logged in as 'admin' administrator" do
     login_admin
 
     describe "GET #index" do

--- a/spec/controllers/admin/job_offers_controller_spec.rb
+++ b/spec/controllers/admin/job_offers_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Admin::JobOffersController do
-  context "when logged in as BANT administrator" do
+  context "when logged in as 'admin' administrator" do
     login_admin
 
     let(:valid_attributes) do

--- a/spec/controllers/admin/preferred_users_lists_controller_spec.rb
+++ b/spec/controllers/admin/preferred_users_lists_controller_spec.rb
@@ -26,7 +26,7 @@ require "rails_helper"
 # `rails-controller-testing` gem.
 
 RSpec.describe Admin::PreferredUsersListsController do
-  context "when logged in as BANT administrator" do
+  context "when logged in as 'admin' administrator" do
     login_admin
 
     # This should return the minimal set of attributes required to create a valid

--- a/spec/factories/administrators.rb
+++ b/spec/factories/administrators.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker::Internet.unique.safe_email }
-    role { "bant" }
+    role { "admin" }
     very_first_account { true }
     password { "f4k3p455w0rD!!" }
     confirmed_at { DateTime.now }


### PR DESCRIPTION
# Description

On renomme le rôle "BANT" en "admin". En front, cela s'exprime plutôt par le vocabulaire "administrateur".

Au passage, pour simplifier les recettes, on change les emails des différents comptes créés sur les review apps : 
- cvd_bant@example.com devient admin@example.com
- cvd_employer1@example.com devient employeur_1@example.com
- cvd_employer2@example.com devient employeur_2@example.com
- cvd_brh@example.com devient brh@example.com

Les mots de passe restent les mêmes.

# Review app

https://erecrutement-cvd-staging-pr1691.osc-fr1.scalingo.io

# Links

Closes #1668

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/3e184d9a-544d-4175-9972-34c9dd839554)

