### PR TITLE
:sparkles: Edit availability ranges in admin settings

### DIFF
--- a/app/controllers/admin/settings/availability_ranges_controller.rb
+++ b/app/controllers/admin/settings/availability_ranges_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Admin::Settings::AvailabilityRangesController < Admin::Settings::InheritedResourcesController
+end

--- a/app/controllers/admin/stats/job_offers_controller.rb
+++ b/app/controllers/admin/stats/job_offers_controller.rb
@@ -21,7 +21,7 @@ class Admin::Stats::JobOffersController < Admin::Stats::BaseController
     @permitted_params = permitted_params
 
     @profiles = Profile.joins(job_application: :job_offer).where(job_applications: {job_offers: @job_offers})
-    @profile_availables = @profiles.where.not(availability_range: AvailabilityRange.en_poste)
+    @profile_availables = @profiles.where.not(availability_range: AvailabilityRange.employed)
 
     @per_day = root_rel.group_by_day(:created_at, range: date_range).count
     build_average_affection

--- a/app/models/availability_range.rb
+++ b/app/models/availability_range.rb
@@ -5,13 +5,20 @@ class AvailabilityRange < ApplicationRecord
   acts_as_list
   default_scope -> { order(position: :asc) }
 
-  validates :name, presence: true, uniqueness: true
-
   has_many :profiles, dependent: :nullify
 
-  def self.en_poste
-    find_by(name: "En poste")
-  end
+  validates :name, presence: true, uniqueness: true
+  validate :check_employed, if: -> { employed? }, on: :update
+
+  before_destroy -> { throw :abort }, if: -> { employed? }, prepend: true
+
+  def self.en_poste = find_by(name: "En poste")
+
+  def employed? = self == self.class.employed
+
+  private
+
+  def check_employed = errors.add(:base, "En poste ne peut pas être modifié")
 end
 
 # == Schema Information

--- a/app/models/availability_range.rb
+++ b/app/models/availability_range.rb
@@ -5,13 +5,8 @@ class AvailabilityRange < ApplicationRecord
   acts_as_list
   default_scope -> { order(position: :asc) }
 
-  #####################################
-  # Validations
+  validates :name, presence: true, uniqueness: true
 
-  validates :name, presence: true
-
-  #####################################
-  # Relations
   has_many :profiles, dependent: :nullify
 
   def self.en_poste
@@ -31,6 +26,6 @@ end
 #
 # Indexes
 #
-#  index_availability_ranges_on_name      (name)
+#  index_availability_ranges_on_name      (name) UNIQUE
 #  index_availability_ranges_on_position  (position)
 #

--- a/app/models/availability_range.rb
+++ b/app/models/availability_range.rb
@@ -12,7 +12,7 @@ class AvailabilityRange < ApplicationRecord
 
   before_destroy -> { throw :abort }, if: -> { employed? }, prepend: true
 
-  def self.en_poste = find_by(name: "En poste")
+  def self.employed = find_by(name: "En poste")
 
   def employed? = self == self.class.employed
 

--- a/app/views/admin/settings/inherited_resources/_element.html.haml
+++ b/app/views/admin/settings/inherited_resources/_element.html.haml
@@ -65,6 +65,7 @@
           = link_to fa_icon('arrow-up', class: 'ml-1'), [:move_higher, :admin, :settings, element], method: :post, title: t('buttons.move_higher'), data: {confirm: t('buttons.confirm')}
         - if (resource_class != Page) || (level == 1 && element.right_sibling) || (level > 1 && !element.leaf?)
           = link_to fa_icon('arrow-down', class: 'ml-1'), [:move_lower, :admin, :settings, element], method: :post, title: t('buttons.move_lower'), data: {confirm: t('buttons.confirm')}
-      = link_to fa_icon('pencil', class: 'ml-1'), [:edit, :admin, :settings, element], title: t('buttons.edit')
-      - unless resource_class == Page && level == 0
+      - unless resource_class == AvailabilityRange && element.employed?
+        = link_to fa_icon('pencil', class: 'ml-1'), [:edit, :admin, :settings, element], title: t('buttons.edit')
+      - unless (resource_class == Page && level == 0) || (resource_class == AvailabilityRange && element.employed?)
         = link_to fa_icon('trash-can', class: 'ml-1'), [:admin, :settings, element], method: :delete, title: t('buttons.delete'), data: {confirm: t('buttons.confirm')}

--- a/app/views/admin/settings/shared/_navbar.html.haml
+++ b/app/views/admin/settings/shared/_navbar.html.haml
@@ -73,7 +73,7 @@
       = link_to [:admin, :settings, entry.to_sym], class: klasses do
         = t(".#{ entry }")
   - entries = JobOffer::SETTINGS.map{|x| x.to_s.pluralize.to_sym}
-  - entries += %i[archiving_reasons benefits drawbacks bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
+  - entries += %i[availability_ranges archiving_reasons benefits drawbacks bops salary_ranges rejection_reasons contract_durations foreign_languages foreign_language_levels job_offer_terms]
   - if entries.any?{ |entry| can?(:manage, entry.to_s.singularize.classify.constantize) }
     .list-group-item.menu
       = t(".writing_job_offers")

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -576,6 +576,7 @@ fr:
           job_offer_terms: "Conditions d'accès à la création d'offres"
           user_menu_links: "Onglet espace candidat"
           archiving_reasons: "Motifs d'archivage"
+          availability_ranges: "Disponibilités"
       base:
         index:
           title: "Paramètres"
@@ -904,6 +905,24 @@ fr:
           success: "Motif ajouté !"
         destroy:
           success: "Motif supprimé !"
+      availability_ranges:
+        index:
+          title: "Disponibilités d'un·e candidat·e"
+          add: "Ajouter"
+          card_title:
+            zero: 'Aucune disponibilité pour le moment'
+            one: '1 disponibilité'
+            other: '%{count} disponibilités'
+        new:
+          title: "Ajouter une disponibilité"
+        create:
+          success: "Disponibilité ajoutée !"
+        edit:
+          title: "Modifier la disponibilité '%{name}'"
+        update:
+          success: "Disponibilité modifiée !"
+        destroy:
+          success: "Disponibilité supprimée !"
       salary_ranges:
         index:
           title: "Estimations salariales"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,6 +182,7 @@ Rails.application.routes.draw do
       resources :salary_ranges
       resources :job_application_file_types
       other_settings = %i[
+        availability_ranges
         archiving_reasons benefit drawbacks bops email_template job_application_file_types rejection_reasons
         contract_duration foreign_languages foreign_language_levels job_offer_terms user_menu_links
       ]

--- a/db/migrate/20240731142102_add_uniqueness_index_on_name_to_availability_range.rb
+++ b/db/migrate/20240731142102_add_uniqueness_index_on_name_to_availability_range.rb
@@ -1,0 +1,13 @@
+class AddUniquenessIndexOnNameToAvailabilityRange < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :availability_ranges, :name
+    add_index :availability_ranges, :name, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :availability_ranges, :name
+    add_index :availability_ranges, :name, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_30_165322) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_142102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_30_165322) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_availability_ranges_on_name"
+    t.index ["name"], name: "index_availability_ranges_on_name", unique: true
     t.index ["position"], name: "index_availability_ranges_on_position"
   end
 

--- a/spec/factories/availability_ranges.rb
+++ b/spec/factories/availability_ranges.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :availability_range do
+    name { Faker::Name.unique.name }
+    position { 1 }
+  end
+end
+
+# == Schema Information
+#
+# Table name: availability_ranges
+#
+#  id         :uuid             not null, primary key
+#  name       :string
+#  position   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_availability_ranges_on_name      (name) UNIQUE
+#  index_availability_ranges_on_position  (position)
+#

--- a/spec/fixtures/availability_ranges.yml
+++ b/spec/fixtures/availability_ranges.yml
@@ -21,6 +21,6 @@ three_months_plus:
 #
 # Indexes
 #
-#  index_availability_ranges_on_name      (name)
+#  index_availability_ranges_on_name      (name) UNIQUE
 #  index_availability_ranges_on_position  (position)
 #

--- a/spec/models/availability_range_spec.rb
+++ b/spec/models/availability_range_spec.rb
@@ -3,7 +3,75 @@
 require "rails_helper"
 
 RSpec.describe AvailabilityRange do
-  it { is_expected.to validate_presence_of(:name) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+
+    describe "#check_employed on update" do
+      subject(:update_availability_range) { availability_range.update(name: "something else") }
+
+      let(:availability_range) { create(:availability_range, name:) }
+
+      before { update_availability_range }
+
+      context "when the availability range is 'En poste'" do
+        let(:name) { "En poste" }
+
+        it { expect(availability_range).not_to be_valid }
+
+        it "adds an error" do
+          availability_range.valid?
+          expect(availability_range.errors[:base]).to include("En poste ne peut pas être modifié")
+        end
+      end
+
+      context "when the availability range is not 'En poste'" do
+        let(:name) { "A name" }
+
+        it { expect(availability_range).to be_valid }
+      end
+    end
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:profiles).dependent(:nullify) }
+  end
+
+  describe "before_destroy callbacks" do
+    it "does not allow deletion of 'En poste' availability ranges" do
+      availability_range = create(:availability_range, name: "En poste")
+      expect { availability_range.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
+  end
+
+  describe "#employed" do
+    subject(:employed) { described_class.employed }
+
+    context "when the availability range exists" do
+      let!(:availability_range) { create(:availability_range, name: "En poste") }
+
+      it { expect(employed).to eq(availability_range) }
+    end
+
+    context "when the availability range does not exist" do
+      it { expect(employed).to be_nil }
+    end
+  end
+
+  describe "#employed?" do
+    let(:availability_range) { create(:availability_range, name:) }
+
+    context "when the availability range is 'En poste'" do
+      let(:name) { "En poste" }
+
+      it { expect(availability_range).to be_employed }
+    end
+
+    context "when the availability range is not 'En poste'" do
+      let(:name) { "A name" }
+
+      it { expect(availability_range).not_to be_employed }
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/availability_range_spec.rb
+++ b/spec/models/availability_range_spec.rb
@@ -18,6 +18,6 @@ end
 #
 # Indexes
 #
-#  index_availability_ranges_on_name      (name)
+#  index_availability_ranges_on_name      (name) UNIQUE
 #  index_availability_ranges_on_position  (position)
 #

--- a/spec/models/department_spec.rb
+++ b/spec/models/department_spec.rb
@@ -49,3 +49,16 @@ RSpec.describe Department do
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: departments
+#
+#  id          :uuid             not null, primary key
+#  code        :string
+#  code_region :string
+#  name        :string
+#  name_region :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/spec/requests/admin/settings/availability_ranges_spec.rb
+++ b/spec/requests/admin/settings/availability_ranges_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Settings::AvailabilityRanges" do
+  it_behaves_like "an admin setting", :availability_range, :name, "a new name"
+  it_behaves_like "a movable admin setting", :availability_range
+end


### PR DESCRIPTION
# Description

Cette PR adresse une sous partie de #1705. On permet la modification des disponibilités en back office.

La disponibilité "En poste" est spéciale, car elle sert à filtrer les candidatures. Elle n'est donc pas éditable.

# Review app

https://erecrutement-cvd-staging-pr1779.osc-fr1.scalingo.io

# Links
Related to #1705

# Screenshots

![image](https://github.com/user-attachments/assets/36093f08-0eda-4960-8111-c9fb8ba85376)
