### PR TITLE
:bug: Destroy a category

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -8,6 +8,7 @@ class Category < ApplicationRecord
 
   has_many :job_offers, dependent: :nullify
   has_many :publicly_visible_job_offers, -> { publicly_visible }, class_name: "JobOffer", inverse_of: :category, dependent: :nullify
+  has_many :job_applications, dependent: :nullify
 
   def compute_published_job_offers_count!
     if leaf?

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -4,6 +4,12 @@ require "rails_helper"
 
 RSpec.describe Category do
   it { is_expected.to validate_presence_of(:name) }
+
+  describe "associations" do
+    it { is_expected.to have_many(:job_offers).dependent(:nullify) }
+
+    it { is_expected.to have_many(:job_applications).dependent(:nullify) }
+  end
 end
 
 # == Schema Information

--- a/spec/requests/admin/settings/categories_spec.rb
+++ b/spec/requests/admin/settings/categories_spec.rb
@@ -4,4 +4,26 @@ require "rails_helper"
 
 RSpec.describe "Admin::Settings::Categories" do
   it_behaves_like "an admin setting", :category, :name, "a new name"
+
+  describe "Destroying a category" do
+    subject(:destroy_request) { delete admin_settings_category_path(category) }
+
+    before { sign_in create(:administrator) }
+
+    let!(:category) { create(:category) }
+
+    it { expect { destroy_request }.to change(Category, :count).by(-1) }
+
+    context "when the category has job offers" do
+      before { create(:job_offer, category: category) }
+
+      it { expect { destroy_request }.to change(Category, :count).by(-1) }
+    end
+
+    context "when the category has job applications" do
+      before { create(:job_application, category: category) }
+
+      it { expect { destroy_request }.to change(Category, :count).by(-1) }
+    end
+  end
 end


### PR DESCRIPTION
# Description

1/ Don't crash when the category that's being destroyed has job applications.

2/ Don't crash when the category that's being destroyed has children with job offers or job applications.





# Review app

https://erecrutement-cvd-staging-pr1761.osc-fr1.scalingo.io

# Links

Closes https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/1758
