### PR TITLE
Use Profile's gender instead of User's one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore ASDF config
+.tool-versions
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/controllers/account/users_controller.rb
+++ b/app/controllers/account/users_controller.rb
@@ -136,7 +136,8 @@ class Account::UsersController < Account::BaseController
       :address,
       :postal_code,
       :city,
-      department_users_attributes: %i[department_id]
+      department_users_attributes: %i[department_id],
+      profile_attributes: %i[id gender]
     )
 
     if filtered_params[:photo].present? || filtered_params[:delete_photo] == "0"

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,3 @@
+module ProfilesHelper
+  def gender_options_for_select = enum_options_for_select(Profile, :gender)
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 # Candidate to job offer
 class User < ApplicationRecord
+  self.ignored_columns += %w[gender] # Deprecated on 2024-09-03
+
   PASSWORD_REGEX = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[\\\/<>{}()#¤:;,.?!•·|"'`´~@£¨µ§²$€%^&*+=_-]).{12,70}$/
 
   def self.omniauth_providers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,9 +51,6 @@ class User < ApplicationRecord
 
   mount_uploader :photo, PhotoUploader, mount_on: :photo_file_name
 
-  # TODO: SEB remove gender from users
-  enum gender: {female: 1, male: 2, other: 3}
-
   validates :photo, file_size: {less_than: 1.megabytes}
   validates :first_name, :last_name, presence: true
   validates_plausible_phone :phone

--- a/app/views/account/users/edit.html.haml
+++ b/app/views/account/users/edit.html.haml
@@ -8,7 +8,8 @@
             .autocomplete{ data: { autocomplete_address_target: :query } }
           = f.error_notification
           .form-inputs
-            = f.input :gender, collection: enum_options_for_select(User, :gender), input_html: { class: "rf-select" }, label_required: true, include_blank: false
+            = f.simple_fields_for :profile do |profile_form|
+              = profile_form.input :gender, collection: gender_options_for_select, input_html: { class: "rf-select" }, required: true
             = f.input :first_name
             = f.input :last_name
             = f.input :phone

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -7,7 +7,7 @@
     %h2.rf-h3= t('.general_informations')
     = f.simple_fields_for :user do |user_form|
       = user_form.simple_fields_for :profile do |profile_form|
-        = profile_form.input :gender, collection: enum_options_for_select(Profile, :gender), input_html: { class: "rf-select" }, required: true, selected: current_user&.gender
+        = profile_form.input :gender, collection: gender_options_for_select, input_html: { class: "rf-select" }, required: true
       = user_form.input :first_name, readonly: user_signed_in?
       = user_form.input :last_name, readonly: user_signed_in?
       = user_form.input :phone, required: true


### PR DESCRIPTION
# Description

Dans cette PR, on règle les incohérences constatées sur le champ "Genre" : 
- sur la page "Mes informations personnelles", c'était celui du user
- sur le formulaire de candidature, c'était celui du profil
- sur la page de candidature en back office, c'était celui du profil

Désormais l'attribut `gender` de `User` est déprécié, et on utilise systématiquement celui du `Profile`.

# Review app

https://erecrutement-cvd-staging-pr1802.osc-fr1.scalingo.io

# Links

Closes #1800
