### PR TITLE
Add actor roles to administrators#index

### DIFF
--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -137,7 +137,7 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
     @permitted_params = permitted_params
     @q = Administrator.includes(:inviter).ransack(permitted_params[:q])
     @q.sorts = "created_at desc" if @q.sorts.empty?
-    @administrators_active = @q.result.active.includes(:employer)
+    @administrators_active = @q.result.active.includes(:employer, :job_offer_actors)
     @administrators_inactive = @q.result.inactive.includes(:employer)
   end
 

--- a/app/helpers/administrators_helper.rb
+++ b/app/helpers/administrators_helper.rb
@@ -1,9 +1,19 @@
 module AdministratorsHelper
   def actor_roles_or_general_role(administrator)
-    if (actor_roles = administrator.job_offer_actors.pluck(:role).compact).any?
-      actor_roles.uniq.map { |role| t("activerecord.attributes.job_offer_actor/role.#{role}") }.to_sentence
+    if (actor_roles = actor_roles(administrator)).present?
+      actor_roles
     elsif administrator.role
       t("activerecord.attributes.administrator/role.#{administrator.role}")
     end
+  end
+
+  def actor_roles(administrator)
+    administrator
+      .job_offer_actors
+      .pluck(:role)
+      .compact
+      .uniq
+      .map { |role| t("activerecord.attributes.job_offer_actor/role.#{role}") }
+      .to_sentence
   end
 end

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -14,6 +14,8 @@
         = Administrator.human_attribute_name("role.#{administrator.role}")
       - else
         = t('.no_role')
+  %td
+    = actor_roles(administrator)
   %td.text-dark
     .d-block.text-nowrap
       = l administrator.created_at

--- a/app/views/admin/settings/administrators/index.html.haml
+++ b/app/views/admin/settings/administrators/index.html.haml
@@ -39,6 +39,8 @@
           %th
             = t('.table.role')
           %th
+            = t('.table.job_offer_actor_roles')
+          %th
             = sort_link(@q, :created_at) do
               = t('.table.created_at')
           %th{style: "width: 70px;"}
@@ -50,6 +52,7 @@
             = f.input :employer_id_eq, collection: Employer.all.map{|e| [e.name.truncate(10, separator: '…'), e.id]}, label: false
           %td
             = f.input :role_eq, collection: Administrator.roles.map{|x,y| [Administrator.human_attribute_name("role.#{ x }"), y]}, label: false, input_html: {class: 'w-100'}
+          %td
           %td
           %td
       %tbody

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -596,6 +596,7 @@ fr:
             name: "Nom"
             employer: "Employeur"
             role: "Rôle"
+            job_offer_actor_roles: "Rôles sur les offres"
             last_sign_in_at: "Dernière connexion"
             created_at: "Créé le"
           account_active:

--- a/spec/helpers/administrators_helper_spec.rb
+++ b/spec/helpers/administrators_helper_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe AdministratorsHelper do
   describe "#actor_roles_or_general_role" do
     subject { helper.actor_roles_or_general_role(administrator) }
 
-    let(:administrator) { build(:administrator) }
-
     context "when administrator has actor roles" do
+      let(:administrator) { create(:administrator) }
+
       before do
-        administrator.save!
         job_offer = create(:job_offer)
         create(:job_offer_actor, job_offer:, administrator:, role: :cmg)
         create(:job_offer_actor, job_offer:, administrator:, role: :brh)
@@ -19,15 +18,44 @@ RSpec.describe AdministratorsHelper do
     end
 
     context "when administrator has general role" do
+      let(:administrator) { build(:administrator) }
+
       before { allow(administrator).to receive(:role).and_return(:employer) }
 
       it { is_expected.to eq("Employeur") }
     end
 
     context "when administrator has no roles" do
+      let(:administrator) { build(:administrator) }
+
       before { allow(administrator).to receive(:role).and_return(nil) }
 
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#actor_roles" do
+    subject { helper.actor_roles(administrator) }
+
+    context "when administrator has actor roles" do
+      let(:administrator) { create(:administrator) }
+
+      before do
+        job_offer = create(:job_offer)
+        create(:job_offer_actor, job_offer:, administrator:, role: :cmg)
+        create(:job_offer_actor, job_offer:, administrator:, role: :brh)
+        create(:job_offer_actor, job_offer:, administrator:, role: :grand_employer)
+      end
+
+      it { is_expected.to eq("CMG, RH et Grand Employeur") }
+    end
+
+    context "when administrator has no actor roles" do
+      let(:administrator) { build(:administrator) }
+
+      before { allow(administrator).to receive(:role).and_return(nil) }
+
+      it { is_expected.to be_blank }
     end
   end
 end


### PR DESCRIPTION
# Description

Sur la liste des administrators, on ajoute les "actor roles", c'est à dire les rôles qu'iels ont sur les offres d'emploi.

# Review app

https://erecrutement-cvd-staging-pr1777.osc-fr1.scalingo.io

# Links

Closes #1735

# Screenshots

![image](https://github.com/user-attachments/assets/89b81c16-56c8-411f-953d-881dce00361d)
