### PR TITLE
🐛 Fix missing 't' shortcut

### DIFF
--- a/app/helpers/job_offers_helper.rb
+++ b/app/helpers/job_offers_helper.rb
@@ -40,7 +40,7 @@ module JobOffersHelper
 
   def job_offer_start_display(job_offer)
     if job_offer.available_immediately?
-      t(".available_immediately")
+      I18n.t("job_offers.job_offer_head.available_immediately")
     else
       I18n.l(job_offer.contract_start_on)
     end

--- a/spec/helpers/job_offers_helper_spec.rb
+++ b/spec/helpers/job_offers_helper_spec.rb
@@ -109,4 +109,22 @@ RSpec.describe JobOffersHelper do
       it { is_expected.to eq("Non") }
     end
   end
+
+  describe ".job_offer_start_display" do
+    subject { job_offer_start_display(job_offer) }
+
+    let(:job_offer) { create(:job_offer, available_immediately:) }
+
+    context "when the job offer is available immediately" do
+      let(:available_immediately) { true }
+
+      it { is_expected.to eq(I18n.t("job_offers.job_offer_head.available_immediately")) }
+    end
+
+    context "when the job offer is not available immediately" do
+      let(:available_immediately) { false }
+
+      it { is_expected.to eq(I18n.l(job_offer.contract_start_on)) }
+    end
+  end
 end


### PR DESCRIPTION
# Description

On règle le problème suivant : lorsque l'offre d'emploi est immédiatement disponible, il y avait un crash lors de la génération du PDF. C'est parce que dans le helper `JobOffersHelper`, on utilisait directement le raccourci `t` au lieu de faire `I18n.t`.

# Review app

https://erecrutement-cvd-staging-pr1720.osc-fr1.scalingo.io

