### PR TITLE
🗃️ Update job offer parameters

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -234,6 +234,7 @@ class Admin::JobOffersController < Admin::BaseController
       organization_description bne_date bne_value pep_date pep_value
     ]
     fields << {benefit_ids: []}
+    fields << {drawback_ids: []}
     job_offer_actors_attributes = %i[id role _destroy]
     job_offer_actors_attributes << {administrator_attributes: %i[id email _destroy]}
     fields << {job_offer_actors_attributes: job_offer_actors_attributes}

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -228,7 +228,7 @@ class Admin::JobOffersController < Admin::BaseController
     fields = %i[
       title description category_id professional_category_id employer_id required_profile
       recruitment_process contract_type_id contract_duration_id contract_start_on
-      is_remote_possible available_immediately study_level_id experience_level_id bop_id
+      is_remote_possible study_level_id experience_level_id bop_id
       sector_id estimate_monthly_salary_net estimate_annual_salary_gross
       location city county county_code country_code postcode region spontaneous
       organization_description bne_date bne_value pep_date pep_value

--- a/app/controllers/admin/settings/drawbacks_controller.rb
+++ b/app/controllers/admin/settings/drawbacks_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Admin::Settings::DrawbacksController < Admin::Settings::InheritedResourcesController
+end

--- a/app/helpers/job_offers_helper.rb
+++ b/app/helpers/job_offers_helper.rb
@@ -29,6 +29,8 @@ module JobOffersHelper
       job_offer_salary_display(job_offer)
     when :benefits
       job_offer_benefits_display(job_offer)
+    when :drawbacks
+      job_offer_drawbacks_display(job_offer)
     when :is_remote_possible
       job_offer_remote_display(job_offer)
     end
@@ -50,6 +52,14 @@ module JobOffersHelper
   def job_offer_benefits_display(job_offer)
     if job_offer.benefits.present?
       job_offer.benefits.pluck(:name).join("<br/>").html_safe # rubocop:disable Rails/OutputSafety
+    else
+      "-"
+    end
+  end
+
+  def job_offer_drawbacks_display(job_offer)
+    if job_offer.drawbacks.present?
+      job_offer.drawbacks.pluck(:name).join("<br/>").html_safe # rubocop:disable Rails/OutputSafety
     else
       "-"
     end

--- a/app/helpers/job_offers_helper.rb
+++ b/app/helpers/job_offers_helper.rb
@@ -38,13 +38,7 @@ module JobOffersHelper
     [job_offer.contract_type_name, job_offer.contract_duration_name].compact.join(" ")
   end
 
-  def job_offer_start_display(job_offer)
-    if job_offer.available_immediately?
-      I18n.t("job_offers.job_offer_head.available_immediately")
-    else
-      I18n.l(job_offer.contract_start_on)
-    end
-  end
+  def job_offer_start_display(job_offer) = I18n.l(job_offer.contract_start_on)
 
   def job_offer_salary_display(job_offer)
     res = []

--- a/app/models/drawback.rb
+++ b/app/models/drawback.rb
@@ -1,0 +1,22 @@
+class Drawback < ApplicationRecord
+  acts_as_list
+  default_scope -> { order(position: :asc) }
+
+  validates :name, presence: true, uniqueness: true
+end
+
+# == Schema Information
+#
+# Table name: drawbacks
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_drawbacks_on_name      (name) UNIQUE
+#  index_drawbacks_on_position  (position)
+#

--- a/app/models/drawback_job_offer.rb
+++ b/app/models/drawback_job_offer.rb
@@ -1,0 +1,25 @@
+class DrawbackJobOffer < ApplicationRecord
+  belongs_to :drawback
+  belongs_to :job_offer
+end
+
+# == Schema Information
+#
+# Table name: drawback_job_offers
+#
+#  id           :uuid             not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  drawback_id  :uuid             not null
+#  job_offer_id :uuid             not null
+#
+# Indexes
+#
+#  index_drawback_job_offers_on_drawback_id   (drawback_id)
+#  index_drawback_job_offers_on_job_offer_id  (job_offer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_224623ffa1  (drawback_id => drawbacks.id)
+#  fk_rails_e2f65b84f4  (job_offer_id => job_offers.id)
+#

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -46,6 +46,8 @@ class JobOffer < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :benefit_job_offers, dependent: :destroy
   has_many :benefits, through: :benefit_job_offers
+  has_many :drawback_job_offers, dependent: :destroy
+  has_many :drawbacks, through: :drawback_job_offers
   has_many :job_applications, dependent: :destroy
   has_many :job_offer_actors, inverse_of: :job_offer, dependent: :destroy
   has_many :administrators, through: :job_offer_actors

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -321,7 +321,6 @@ end
 #  affected_job_applications_count                  :integer          default(0), not null
 #  after_meeting_rejected_job_applications_count    :integer          default(0), not null
 #  archived_at                                      :datetime
-#  available_immediately                            :boolean          default(FALSE)
 #  bne_date                                         :date
 #  bne_value                                        :string
 #  city                                             :string

--- a/app/models/pdf_job_offer.rb
+++ b/app/models/pdf_job_offer.rb
@@ -16,6 +16,7 @@ class PdfJobOffer < SimpleDelegator
     add_logo if logo?
     add_vertical_space
     add_title
+    add_location
     add_vertical_space
     add_attributes
     add_vertical_space
@@ -33,13 +34,15 @@ class PdfJobOffer < SimpleDelegator
 
   def add_title = text title, size: 20, style: :bold, align: :center
 
+  def add_location = text job_offer_value_for_attribute(self, :location), size: 12, align: :center
+
   def add_attributes = table attributes_tables, cell_style: attributes_style, width: bounds.width
 
   def attributes_tables
     [
-      [attribute_table(:contract_type), attribute_table(:contract_start_on), attribute_table(:location)],
-      [attribute_table(:study_level), attribute_table(:category), attribute_table(:experience_level)],
-      [attribute_table(:salary), attribute_table(:benefits), attribute_table(:is_remote_possible)]
+      [attribute_table(:contract_type), attribute_table(:contract_start_on), attribute_table(:study_level)],
+      [attribute_table(:category), attribute_table(:experience_level), attribute_table(:salary)],
+      [attribute_table(:benefits), attribute_table(:drawbacks), attribute_table(:is_remote_possible)]
     ]
   end
 
@@ -48,8 +51,10 @@ class PdfJobOffer < SimpleDelegator
   def attribute_table(attribute)
     make_table(attribute_data(attribute), cell_style: attribute_style, width: bounds.width / 3) do
       row(0).font_style = :bold
+      row(0).size = 10
       row(0).background_color = "F0F0F0"
       row(1).height = 50
+      row(1).size = 10
     end
   end
 

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -85,6 +85,8 @@
                       .col-12.col-md-4
                         = f.association :benefits, as: :check_boxes
                       .col-12.col-md-4
+                        = f.association :drawbacks, as: :check_boxes
+                      .col-12.col-md-4
                         = f.input :is_remote_possible, as: :radio_buttons
               .card.mt-5
                 .card-header

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -84,11 +84,8 @@
                     .row
                       .col-12.col-md-4
                         = f.association :benefits, as: :check_boxes
-                    .row
                       .col-12.col-md-4
                         = f.input :is_remote_possible, as: :radio_buttons
-                      .col-12.col-md-4
-                        = f.input :available_immediately, as: :radio_buttons
               .card.mt-5
                 .card-header
                   .card-title= t('.card_1_3_title')

--- a/app/views/admin/settings/shared/_navbar.html.haml
+++ b/app/views/admin/settings/shared/_navbar.html.haml
@@ -73,7 +73,7 @@
       = link_to [:admin, :settings, entry.to_sym], class: klasses do
         = t(".#{ entry }")
   - entries = JobOffer::SETTINGS.map{|x| x.to_s.pluralize.to_sym}
-  - entries += %i[archiving_reasons benefits bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
+  - entries += %i[archiving_reasons benefits drawbacks bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
   - if entries.any?{ |entry| can?(:manage, entry.to_s.singularize.classify.constantize) }
     .list-group-item.menu
       = t(".writing_job_offers")

--- a/app/views/job_offers/_job_offer_head.html.haml
+++ b/app/views/job_offers/_job_offer_head.html.haml
@@ -1,4 +1,4 @@
-- attributes = %i[contract_type contract_start_on location study_level category experience_level salary is_remote_possible benefits]
+- attributes = %i[contract_type contract_start_on location study_level category experience_level salary is_remote_possible benefits drawbacks]
 - attributes.each_with_index do |attribute, index|
   .d-flex.align-items-center.mb-2{class: index == 0 ? nil : 'rf-mt-1w'}
     = fa_icon job_offer_icon_for_attribute(attribute), class: 'mr-3'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -547,7 +547,8 @@ fr:
         navbar:
           admin: "Administration"
           administrators: "Comptes admin"
-          benefits: "Avantage(s) en nature"
+          benefits: "Avantages"
+          drawbacks: "Contraintes"
           bops: "BOPs"
           categories: "Domaines professionnels"
           cmgs: "Liste des CMG"
@@ -741,6 +742,22 @@ fr:
           success: "Avantage en nature mis à jour !"
         destroy:
           success: "Avantage en nature supprimé !"
+      drawbacks:
+        index:
+          card_title:
+            zero: "Aucune contrainte particulière d'exercice"
+            one: "1 contrainte particulière d'exercice"
+            other: "%{count} contraintes particulières d'exercice"
+        new:
+          title: "Ajouter une contrainte particulière d'exercice"
+        edit:
+          title: "Modifier '%{name}'"
+        create:
+          success: "Contrainte particulière d'exercice créée !"
+        update:
+          success: "Contrainte particulière d'exercice mise à jour !"
+        destroy:
+          success: "Contrainte particulière d'exercice supprimée !"
       job_offer_terms:
         index:
           card_title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -606,7 +606,7 @@ fr:
             other: "Comptes actifs (%{count})"
           account_inactive:
             zero: 'Aucun compte admin désactivé'
-            one: 'Comte désactivé (1)'
+            one: 'Compte désactivé (1)'
             other: "Comptes désactivés (%{count})"
           card_title:
             zero: 'Aucun compte admin'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -152,7 +152,6 @@ fr:
       organization_description: "Descriptif de l'organisation"
       recruitment_process: "Process de recrutement"
     job_offer_head:
-      available_immediately: "Poste à pourvoir immédiatement"
       benefit: "Avantage en nature"
     successful:
       subject: "Votre candidature à l'offre %{job_offer_identifier} sur %{service_name}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1199,6 +1199,7 @@ fr:
         salary: "Rémunération"
         recruitment_process: Process de recrutement
         benefits: "Avantages liés au poste"
+        drawbacks: "Contraintes particulières d'exercice"
         is_remote_possible: "Télétravail"
         organization_description: "Descriptif de l'organisation"
         required_profile: "Profil recherché"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -105,7 +105,6 @@ fr:
         contract_duration: "Durée du contrat"
         contract_start_on: "Prise de fonction souhaitée"
         is_remote_possible: "Télétravail possible ?"
-        available_immediately: "Disponible immédiatement ?"
         sector: "Secteur / Filière"
         option_cover_letter: "Lettre de motivation"
         option_resume: "CV"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,9 +180,8 @@ Rails.application.routes.draw do
       resources :salary_ranges
       resources :job_application_file_types
       other_settings = %i[
-        archiving_reasons benefit bops email_template job_application_file_types rejection_reasons
-        contract_duration foreign_languages foreign_language_levels job_offer_terms
-        user_menu_links
+        archiving_reasons benefit drawbacks bops email_template job_application_file_types rejection_reasons
+        contract_duration foreign_languages foreign_language_levels job_offer_terms user_menu_links
       ]
       (JobOffer::SETTINGS + other_settings).each do |setting|
         resources setting.to_s.pluralize.to_sym, except: %i[show] do

--- a/db/migrate/20240522120847_remove_available_immediately_from_job_offers.rb
+++ b/db/migrate/20240522120847_remove_available_immediately_from_job_offers.rb
@@ -1,0 +1,5 @@
+class RemoveAvailableImmediatelyFromJobOffers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :job_offers, :available_immediately, :boolean }
+  end
+end

--- a/db/migrate/20240522122640_create_drawbacks.rb
+++ b/db/migrate/20240522122640_create_drawbacks.rb
@@ -1,0 +1,12 @@
+class CreateDrawbacks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :drawbacks, id: :uuid do |t|
+      t.string :name
+      t.integer :position
+
+      t.timestamps
+    end
+    add_index :drawbacks, :name, unique: true
+    add_index :drawbacks, :position
+  end
+end

--- a/db/migrate/20240522124756_create_drawback_job_offers.rb
+++ b/db/migrate/20240522124756_create_drawback_job_offers.rb
@@ -1,0 +1,10 @@
+class CreateDrawbackJobOffers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :drawback_job_offers, id: :uuid do |t|
+      t.references :drawback, null: false, foreign_key: true, type: :uuid
+      t.references :job_offer, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_22_122640) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_124756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -233,6 +233,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_122640) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "drawback_job_offers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "drawback_id", null: false
+    t.uuid "job_offer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["drawback_id"], name: "index_drawback_job_offers_on_drawback_id"
+    t.index ["job_offer_id"], name: "index_drawback_job_offers_on_job_offer_id"
   end
 
   create_table "drawbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -778,6 +787,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_122640) do
   add_foreign_key "cmgs", "organizations"
   add_foreign_key "department_users", "departments"
   add_foreign_key "department_users", "users"
+  add_foreign_key "drawback_job_offers", "drawbacks"
+  add_foreign_key "drawback_job_offers", "job_offers"
   add_foreign_key "email_attachments", "emails"
   add_foreign_key "emails", "job_applications"
   add_foreign_key "job_application_files", "job_application_file_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_22_120847) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_122640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -233,6 +233,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_120847) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "drawbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_drawbacks_on_name", unique: true
+    t.index ["position"], name: "index_drawbacks_on_position"
   end
 
   create_table "email_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_143624) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_120847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -436,7 +436,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_143624) do
     t.string "identifier"
     t.integer "option_photo"
     t.integer "notifications_count", default: 0
-    t.boolean "available_immediately", default: false
     t.string "city"
     t.string "county"
     t.integer "county_code"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -209,6 +209,10 @@ Benefit.create!(name: "Voiture")
 Benefit.create!(name: "Crèche")
 Benefit.create!(name: "Appartement de fonction")
 
+Drawback.create!(name: "Astreintes")
+Drawback.create!(name: "Travail de nuit")
+Drawback.create!(name: "Permis de conduire")
+
 AvailabilityRange.create!(name: "En poste")
 AvailabilityRange.create!(name: "Disponible immédiatement")
 AvailabilityRange.create!(name: "Disponible sous 1 mois")

--- a/spec/factories/drawbacks.rb
+++ b/spec/factories/drawbacks.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :drawback do
+    name { Faker::Name.unique.name }
+  end
+end
+
+# == Schema Information
+#
+# Table name: drawbacks
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_drawbacks_on_name      (name) UNIQUE
+#  index_drawbacks_on_position  (position)
+#

--- a/spec/factories/job_offers.rb
+++ b/spec/factories/job_offers.rb
@@ -57,7 +57,6 @@ end
 #  affected_job_applications_count                  :integer          default(0), not null
 #  after_meeting_rejected_job_applications_count    :integer          default(0), not null
 #  archived_at                                      :datetime
-#  available_immediately                            :boolean          default(FALSE)
 #  bne_date                                         :date
 #  bne_value                                        :string
 #  city                                             :string

--- a/spec/helpers/job_offers_helper_spec.rb
+++ b/spec/helpers/job_offers_helper_spec.rb
@@ -113,18 +113,8 @@ RSpec.describe JobOffersHelper do
   describe ".job_offer_start_display" do
     subject { job_offer_start_display(job_offer) }
 
-    let(:job_offer) { create(:job_offer, available_immediately:) }
+    let(:job_offer) { create(:job_offer) }
 
-    context "when the job offer is available immediately" do
-      let(:available_immediately) { true }
-
-      it { is_expected.to eq(I18n.t("job_offers.job_offer_head.available_immediately")) }
-    end
-
-    context "when the job offer is not available immediately" do
-      let(:available_immediately) { false }
-
-      it { is_expected.to eq(I18n.l(job_offer.contract_start_on)) }
-    end
+    it { is_expected.to eq(I18n.l(job_offer.contract_start_on)) }
   end
 end

--- a/spec/helpers/job_offers_helper_spec.rb
+++ b/spec/helpers/job_offers_helper_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe JobOffersHelper do
       it { is_expected.to eq(job_offer_benefits_display(job_offer)) }
     end
 
+    context "when the attribute is :drawbacks" do
+      let(:attribute) { :drawbacks }
+
+      it { is_expected.to eq(job_offer_drawbacks_display(job_offer)) }
+    end
+
     context "when the attribute is :is_remote_possible" do
       let(:attribute) { :is_remote_possible }
 

--- a/spec/models/drawback_job_offer_spec.rb
+++ b/spec/models/drawback_job_offer_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe DrawbackJobOffer do
+  describe "associations" do
+    it { is_expected.to belong_to(:drawback) }
+
+    it { is_expected.to belong_to(:job_offer) }
+  end
+end

--- a/spec/models/drawback_spec.rb
+++ b/spec/models/drawback_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Drawback do
+  it { is_expected.to validate_presence_of(:name) }
+end
+
+# == Schema Information
+#
+# Table name: drawbacks
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_drawbacks_on_name      (name) UNIQUE
+#  index_drawbacks_on_position  (position)
+#

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe JobOffer do
 
   describe "associations" do
     it { is_expected.to have_many(:bookmarks).dependent(:destroy) }
+
+    it { is_expected.to have_many(:job_offer_actors).dependent(:destroy) }
+
+    it { is_expected.to have_many(:benefit_job_offers).dependent(:destroy) }
+
+    it { is_expected.to have_many(:benefits).through(:benefit_job_offers) }
+
+    it { is_expected.to have_many(:drawback_job_offers).dependent(:destroy) }
+
+    it { is_expected.to have_many(:drawbacks).through(:drawback_job_offers) }
   end
 
   describe "delegations" do

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -390,7 +390,6 @@ end
 #  affected_job_applications_count                  :integer          default(0), not null
 #  after_meeting_rejected_job_applications_count    :integer          default(0), not null
 #  archived_at                                      :datetime
-#  available_immediately                            :boolean          default(FALSE)
 #  bne_date                                         :date
 #  bne_value                                        :string
 #  city                                             :string

--- a/spec/requests/admin/settings/drawbacks_spec.rb
+++ b/spec/requests/admin/settings/drawbacks_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Settings::Drawbacks" do
+  it_behaves_like "an admin setting", :drawback, :name, "a new name"
+  it_behaves_like "a movable admin setting", :drawback
+end


### PR DESCRIPTION
# Description

On met à jour plusieurs paramètres de l'offre d'emploi.

On commence par supprimer totalement la notion "disponible immédiatement".

Ensuite, on ajoute le nouveau paramètre "contrainte particulière d'exercice" dans les paramètres d'administration.

Cela permet d'ajouter ces contraintes à l'offre d'emploi en édition.

Enfin les "contraintes particulières d'exercices" sont affichées dans l'offre d'emploi en front office ainsi que dans le PDF.

# Review app

https://erecrutement-cvd-staging-pr1740.osc-fr1.scalingo.io

# Links

Closes #1671

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/d4f5e5aa-84c5-460a-a26d-cacab8f4864a)

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/dbfc1da6-60f0-4e7b-8210-de0ebbb4d5d5)

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/e45d16c9-1940-4032-88e5-fb74dcf48b0b)

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/d1bf861b-7ca1-444e-a68f-7b5e34e0967d)

