### PR TITLE
✨ Auto add 'F/H' add the end of job offer title

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -37,6 +37,9 @@ application.register("password-rules", PasswordRulesController)
 import PasswordVisibilityController from "./password_visibility_controller"
 application.register("password-visibility", PasswordVisibilityController)
 
+import RegulationController from "./regulation_controller"
+application.register("regulation", RegulationController)
+
 import RemoveRecipientController from "./remove_recipient_controller"
 application.register("remove-recipient", RemoveRecipientController)
 

--- a/app/javascript/controllers/job_offer_management_controller.js
+++ b/app/javascript/controllers/job_offer_management_controller.js
@@ -22,7 +22,6 @@ export default class extends Controller {
   }
 
   addFields(event) {
-    debugger
     let node = event.currentTarget
     let emailField = node.previousElementSibling.querySelector('input[type=email]')
     if (emailField == null) {

--- a/app/javascript/controllers/regulation_controller.js
+++ b/app/javascript/controllers/regulation_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+const INCORRECT_SUFFIXES = [
+  "f/h", "f/H", "F/h",
+  "h/f", "H/f", "h/F", "H/F",
+  "fh", "FH", "Fh", "fH",
+  "hf", "HF", "Hf", "hF"
+]
+const CORRECT_SUFFIX = "F/H"
+
+export default class extends Controller {
+  correctTitle(event) {
+    const title = event.target.value
+    if (this.endsWithIncorrectSuffix(title)) {
+      event.target.value = this.replaceLastWithCorrectSuffix(title)
+    } else if (!title.endsWith("F/H")) {
+      event.target.value = title + " F/H"
+    }
+  }
+
+  // private
+
+  endsWithIncorrectSuffix(str) {
+    return INCORRECT_SUFFIXES.some(suffix => str.endsWith(suffix))
+  }
+
+  replaceLastWithCorrectSuffix(str) {
+    const foundSuffix = INCORRECT_SUFFIXES.find(suffix => str.endsWith(suffix))
+    return this.replaceLast(str, foundSuffix)
+  }
+
+  replaceLast(str, search) {
+    const indexOfLast = str.lastIndexOf(search)
+    return str.substring(0, indexOfLast) + CORRECT_SUFFIX
+  }
+}

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -1,7 +1,7 @@
 - suffix = @job_offer.new_record? ? 'new' : 'edit'
 - card_1_title = t(".card_1_title_#{ suffix }", job_offer_identifier: @job_offer.identifier)
 - card_2_title = t('.card_2_title')
-.container-fluid{data: { controller: "job-offer-management"}}
+.container-fluid{data: { controller: "job-offer-management regulation"}}
   .row
     .col-12.px-0
       = simple_form_for([:admin, @job_offer], data: {controller: "form-save trix-errors", trix_errors_model_name_value: "job_offer", trix_errors_inputs_value: @job_offer.errors.attribute_names, form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData"}) do |f|
@@ -23,7 +23,7 @@
                   .form-inputs
                     .row
                       .col-12{class: f.object.new_record? ? nil : "col-md-9"}
-                        = f.input :title, disabled: @job_offer.archived?
+                        = f.input :title, disabled: @job_offer.archived?, input_html: {data: {action: "blur->regulation#correctTitle"}}
                       - if !f.object.new_record?
                         .col-12.col-md-3
                           = f.input :identifier, readonly: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ organization = Organization.create!(
   service_description_short: desc_short,
   job_offer_term_title: "Bienvenue sur l'outil E-recrutement contractuels",
   job_offer_term_subtitle: "Vous souhaitez recourir à un agent contractuel civil car",
-  job_offer_term_warning: "C'est pas possible"
+  job_offer_term_warning: "C'est impossible"
 )
 [
   "Le poste fait appel à des compétences techniques spécialisées ou nouvelles (un encart en surbrillance en passant la souris sur la première les compétences sollicitées sont trop récentes ou trop spécialisées pour recourir dans l'immédiat à un fonctionnaire)", "Car l'emploi ne requiert pas d'être honoré par un fonctionnaire formé par une école de la fonction publique (poste d'attaché uniquement).", "Vous n'avez reçu aucune candidature de fonctionnaire suite à la publication de l'annonce sur la Bourse nationale de l'emploi (BNE) et à la Place de l'emploi public (РЕР)"


### PR DESCRIPTION
# Description

On corrige automatiquement le titre de l'offre d'emploi pour s'assurer qu'il termine bien par "F/H", même si l'admin saisit "H/F", "h/f", "f/h", "fh", "HF"... ou ne saisit rien.

# Review app

https://erecrutement-cvd-staging-pr1724.osc-fr1.scalingo.io

# Links

Closes #1604
