### PR TITLE
User can't be accepted twice

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -46,6 +46,7 @@ class JobApplication < ApplicationRecord
   validates :user_id, uniqueness: {scope: :job_offer_id}, on: :create, allow_nil: true # rubocop:disable Rails/UniqueValidationWithoutIndex
   validate :cant_accept_before_delay
   validate :complete_files_before_draft_contract
+  validate :cant_be_accepted_twice, if: -> { accepted? }, unless: -> { has_accepted_other_job_application? }
 
   before_validation :set_employer
   before_save :compute_notifications_counter
@@ -295,6 +296,10 @@ class JobApplication < ApplicationRecord
 
     errors.add(:state, :complete_files_before_draft_contract)
   end
+
+  def cant_be_accepted_twice = errors.add(:state, :cant_be_accepted_twice)
+
+  def has_accepted_other_job_application? = user.job_applications.where(state: "accepted").where.not(id: id).empty?
 
   class << self
     def rejected_states

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1107,6 +1107,7 @@ fr:
             state:
               cant_accept_before_delay: "Un délai de 30 jours après la publication de l'offre sur la PEP doit être respecté avant d'accepter une candidature"
               complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
+              cant_be_accepted_twice: "Cette action n'est pas possible. Ce candidat est déjà à l'état \"Retenu\" dans une offre d'emploi."
             cover_letter_content_type:
               invalid: "PDF uniquement, max 2Mo"
             resume_content_type:

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe JobApplication do
   let(:job_offer) { create(:job_offer) }
   let(:job_application) { create(:job_application, job_offer: job_offer) }
 
+  describe "validations" do
+    describe "#cant_be_accepted_twice" do
+      subject(:acceptance) { job_application.accepted! }
+
+      let(:job_application) { create(:job_application) }
+
+      context "when the user has not been accepted for another job offer" do
+        it { is_expected.to be(true) }
+      end
+
+      context "when the user has been accepted for another job offer" do
+        before { create(:job_application, user: job_application.user, job_offer: create(:job_offer), state: :accepted) }
+
+        it { expect { acceptance }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
+    end
+  end
+
   it "correcties tell rejected state" do
     expect(job_application.rejected_state?).to be(false)
 


### PR DESCRIPTION
# Description

Lorsqu'un·e candidat·e est déjà retenu·e sur une offre d'emploi, iel ne peut pas être retenu·e sur une seconde.

# Review app

https://erecrutement-cvd-staging-pr1767.osc-fr1.scalingo.io

# Links

Closes #1733

# Screenshots

![image](https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/assets/1193334/006c2047-2c4d-48dd-a1cc-bfc3c4fbbfa7)
