### PR TITLE
Search for users without departments

### DIFF
--- a/app/views/admin/users/_filter_department.html.haml
+++ b/app/views/admin/users/_filter_department.html.haml
@@ -6,6 +6,13 @@
     - if ary.any?
       = "(#{ary.size})"
   .dropdown-menu.dropdown-menu-right.allow-focus{aria: {labelledby: 'dropdownContractType'}}
+    %ul.mb-0
+      %li
+        .form-check.form-check-inline.w-100
+          - input_id = "department_none"
+          - checked = ary.include?("none")
+          = check_box_tag "q[#{search_key}][]", "none", checked, class: 'form-check-input', id: input_id
+          %label.form-check-label.text-truncate.d-block{for: input_id, title: "Aucun"}= "Aucun"
     - Department.regions.each do |region, departments|
       %ul.mb-0
         %li

--- a/app/views/department_users/_form.html.haml
+++ b/app/views/department_users/_form.html.haml
@@ -6,7 +6,7 @@
         .rf-col-12
           - name = "#{form}[department_users_attributes][index][department_id]"
           = label_tag name, "Souhait(s) géographique(s) (département)"
-          = select_tag name, options_from_collection_for_select(Department.all, "id", "label"), class: "rf-select", include_blank: true
+          = select_tag name, options_from_collection_for_select(Department.all, "id", "label"), class: "rf-select", prompt: "Aucun"
     .rf-col-1.text-center.rf-mt-4w
       %button.blank_button.rf-fi-delete-line{data: { action: 'click->duplicator#remove' }}
   %div{ data: { duplicator: { target: :root }}}
@@ -17,7 +17,7 @@
             .rf-col-12
               - name = "#{form}[department_users_attributes][#{index}][department_id]"
               = label_tag name, "Souhait(s) géographique(s) (département)"
-              = select_tag name, options_from_collection_for_select(Department.all, "id", "label", selected: department_user.department_id), class: "rf-select", include_blank: true
+              = select_tag name, options_from_collection_for_select(Department.all, "id", "label", selected: department_user.department_id), class: "rf-select", prompt: "Aucun"
         .rf-col-1.text-center.rf-mt-4w
           %button.blank_button.rf-fi-delete-line{data: { action: 'click->duplicator#remove' }}
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe "Admin::Users" do
   before { sign_in admin }
 
   describe "GET /admin/candidats" do
-    subject(:index_request) { get admin_users_path }
+    subject(:index_request) { get admin_users_path, params: }
+
+    let(:params) { {} }
 
     it "is successful" do
       index_request
@@ -19,6 +21,63 @@ RSpec.describe "Admin::Users" do
     it "renders the template" do
       expect(index_request).to render_template(:index)
     end
+
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    describe "filtering users on departments" do
+      let!(:ain) { create(:department, name: "Ain") }
+      let!(:gironde) { create(:department, name: "Gironde") }
+
+      let!(:user_none) { create(:user) }
+      let!(:user_gironde) { create(:user) }
+      let!(:user_ain) { create(:user) }
+
+      before do
+        user_ain.departments << ain
+        user_gironde.departments << gironde
+        index_request
+      end
+
+      context "when filtering on a single department" do
+        let(:params) { {q: {departments_id_in: [ain.id]}} }
+
+        it { expect(response.body).to include(user_ain.full_name) }
+
+        it { expect(response.body).not_to include(user_gironde.full_name) }
+
+        it { expect(response.body).not_to include(user_none.full_name) }
+      end
+
+      context "when filtering on multiple departments" do
+        let(:params) { {q: {departments_id_in: [ain.id, gironde.id]}} }
+
+        it { expect(response.body).to include(user_ain.full_name) }
+
+        it { expect(response.body).to include(user_gironde.full_name) }
+
+        it { expect(response.body).not_to include(user_none.full_name) }
+      end
+
+      context "when filtering on 'none' department" do
+        let(:departments) { {departments_id_in: ["none"]} }
+
+        it { expect(response.body).not_to include(user_ain.full_name) }
+
+        it { expect(response.body).not_to include(user_gironde.full_name) }
+
+        it { expect(response.body).to include(user_none.full_name) }
+      end
+
+      context "when filtering on 'none' departments and an existing department" do
+        let(:departments) { {departments_id_in: ["none", ain.id]} }
+
+        it { expect(response.body).to include(user_ain.full_name) }
+
+        it { expect(response.body).not_to include(user_gironde.full_name) }
+
+        it { expect(response.body).to include(user_none.full_name) }
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 
   describe "GET /admin/candidats/:id" do


### PR DESCRIPTION
# Description

L'objectif de cette PR est de permettre à l'admin de chercher des candidat·es sans souhait géographique.

On commence par ajouter l'option "Aucun" dans le select des souhaits géographique, lorsque le·a candidat·e postule.

Ensuite, on ajoute la même option dans le formulaire de recherche de candidat·es, côté admin.

Enfin, on lorsque cette option est sélectionnée, on renvoie dans les résultats de recherche les candidat·es sans souhait géographique.

RAF : 
- [ ] recherche => `department_users_department_id_not_in: Department.pluck(:id)`, [merging searches](https://activerecord-hackery.github.io/ransack/going-further/merging-searches/)

# Review app

https://erecrutement-cvd-staging-pr1746.osc-fr1.scalingo.io

# Links

Closes #1729

# Screenshots
