### PR TITLE
:wastebasket: Destroy an admin

### DIFF
--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -129,6 +129,8 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
     end
   end
 
+  def destroy = @administrator.destroy!
+
   private
 
   def set_administrators

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -18,7 +18,7 @@ class Administrator < ApplicationRecord
   has_many :invitees, class_name: "Administrator", foreign_key: "inviter_id", inverse_of: :inviter, dependent: :nullify
 
   has_many :owned_job_offers, class_name: "JobOffer", foreign_key: "owner_id", inverse_of: :owner, dependent: :nullify
-  has_many :job_offer_actors, dependent: :nullify
+  has_many :job_offer_actors, dependent: :destroy
   has_many :job_offers, through: :job_offer_actors
 
   belongs_to :supervisor_administrator, optional: true, class_name: "Administrator"

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -1,4 +1,4 @@
-%tr
+%tr{id: dom_id(administrator)}
   %td
     / = image_user_tag administrator.photo, width: 40, class: 'mr-2'
   %td
@@ -50,3 +50,7 @@
       - if can?(:reactivate, administrator) && administrator.inactive?
         %li.list-inline-item
           = link_to fa_icon('check'), [:reactivate, :admin, :settings, administrator], method: :post, title: t('buttons.reactivate'), data: {confirm: t('buttons.confirm')}
+      - if can?(:destroy, administrator) && administrator.inactive?
+        %li.list-inline-item
+          = link_to fa_icon('trash'), [:admin, :settings, administrator], method: :delete, remote: true, title: t('buttons.destroy'), data: {confirm: t('buttons.confirm')}
+

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -41,7 +41,7 @@
         %li.list-inline-item
           = link_to fa_icon('pencil'), [:edit, :admin, :settings, administrator], title: t('buttons.edit')
       - unless administrator.confirmed_at.present?
-        - if can?(:manage, administrator)
+        - if can?(:manage, administrator) && administrator.active?
           %li.list-inline-item
             = link_to fa_icon('arrows-rotate'), [:resend_confirmation_instructions, :admin, :settings, administrator], method: :post, title: t('buttons.resend_confirmation_instructions'), data: {confirm: t('buttons.confirm')}
       - if can?(:deactivate, administrator) && administrator.active?

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -49,4 +49,4 @@
           = link_to fa_icon('close'), [:deactivate, :admin, :settings, administrator], method: :post, title: t('buttons.deactivate'), data: {confirm: t('buttons.confirm')}
       - if can?(:reactivate, administrator) && administrator.inactive?
         %li.list-inline-item
-          = link_to fa_icon('close'), [:reactivate, :admin, :settings, administrator], method: :post, title: t('buttons.reactivate'), data: {confirm: t('buttons.confirm')}
+          = link_to fa_icon('check'), [:reactivate, :admin, :settings, administrator], method: :post, title: t('buttons.reactivate'), data: {confirm: t('buttons.confirm')}

--- a/app/views/admin/settings/administrators/destroy.js.erb
+++ b/app/views/admin/settings/administrators/destroy.js.erb
@@ -1,0 +1,3 @@
+var dom_id = '#<%= dom_id(@administrator) %>'
+var node = document.querySelector(dom_id)
+node.remove()

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -103,7 +103,7 @@ fr:
     registrations:
       destroyed: Au revoir ! Votre compte a été annulé avec succès. Nous espérons vous revoir bientôt.
       edit:
-        are_you_sure: "Êtes-vous sûr ?"
+        are_you_sure: "Êtes-vous sûr(e) ?"
         cancel_my_account: Supprimer mon compte
         currently_waiting_confirmation_for_email: "Confirmation en attente pour: %{email}"
         leave_blank_if_you_don_t_want_to_change_it: laissez ce champ vide pour le laisser inchangé

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -607,7 +607,7 @@ fr:
             other: "Comptes actifs (%{count})"
           account_inactive:
             zero: 'Aucun compte admin désactivé'
-            one: 'Comte désactivé (1)'
+            one: 'Compte désactivé (1)'
             other: "Comptes désactivés (%{count})"
           card_title:
             zero: 'Aucun compte admin'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,7 +68,7 @@ fr:
     choose_file_validated_html: "Ce fichier a été validé !"
     click_to_edit: "Cliquer pour éditer"
     close: "Fermer"
-    confirm: "Êtes-vous sûr ?"
+    confirm: "Êtes-vous sûr(e) ?"
     copy: "Dupliquer"
     deactivate: "Désactiver"
     delete: "Supprimer"
@@ -99,6 +99,7 @@ fr:
     transfer: "Transférer"
     mark_as_read: "Marquer comme lu"
     email: "Courriel"
+    destroy: "Supprimer"
   homepages:
     stepper:
       step_1: "Dépôt de la candidature"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,7 @@ Rails.application.routes.draw do
           post :move_higher, :move_lower
         end
       end
-      resources :administrators, path: "administrateurs", except: %i[destroy] do
+      resources :administrators, path: "administrateurs" do
         collection do
           get :export
           get :inactive

--- a/spec/requests/admin/settings/administrators_spec.rb
+++ b/spec/requests/admin/settings/administrators_spec.rb
@@ -201,4 +201,19 @@ RSpec.describe "Admin::Settings::Administrators" do
       end
     end
   end
+
+  describe "DELETE /admin/parametres/administrateurs/:id" do
+    subject(:destroy_request) { delete admin_settings_administrator_path(administrator), xhr: true }
+
+    let!(:administrator) { create(:administrator) }
+
+    it { expect { destroy_request }.to change(Administrator, :count).by(-1) }
+
+    describe "response" do
+      before { destroy_request }
+
+      it { expect(response).to be_successful }
+      it { expect(response).to render_template(:destroy) }
+    end
+  end
 end


### PR DESCRIPTION
# Description

On permet la suppression d'un admin. Pour cela, on effectue les modification suivantes : 
- bouton pour réactiver un admin
- suppression du bouton pour envoyer les instructions de confirmation à un admin désactivé
- ajout du bouton pour supprimer un admin

# Review app

https://erecrutement-cvd-staging-pr1737.osc-fr1.scalingo.io

# Links

Closes #1700

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/8e428dac-4e7c-4c80-b064-b6c142125261)

