### PR TITLE
🐛 Fix crashing export

### DIFF
--- a/lib/services/exporter/administrator.rb
+++ b/lib/services/exporter/administrator.rb
@@ -37,11 +37,19 @@ class Exporter::Administrator < Exporter::Base
       administrator.email,
       administrator.employer&.code,
       administrator.deleted_at ? "Actif" : "Inactif",
-      Administrator.human_attribute_name("role.#{administrator.role}"),
+      role(administrator),
       localize(administrator.created_at),
       localize(administrator.last_sign_in_at),
       administrator.inviter&.full_name,
       administrator.owned_job_offers.map { |o| o.identifier }.join(", ")
     ]
+  end
+
+  def role(administrator)
+    if administrator.role.present?
+      Administrator.human_attribute_name("role.#{administrator.role}")
+    else
+      I18n.t("admin.settings.administrators.administrator.no_role")
+    end
   end
 end


### PR DESCRIPTION
# Description

Il y avait un crash à l'export de la liste des administrateurs. Le cas de figure où le rôle de l'admin est manquant ("Aucun rôle") n'était pas géré. C'est corrigé ici.

# Review app

https://erecrutement-cvd-staging-pr1742.osc-fr1.scalingo.io

# Links

Closes #1741
