### PR TITLE
:sparkles: Create my profile page

### DIFF
--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -1,0 +1,23 @@
+class Account::ProfilesController < Account::BaseController
+  before_action :find_profile
+
+  def edit
+  end
+
+  def update
+    @profile.assign_attributes(profile_params)
+    if @profile.save
+      redirect_to edit_account_profiles_path, notice: t(".success")
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def find_profile = @profile = current_user.profile.presence || current_user.build_profile
+
+  def profile_params
+    params.require(:profile).permit(:availability_range_id, :study_level_id)
+  end
+end

--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -6,6 +6,7 @@ class Account::ProfilesController < Account::BaseController
 
   def update
     @profile.profileable.departments = departments
+    @profile.profile_foreign_languages = []
     @profile.assign_attributes(profile_params.merge(profileable: current_user))
     if @profile.save
       redirect_to edit_account_profiles_path, notice: t(".success")
@@ -24,7 +25,8 @@ class Account::ProfilesController < Account::BaseController
       .permit(
         :availability_range_id,
         :study_level_id,
-        profileable_attributes: {department_users_attributes: [:department_id]}
+        profileable_attributes: {department_users_attributes: [:department_id]},
+        profile_foreign_languages_attributes: %i[foreign_language_id foreign_language_level_id]
       )
       .except(:profileable_attributes)
   end

--- a/app/controllers/account/users_controller.rb
+++ b/app/controllers/account/users_controller.rb
@@ -18,7 +18,6 @@ class Account::UsersController < Account::BaseController
 
   def update
     respond_to do |format|
-      @user.department_users = []
       if @user.update(user_params)
         format.html { redirect_to %i[edit account user], notice: t(".success") }
         format.js {}
@@ -135,8 +134,7 @@ class Account::UsersController < Account::BaseController
       :delete_photo,
       :address,
       :postal_code,
-      :city,
-      department_users_attributes: %i[department_id]
+      :city
     )
 
     if filtered_params[:photo].present? || filtered_params[:delete_photo] == "0"

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -52,6 +52,8 @@ class JobApplication < ApplicationRecord
   before_save :compute_notifications_counter
   before_save :cleanup_rejection_reason, unless: proc { |ja| ja.rejected_state? }
 
+  after_create :create_user_profile, if: -> { user.present? }, unless: :user_has_profile?
+
   FINISHED_STATES = %w[rejected phone_meeting_rejected after_meeting_rejected affected].freeze
   REJECTED_STATES = %w[rejected phone_meeting_rejected after_meeting_rejected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met].freeze
@@ -300,6 +302,10 @@ class JobApplication < ApplicationRecord
   def cant_be_accepted_twice = errors.add(:state, :cant_be_accepted_twice)
 
   def has_accepted_other_job_application? = user.job_applications.where(state: "accepted").where.not(id: id).empty?
+
+  def create_user_profile = user.create_profile_from!(profile)
+
+  def user_has_profile? = user.profile.present?
 
   class << self
     def rejected_states

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -12,7 +12,9 @@ class Profile < ApplicationRecord
   belongs_to :experience_level, optional: true
   belongs_to :availability_range, optional: true
   belongs_to :age_range, optional: true
+
   has_many :profile_foreign_languages, dependent: :destroy
+
   accepts_nested_attributes_for :profile_foreign_languages,
     reject_if: proc { |attrs| attrs["foreign_language_id"].blank? || attrs["foreign_language_level_id"].blank? }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,8 @@ class User < ApplicationRecord
   belongs_to :organization
   has_many :omniauth_informations, dependent: :destroy
 
+  has_one :profile, as: :profileable, dependent: :destroy
+
   has_many :bookmarks, dependent: :destroy
   has_many :job_applications, -> { order(created_at: :desc) }, dependent: :nullify, inverse_of: :user
   has_many :job_application_files, through: :job_applications
@@ -124,6 +126,14 @@ class User < ApplicationRecord
 
   def full_address
     [address, postal_code, city].compact.join(" ")
+  end
+
+  def create_profile_from!(existing_profile)
+    return if profile.present?
+
+    self.profile = existing_profile.dup
+    profile.profileable = self
+    save!
   end
 
   private

--- a/app/tasks/maintenance/populate_user_profiles_task.rb
+++ b/app/tasks/maintenance/populate_user_profiles_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class PopulateUserProfilesTask < MaintenanceTasks::Task
+    def collection = User.where.missing(:profile)
+
+    def process(element) = create_user_profile(element)
+
+    delegate :count, to: :collection
+
+    private
+
+    def create_user_profile(user)
+      return if user.job_applications.empty?
+      return if user.job_applications.first.profile.blank?
+
+      user.profile = user.job_applications.first.profile.dup
+      user.profile.profileable = user
+      user.save(validate: false)
+    end
+  end
+end

--- a/app/views/account/_navbar.html.haml
+++ b/app/views/account/_navbar.html.haml
@@ -4,15 +4,22 @@
     #rf-sidemenu-wrapper.rf-sidemenu__wrapper
       .rf-sidemenu__title Mon espace candidat
       %ul.rf-sidemenu__list
-        - klass = controller.controller_name == 'job_applications' ? 'rf-sidemenu__item--active' : nil
-        %li.rf-sidemenu__item{class: klass}
-          = link_to "Mes candidatures", [:account, :job_applications], class: "rf-sidemenu__link"
         - klass = controller.controller_name == 'users' && controller.action_name == 'edit' ? 'rf-sidemenu__item--active' : nil
         %li.rf-sidemenu__item{class: klass}
           = link_to "Mes informations personnelles", [:edit, :account, :user], class: "rf-sidemenu__link"
+
+        - klass = controller.controller_name == 'profiles' ? 'rf-sidemenu__item--active' : nil
+        %li.rf-sidemenu__item{class: klass}
+          = link_to "Mon profil candidat", [:edit, :account, :profiles], class: "rf-sidemenu__link"
+
+        - klass = controller.controller_name == 'job_applications' ? 'rf-sidemenu__item--active' : nil
+        %li.rf-sidemenu__item{class: klass}
+          = link_to "Mes candidatures", [:account, :job_applications], class: "rf-sidemenu__link"
+
         - klass = controller.controller_name == 'users' && controller.action_name == 'show' ? 'rf-sidemenu__item--active' : nil
         %li.rf-sidemenu__item{class: klass}
           = link_to "Mon compte", [:account, :user], class: "rf-sidemenu__link"
+
         - UserMenuLink.all.each do |menu_link|
           %li.rf-sidemenu__item
             = link_to menu_link.name, menu_link.url, class: "rf-sidemenu__link", target: "_blank"

--- a/app/views/account/profiles/edit.html.haml
+++ b/app/views/account/profiles/edit.html.haml
@@ -1,0 +1,15 @@
+.rf-container
+  .rf-grid-row
+    .rf-col-12
+      %h2.rf-h3= t('.title')
+      .rf-mb-5w.rf-pb-5w
+        = simple_form_for(@profile, url: [:account, :profiles], method: :patch) do |f|
+          = f.error_notification
+
+          .form-inputs
+            = f.association :availability_range, input_html: { class: "rf-select" }
+
+            = f.association :study_level, required: true, input_html: { class: "rf-select" }
+
+          .rf-input-group.rf-grid-row.justify-content-end.rf-mt-3w
+            = f.button :submit, t('buttons.save'), class: 'rf-btn'

--- a/app/views/account/profiles/edit.html.haml
+++ b/app/views/account/profiles/edit.html.haml
@@ -11,5 +11,8 @@
 
             = f.association :study_level, required: true, input_html: { class: "rf-select" }
 
+            = f.simple_fields_for @profile.profileable do |user_form|
+              = render partial: '/department_users/form', locals: { user_form: user_form, kind: :profile }
+
           .rf-input-group.rf-grid-row.justify-content-end.rf-mt-3w
             = f.button :submit, t('buttons.save'), class: 'rf-btn'

--- a/app/views/account/profiles/edit.html.haml
+++ b/app/views/account/profiles/edit.html.haml
@@ -14,5 +14,7 @@
             = f.simple_fields_for @profile.profileable do |user_form|
               = render partial: '/department_users/form', locals: { user_form: user_form, kind: :profile }
 
+            = render partial: '/profile_foreign_languages/form', locals: { profile_form: f, name_prefix: "profile" }
+
           .rf-input-group.rf-grid-row.justify-content-end.rf-mt-3w
             = f.button :submit, t('buttons.save'), class: 'rf-btn'

--- a/app/views/account/users/edit.html.haml
+++ b/app/views/account/users/edit.html.haml
@@ -25,7 +25,6 @@
               .rf-col-12.rf-col-md-7.rf-mt-3w
                 = f.input :city, input_html: { data: { autocomplete_address_target: :city } }, required: false
 
-            = render partial: '/department_users/form', locals: { user_form: f, kind: :user }
             = f.input :photo
             - if @user.photo.present?
               = f.input :delete_photo, as: :boolean

--- a/app/views/department_users/_form.html.haml
+++ b/app/views/department_users/_form.html.haml
@@ -1,4 +1,4 @@
-- form = kind == :job_application ? "job_application[user_attributes]" : "user"
+- form = kind == :job_application ? "job_application[user_attributes]" : "profile[profileable_attributes]"
 %div{ data: { controller: "duplicator"}}
   .rf-grid-row.fr-grid-row--center.d-none{ data: { duplicator: { target: :duplicated }}}
     .rf-col-11

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -24,7 +24,7 @@
       = profile_form.association :study_level, required: true, input_html: { class: "rf-select" }
       = profile_form.association :experience_level, input_html: { class: "rf-select" }
       = profile_form.input :has_corporate_experience, label: "Expérience antérieure #{current_organization.operator_name}"
-      = render partial: '/profile_foreign_languages/form', locals: { profile_form: profile_form }
+      = render partial: '/profile_foreign_languages/form', locals: { profile_form: profile_form, name_prefix: "job_application[profile_attributes]" }
 
     %h2.rf-h3= t('.documents')
     - job_application_files = @job_application.job_application_files.to_a

--- a/app/views/profile_foreign_languages/_form.html.haml
+++ b/app/views/profile_foreign_languages/_form.html.haml
@@ -3,11 +3,11 @@
     .rf-col-11
       .rf-grid-row.rf-grid-row--gutters
         .rf-col-6
-          - name = "job_application[profile_attributes][profile_foreign_languages_attributes][index][foreign_language_id]"
+          - name = "#{name_prefix}[profile_foreign_languages_attributes][index][foreign_language_id]"
           = label_tag name, t("simple_form.labels.defaults.foreign_language")
           = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name"), class: "rf-select", include_blank: true
         .rf-col-6
-          - name = "job_application[profile_attributes][profile_foreign_languages_attributes][index][foreign_language_level_id]"
+          - name = "#{name_prefix}[profile_foreign_languages_attributes][index][foreign_language_level_id]"
           = label_tag name, t("simple_form.labels.defaults.foreign_language_level")
           = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name"), class: "rf-select", include_blank: true
     .rf-col-1.text-center.rf-mt-4w
@@ -18,11 +18,11 @@
         .rf-col-11
           .rf-grid-row.rf-grid-row--gutters
             .rf-col-6
-              - name = "job_application[profile_attributes][profile_foreign_languages_attributes][#{index}][foreign_language_id]"
+              - name = "#{name_prefix}[profile_foreign_languages_attributes][#{index}][foreign_language_id]"
               = label_tag name, t("simple_form.labels.defaults.foreign_language")
               = select_tag name, options_from_collection_for_select(ForeignLanguage.all, "id", "name", selected: profile_foreign_language.foreign_language_id), class: "rf-select", include_blank: true
             .rf-col-6
-              - name = "job_application[profile_attributes][profile_foreign_languages_attributes][#{index}][foreign_language_level_id]"
+              - name = "#{name_prefix}[profile_foreign_languages_attributes][#{index}][foreign_language_level_id]"
               = label_tag name, t("simple_form.labels.defaults.foreign_language_level")
               = select_tag name, options_from_collection_for_select(ForeignLanguageLevel.all, "id", "name", selected: profile_foreign_language.foreign_language_level_id), class: "rf-select", include_blank: true
         .rf-col-1.text-center.rf-mt-4w

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -234,6 +234,11 @@ fr:
         title: "Envoyer un courriel"
         add_attachment: "Ajouter une pièce jointe"
       index:
+    profiles:
+      edit:
+        title: "Mon profil candidat"
+      update:
+        success: "Profil mis à jour !"
     users:
       link_france_connect:
         title: Certifier mon compte FranceConnect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,12 @@ Rails.application.routes.draw do
 
   authenticate :user do
     namespace "account", path: "espace-candidat" do
+      resource :profiles, path: "mon-profil", only: [] do
+        collection do
+          get :edit
+          patch :update
+        end
+      end
       resources :job_applications, path: "mes-candidatures" do
         member do
           get :job_offer, path: "offre"

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -5,10 +5,7 @@ FactoryBot.define do
     job_offer
     organization { Organization.first }
     user
-
-    before(:create) do |job_application|
-      job_application.profile = create(:profile, profileable: job_application)
-    end
+    profile { association :profile, profileable: @instance }
   end
 
   trait :with_job_application_file do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -182,6 +182,24 @@ RSpec.describe JobApplication do
       end
     end
   end
+
+  describe "after_create callbacks" do
+    describe "#create_user_profile" do
+      subject(:create) { job_application.save! }
+
+      let!(:job_application) { build(:job_application, employer: build(:employer)) }
+
+      context "when the user is missing" do
+        before { job_application.user = nil }
+
+        it { expect { create }.to change(Profile, :count).by(1) } # the one of the job application only
+      end
+
+      context "when the user is present and has no profile" do
+        it { expect { create }.to change(Profile, :count).by(2) } # the one of the job application only and the one of the user
+      end
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/requests/account/profiles_spec.rb
+++ b/spec/requests/account/profiles_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Account::Profiles" do
+  let(:user) { create(:confirmed_user) }
+
+  before { sign_in user }
+
+  describe "GET /espace-candidat/mon-profile/edit" do
+    subject(:edit_request) { get edit_account_profiles_path }
+
+    before { edit_request }
+
+    it { expect(response).to be_successful }
+
+    it { expect(response).to render_template(:edit) }
+  end
+
+  describe "PATCH /espace-candidat/mon-profile" do
+    subject(:update_request) { patch account_profiles_path, params: params }
+
+    let(:params) { {profile: {availability_range_id: availability_range_id, study_level_id: study_level_id}} }
+    let(:availability_range_id) { AvailabilityRange.first.id }
+    let(:study_level_id) { create(:study_level).id }
+
+    context "when the user has a profile" do
+      before { user.update!(profile: create(:profile, profileable: user)) }
+
+      it { expect { update_request }.not_to change { user.reload.profile } }
+
+      describe "response" do
+        before { update_request }
+
+        it { expect(response).to redirect_to(edit_account_profiles_path) }
+      end
+    end
+
+    context "when the user doesn't have a profile" do
+      it { expect { update_request }.to change { user.reload.profile }.from(nil) }
+
+      describe "response" do
+        before { update_request }
+
+        it { expect(response).to redirect_to(edit_account_profiles_path) }
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/populate_user_profiles_task_spec.rb
+++ b/spec/tasks/maintenance/populate_user_profiles_task_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe PopulateUserProfilesTask do
+    describe "#process" do
+      subject(:process) { described_class.process(user) }
+      let(:user) { create(:user) }
+
+      before do
+        create(:job_application, user:)
+        user.update!(profile: nil)
+      end
+
+      it { expect { process }.to change { user.reload.profile }.from(nil).to(an_instance_of(Profile)) }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Dans cette PR on crée la page "Mon profil candidat". 

La notion de "profil" existait déjà dans l'application, au travers du modèle `Profile`, précédemment rattaché uniquement au modèle `JobApplication` (qui représente la candidature). Désormais, on rattache également le profil au modèle `User`.

Ainsi, lorsque la personne candidate pour la première fois, on crée également son profil, en copiant celui du `JobApplication` (c'est-à-dire de la candidature).

On ajoute en outre une tâche de maintenance qui va remplir les profils de tous les users en base, en copiant le profil de leur dernière candidature.

Ensuite, une fois qu'on dispose du profil de user, on peut ajouter la page "Mon profil candidat", qui permet à la personne d'éditer ses informations : 
- dates de dispo
- niveau d'études
- souhaits géographiques

RAF : 
- domaine pro + expérience
- langues étrangères + niveaux
- documents

# Review app

https://erecrutement-cvd-staging-pr<PR-NUMBER>.osc-fr1.scalingo.io

# :warning: 

- [ ] jouer la tâche de maintenance sur les instances de staging
- [ ] jouer la tâche de maintenance sur les instances de prod

# Links

Closes #<ISSUE-NUMBER>

# Screenshots
