### PR TITLE
:bug: Don't crash when category is blank

### DIFF
--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -251,6 +251,8 @@ class JobOffer < ApplicationRecord
   end
 
   def update_category_counter
+    return if category.blank?
+
     category.self_and_ancestors.reverse.each(&:compute_published_job_offers_count!)
   end
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -453,6 +453,8 @@ fr:
         success: "Annonce désarchivée !"
       update_and_archive:
         success: "Annonce mise à jour et archivée !"
+      update_and_unarchive:
+        success: "Annonce mise à jour et désarchivée !"
       suspend:
         success: "Annonce mise en pause !"
       update_and_suspend:


### PR DESCRIPTION
# Description

Depuis #1771, la catégorie d'une offre d'emploi est optionnelle. Cela produit un crash lorsqu'on veut mettre à jour le compteur d'offres d'emploi de la catégorie, par exemple lorsqu'une offre d'emploi est archivée.

On règle le problème ici.

# Review app

https://erecrutement-cvd-staging-pr1786.osc-fr1.scalingo.io

# Links

Closes #1784
