### PR TITLE
🐛 Remove admin login flash

### DIFF
--- a/app/controllers/administrators/sessions_controller.rb
+++ b/app/controllers/administrators/sessions_controller.rb
@@ -1,0 +1,7 @@
+class Administrators::SessionsController < Devise::SessionsController
+  after_action :remove_notice, only: :create # rubocop:disable Rails/LexicallyScopedActionFilter
+
+  private
+
+  def remove_notice = flash.discard(:notice)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,8 @@ Rails.application.routes.draw do
     patch "/admin/confirmation" => "administrators/confirmations#update", :as => :update_administrator_confirmation
   end
   devise_for :administrators, path: "admin", controllers: {
-    confirmations: "administrators/confirmations"
+    confirmations: "administrators/confirmations",
+    sessions: "administrators/sessions"
   }
   devise_for :users, controllers: {
     registrations: "users/registrations",


### PR DESCRIPTION
# Description

Lors de l'authentification de l'administrateur, le message suivant s'affichait : 
![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/0e08cbeb-d709-4b65-8273-3263b0a4847f)

Cela fait suite à #1723.

Ici, on retire le flash message après l'authentification de l'admin.

# Review app

https://erecrutement-cvd-staging-pr<PR-NUMBER>.osc-fr1.scalingo.io

# Links

Linked to #1661
Linked to #1723
