### PR TITLE
Update admin confirmation instructions

### DIFF
--- a/app/helpers/administrators_helper.rb
+++ b/app/helpers/administrators_helper.rb
@@ -1,0 +1,9 @@
+module AdministratorsHelper
+  def actor_roles_or_general_role(administrator)
+    if (actor_roles = administrator.job_offer_actors.pluck(:role).compact).any?
+      actor_roles.uniq.map { |role| t("activerecord.attributes.job_offer_actor/role.#{role}") }.to_sentence
+    elsif administrator.role
+      t("activerecord.attributes.administrator/role.#{administrator.role}")
+    end
+  end
+end

--- a/app/mailers/platform_mailer.rb
+++ b/app/mailers/platform_mailer.rb
@@ -3,14 +3,23 @@
 # Overwriting devise mailer class to allow site name injection in mail subjects
 class PlatformMailer < Devise::Mailer
   helper :application # gives access to all helpers defined within `application_helper`.
+
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+  include AdministratorsHelper
+
   default template_path: "devise/mailer" # to make sure that your mailer uses the devise views
 
   def confirmation_instructions(record, token, opts = {})
-    organization = record.organization
-    service_name = organization.service_name
-    i18n_key = "devise.mailer.confirmation_instructions.subject"
-    opts[:subject] = I18n.t(i18n_key, service_name: service_name)
+    opts[:subject] = I18n.t(
+      "devise.mailer.confirmation_instructions.subject",
+      service_name: record.organization.service_name
+    )
+
+    if record.is_a?(Administrator)
+      opts[:template_name] = "confirmation_instructions_admin"
+      @roles = actor_roles_or_general_role(record)
+    end
+
     super
   end
 

--- a/app/views/platform_mailer/confirmation_instructions_admin.html.haml
+++ b/app/views/platform_mailer/confirmation_instructions_admin.html.haml
@@ -1,0 +1,14 @@
+%p
+  = t('.greeting')
+%p
+  - if @roles.present?
+    = t('.instruction', roles: @roles, site: ENV.fetch('DEFAULT_HOST'))
+  - else
+    = t('.instruction_no_roles', site: ENV.fetch('DEFAULT_HOST'))
+- text = t('.action')
+- url = confirmation_url(@resource, confirmation_token: @token)
+= render partial: 'devise/mailer/email_button', locals: {text: text, url: url}
+%p
+  = t('.instruction_1')
+%p
+  = t('.team', service_name: @resource.organization.service_name)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -176,6 +176,14 @@ fr:
         title: "Nouvelles candidatures"
       published_job_offers:
         title: "Offres publiées récemment"
+  platform_mailer:
+    confirmation_instructions_admin:
+      greeting: Bonjour,
+      instruction: "Vous avez été notifié comme « %{roles} » dans une offre d’emploi sur le site de recrutement %{site}. Pour y accéder, veuillez confirmer votre compte en cliquant sur le lien suivant :"
+      instruction_no_roles: "Vous avez été ajouté sur le site de recrutement %{site}. Pour y accéder, veuillez confirmer votre compte en cliquant sur le lien suivant :"
+      instruction_1: Votre compte ne sera pas activé tant que toutes les étapes de création de votre compte ou de confirmation de votre compte ne seront pas finalisées dans l’application.
+      team: L'équipe de recrutement de %{service_name}
+      action: Je confirme mon courriel
   shared:
     footer:
       legal_notice: "Mentions légales"

--- a/spec/helpers/administrators_helper_spec.rb
+++ b/spec/helpers/administrators_helper_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe AdministratorsHelper do
+  describe "#actor_roles_or_general_role" do
+    subject { helper.actor_roles_or_general_role(administrator) }
+
+    let(:administrator) { build(:administrator) }
+
+    context "when administrator has actor roles" do
+      before do
+        administrator.save!
+        job_offer = create(:job_offer)
+        create(:job_offer_actor, job_offer:, administrator:, role: :cmg)
+        create(:job_offer_actor, job_offer:, administrator:, role: :brh)
+        create(:job_offer_actor, job_offer:, administrator:, role: :grand_employer)
+      end
+
+      it { is_expected.to eq("CMG, RH et Grand Employeur") }
+    end
+
+    context "when administrator has general role" do
+      before { allow(administrator).to receive(:role).and_return(:employer) }
+
+      it { is_expected.to eq("Employeur") }
+    end
+
+    context "when administrator has no roles" do
+      before { allow(administrator).to receive(:role).and_return(nil) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/mailers/previews/platform_mailer_preview.rb
+++ b/spec/mailers/previews/platform_mailer_preview.rb
@@ -1,11 +1,19 @@
 class PlatformMailerPreview < ActionMailer::Preview
-  def confirmation_instructions = PlatformMailer.confirmation_instructions(Administrator.first, "faketoken")
+  def confirmation_instructions_admin = PlatformMailer.confirmation_instructions(admin, "faketoken")
 
-  def reset_password_instructions = PlatformMailer.reset_password_instructions(Administrator.first, "faketoken")
+  def confirmation_instructions_user = PlatformMailer.confirmation_instructions(user, "faketoken")
 
-  def unlock_instructions = PlatformMailer.unlock_instructions(Administrator.first, "faketoken")
+  def reset_password_instructions = PlatformMailer.reset_password_instructions(admin, "faketoken")
 
-  def email_changed = PlatformMailer.email_changed(Administrator.first)
+  def unlock_instructions = PlatformMailer.unlock_instructions(admin, "faketoken")
 
-  def password_change = PlatformMailer.password_change(Administrator.first)
+  def email_changed = PlatformMailer.email_changed(admin)
+
+  def password_change = PlatformMailer.password_change(admin)
+
+  private
+
+  def admin = Administrator.first
+
+  def user = User.first
 end

--- a/spec/mailers/previews/platform_mailer_preview.rb
+++ b/spec/mailers/previews/platform_mailer_preview.rb
@@ -1,0 +1,11 @@
+class PlatformMailerPreview < ActionMailer::Preview
+  def confirmation_instructions = PlatformMailer.confirmation_instructions(Administrator.first, "faketoken")
+
+  def reset_password_instructions = PlatformMailer.reset_password_instructions(Administrator.first, "faketoken")
+
+  def unlock_instructions = PlatformMailer.unlock_instructions(Administrator.first, "faketoken")
+
+  def email_changed = PlatformMailer.email_changed(Administrator.first)
+
+  def password_change = PlatformMailer.password_change(Administrator.first)
+end


### PR DESCRIPTION
# Description

On met à jour les instructions de confirmations de compte de l'administrateur.

# Review app

https://erecrutement-cvd-staging-pr1718.osc-fr1.scalingo.io

# Links

Closes #1696

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/27c1b199-4a5a-4082-8fe1-03ddc535b55d)

