### PR TITLE
🔒️ Extend password policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ admin = Administrator.new(
   email: 'prenom.nom@domaine.com',
   first_name: 'Prénom',
   last_name: 'Nom',
-  password: '8 caractères minimum (1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial)',
+  password: '12 caractères minimum (1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial)',
   very_first_account: true,
   role: 'admin',
   organization: organization

--- a/app/javascript/controllers/password_rules_controller.js
+++ b/app/javascript/controllers/password_rules_controller.js
@@ -7,8 +7,8 @@ export default class extends Controller {
     this.rules = [
       {
         key: "length",
-        message: "8 caractères minimum",
-        positive: (value) => value.length >= 8
+        message: "12 caractères minimum",
+        positive: (value) => value.length >= 12
       },
       {
         key: "uppercase",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 # Candidate to job offer
 class User < ApplicationRecord
+  PASSWORD_REGEX = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[\\\/<>{}()#¤:;,.?!•·|"'`´~@£¨µ§²$€%^&*+=_-]).{12,70}$/
+
   def self.omniauth_providers
     ENV["FRANCE_CONNECT_HOST"] ? [:france_connect] : []
   end
@@ -88,9 +90,7 @@ class User < ApplicationRecord
   end
 
   def password_complexity
-    # Regexp extracted from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
-    regexp = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/
-    return if password.blank? || password =~ regexp
+    return if password.blank? || password =~ PASSWORD_REGEX
 
     errors.add :password, :not_strong_enough
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1086,7 +1086,7 @@ fr:
         mandatory_file: "est obligatoire"
         allowed_file_content_types: "au mauvais format (seuls ces formats sont acceptés: %{types})"
         invalid_suffix: "n'est pas conforme, doit se terminer par %{suffixes}"
-        not_strong_enough: "Pas assez complexe : doit avoir au moins 8 caractères, dont au moins 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial parmi #?!@$%^&*-'"
+        not_strong_enough: "Pas assez complexe : doit avoir au moins 12 caractères, dont au moins 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial"
         spoofed_media_type: "Type de fichier incorrect"
       models:
         job_application:

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -226,7 +226,7 @@ fr:
         first_name: "Facultatif"
         last_name: "Facultatif"
         employer_id: "Actif seulement si le rôle est \"Employeur\""
-        password: "8 caractères minimum, dont au moins 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial parmi #?!@$%^&*-'"
+        password: "12 caractères minimum, dont au moins 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial"
       employer:
         code: "Ce champ est utilisé pour construire l'identifiant unique d'une annonce."
       job_application:


### PR DESCRIPTION
# Description

On améliore la sécurité des mots de passe de la manière suivante :
- longueur minimum de 12 caractères
- augmentation du nombre de caractères spéciaux disponibles

Précédemment les caractères spéciaux suivants étaient disponibles : 
```
#?!@$%^&*-
```

Désormais, on peut piocher dans la liste suivante : 
```
\/<>{}()#¤:;,.?!•·|"'`´~@£¨µ§²$€%^&*+=_-
```

# Review app

https://erecrutement-cvd-staging-pr1736.osc-fr1.scalingo.io

# Links

Closes #1717

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/6b7b5aa1-ab9b-4c5f-88e4-b32a91c427ed)
