### PR TITLE
Add the resume to My profile page

### DIFF
--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -26,6 +26,7 @@ class Account::ProfilesController < Account::BaseController
       :study_level_id,
       :experience_level_id,
       :has_corporate_experience,
+      :resume,
       profile_foreign_languages_attributes: %i[foreign_language_id foreign_language_level_id],
       category_experience_levels_attributes: %i[category_id experience_level_id],
       department_profiles_attributes: %i[department_id]

--- a/app/controllers/account/resumes_controller.rb
+++ b/app/controllers/account/resumes_controller.rb
@@ -1,0 +1,16 @@
+class Account::ResumesController < Account::BaseController
+  def show
+    send_data(
+      profile.resume.read,
+      filename: profile.resume_file_name,
+      type: "application/pdf",
+      disposition: "inline"
+    )
+  ensure
+    response.stream.close if response.stream.respond_to?(:close)
+  end
+
+  private
+
+  def profile = @profile ||= current_user.profile.presence
+end

--- a/app/controllers/admin/resumes_controller.rb
+++ b/app/controllers/admin/resumes_controller.rb
@@ -4,7 +4,7 @@ class Admin::ResumesController < Admin::BaseController
   def show
     send_data(
       user.profile.resume.read,
-      filename: "resume.pdf",
+      filename: user.profile.resume_file_name,
       type: "application/pdf",
       disposition: "inline"
     )

--- a/app/controllers/admin/resumes_controller.rb
+++ b/app/controllers/admin/resumes_controller.rb
@@ -1,0 +1,18 @@
+class Admin::ResumesController < Admin::BaseController
+  skip_load_and_authorize_resource
+
+  def show
+    send_data(
+      user.profile.resume.read,
+      filename: "resume.pdf",
+      type: "application/pdf",
+      disposition: "inline"
+    )
+  ensure
+    response.stream.close if response.stream.respond_to?(:close)
+  end
+
+  private
+
+  def user = @user ||= User.find(params[:user_id])
+end

--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -63,6 +63,8 @@ class JobOffersController < ApplicationController
     @job_application.user.organization = current_organization unless user_signed_in?
 
     if user_signed_in?
+      @job_application.user.profile.profile_foreign_languages = []
+      @job_application.user.profile.category_experience_levels = []
       if job_application_params[:user_attributes].present?
         @job_application.user.assign_attributes(
           job_application_params[:user_attributes].except(:profile_attributes)

--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -154,6 +154,7 @@ class JobOffersController < ApplicationController
           :availability_range_id,
           :experience_level_id,
           :study_level_id,
+          :resume,
           profile_foreign_languages_attributes: [
             :foreign_language_id,
             :foreign_language_level_id

--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -59,15 +59,18 @@ class JobOffersController < ApplicationController
     @job_application = JobApplication.new(job_application_params)
     @job_application.job_offer = @job_offer
     @job_application.organization = @job_offer.organization
+    @job_application.user = current_user if user_signed_in?
+    @job_application.user.organization = current_organization unless user_signed_in?
 
     if user_signed_in?
-      @job_application.user = current_user
       if job_application_params[:user_attributes].present?
-        @job_application.user.assign_attributes(job_application_params[:user_attributes])
+        @job_application.user.assign_attributes(
+          job_application_params[:user_attributes].except(:profile_attributes)
+        )
       end
+      @job_application.user.profile.assign_attributes(job_application_params[:user_attributes][:profile_attributes])
+      @job_application.user.profile.departments = departments
     end
-
-    @job_application.user.organization = current_organization
 
     respond_to do |format|
       if @job_application.save(context: :profile)
@@ -130,29 +133,44 @@ class JobOffersController < ApplicationController
   end
 
   def job_application_params
-    permitted_params = %i[category_id]
-
-    base_user_attributes = %i[
-      photo email password password_confirmation terms_of_service certify_majority
-      receive_job_offer_mails
-    ]
-    profile_attributes = %i[
-      gender has_corporate_experience age_range_id availability_range_id experience_level_id study_level_id
-    ]
-    profile_attributes << {
-      profile_foreign_languages_attributes: %i[foreign_language_id foreign_language_level_id],
-      category_experience_levels_attributes: %i[category_id experience_level_id],
-      department_profiles_attributes: %i[department_id]
-    }
-    user_attributes = %i[first_name last_name phone website_url]
-    user_attributes << {profile_attributes: profile_attributes}
-    user_attributes += base_user_attributes unless user_signed_in?
-    permitted_params << {user_attributes: user_attributes}
-
-    job_application_files_attributes = %i[content job_application_file_type_id job_application_file_existing_id]
-    permitted_params << {job_application_files_attributes: job_application_files_attributes}
-
-    params.require(:job_application).permit(permitted_params)
+    params.require(:job_application).permit(
+      :category_id,
+      user_attributes: [
+        :first_name,
+        :last_name,
+        :phone,
+        :website_url,
+        :photo,
+        :email,
+        :password,
+        :password_confirmation,
+        :terms_of_service,
+        :certify_majority,
+        :receive_job_offer_mails,
+        profile_attributes: [
+          :gender,
+          :has_corporate_experience,
+          :age_range_id,
+          :availability_range_id,
+          :experience_level_id,
+          :study_level_id,
+          profile_foreign_languages_attributes: [
+            :foreign_language_id,
+            :foreign_language_level_id
+          ],
+          category_experience_levels_attributes: [
+            :category_id,
+            :experience_level_id
+          ],
+          department_profiles_attributes: %i[department_id]
+        ]
+      ],
+      job_application_files_attributes: [
+        :content,
+        :job_application_file_type_id,
+        :job_application_file_existing_id
+      ]
+    )
   end
 
   def search_params

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -27,6 +27,9 @@ class Profile < ApplicationRecord
     reject_if: proc { |attrs| attrs["category_id"].blank? || attrs["experience_level_id"].blank? }
   accepts_nested_attributes_for :department_profiles, reject_if: :all_blank
 
+  mount_uploader :resume, DocumentUploader, mount_on: :resume_file_name
+  validates :resume, file_size: {less_than: 2.megabytes}, if: -> { resume.present? }
+
   validate :at_least_one_category_experience_level, on: :profile
 
   def at_least_one_category_experience_level
@@ -60,6 +63,7 @@ end
 #  has_corporate_experience :boolean
 #  is_currently_employed    :boolean
 #  profileable_type         :string
+#  resume_file_name         :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  age_range_id             :uuid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,7 +162,6 @@ end
 #  encrypted_password               :string           default(""), not null
 #  failed_attempts                  :integer          default(0), not null
 #  first_name                       :string
-#  gender                           :integer          default("other")
 #  job_applications_count           :integer          default(0), not null
 #  last_name                        :string
 #  last_sign_in_at                  :datetime

--- a/app/tasks/maintenance/populate_resumes_task.rb
+++ b/app/tasks/maintenance/populate_resumes_task.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class PopulateResumesTask < MaintenanceTasks::Task
+    include Rails.application.routes.url_helpers
+
+    def collection = Profile.where(profileable_type: "User", resume_file_name: [nil, ""])
+
+    def process(profile)
+      job_application = profile.profileable.last_job_application
+      return if job_application.blank?
+
+      job_application_file_type = JobApplicationFileType.find_by(name: "CV")
+      return if job_application_file_type.blank?
+
+      job_application_file = job_application.job_application_files.find_by(job_application_file_type:)
+      return if job_application_file.blank?
+
+      update_resume(profile, job_application_file)
+    end
+
+    delegate :count, to: :collection
+
+    private
+
+    def update_resume(profile, job_application_file)
+      file = Tempfile.new([job_application_file.content_file_name.gsub(".pdf", ""), ".pdf"])
+      file.binmode
+      file.write(job_application_file.document_content.read)
+      file.rewind
+
+      profile.update!(resume: file)
+
+      file.close
+      file.unlink
+    end
+  end
+end

--- a/app/tasks/maintenance/remove_resume_job_application_file_type_task.rb
+++ b/app/tasks/maintenance/remove_resume_job_application_file_type_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class RemoveResumeJobApplicationFileTypeTask < MaintenanceTasks::Task
+    def collection = JobApplicationFileType.unscoped.where(name: "CV")
+
+    def process(job_application_file_type) = job_application_file_type.destroy!
+
+    delegate :count, to: :collection
+  end
+end

--- a/app/views/account/profiles/edit.html.haml
+++ b/app/views/account/profiles/edit.html.haml
@@ -24,5 +24,13 @@
 
             = render partial: '/department_profiles/form', locals: { form: f, name_prefix: :profile, department_profiles: @profile.department_profiles }
 
+            .d-flex.align-items-end
+              %div
+                - label = @profile.resume.blank? ? t('.resume') : t('.resume_html')
+                = f.input :resume, label:, as: :file, required: @profile.resume.blank?
+              %div.rf-ml-3w
+                - if @profile.resume.present?
+                  = link_to @profile.resume_file_name, account_profiles_resume_path, target: '_blank'
+
           .rf-input-group.rf-grid-row.justify-content-end.rf-mt-3w
             = f.button :submit, t('buttons.save'), class: 'rf-btn'

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -20,6 +20,7 @@
 - job_application_files.each do |job_application_file|
   - if job_application_file.document_content.present?
     - file_type = job_application_file.job_application_file_type
+    - next if file_type.name == "CV"
     - pdf_url = url_for([:admin, job_application, job_application_file, {format: :pdf}])
 
     .card

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -2,15 +2,36 @@
 - target_file_type = JobApplicationFileType.where(by_default: true, from_state: target_state, kind: :applicant_provided)
 - job_application_files = job_application.job_application_files.where(job_application_file_type: target_file_type).joins(:job_application_file_type).order('job_application_file_types.position')
 - job_application_files = job_application_files.limit(1) if defined?(only_first) && only_first
+
+- if user.profile.resume.present?
+  .card
+    .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
+      %div
+        = fa_icon('file-lines', class: 'text-secondary')
+        CV
+      %div
+        = link_to admin_user_resume_path(user), target: "_blank" do
+          = fa_icon('download', class: 'text-secondary')
+
+    .card-subheader.bg-secondary
+    %div
+      %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
+
 - job_application_files.each do |job_application_file|
   - if job_application_file.document_content.present?
     - file_type = job_application_file.job_application_file_type
+    - pdf_url = url_for([:admin, job_application, job_application_file, {format: :pdf}])
+
     .card
-      .card-header.with-subheader.bg-white.font-weight-bold.text-secondary
-        = fa_icon('file-lines', class: 'text-secondary')
-        = file_type.name
+      .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
+        %div
+          = fa_icon('file-lines', class: 'text-secondary')
+          = file_type.name
+        %div
+          = link_to pdf_url, target: "_blank" do
+            = fa_icon('download', class: 'text-secondary')
+
       .card-subheader.bg-secondary
       %div
-        - pdf_url = url_for([:admin, job_application, job_application_file, {format: :pdf}])
         %object{data: pdf_url, type: "application/pdf", width: "100%", height: "500px"}
-          = link_to t("buttons.download") + file_type.name, pdf_url
+

--- a/app/views/admin/job_applications/show.html.haml
+++ b/app/views/admin/job_applications/show.html.haml
@@ -20,7 +20,7 @@
               = render partial: 'user_job_applications', locals: {job_applications: @other_job_applications}
         - if tab_active == :cvlm
           .tab-pane.active.show{role: :tabpanel, aria: {labelledby: :cvlm}}
-            = render template: '/admin/job_applications/cvlm', locals: {job_application: @job_application}
+            = render template: '/admin/job_applications/cvlm', locals: {user: user, job_application: @job_application}
         - if can?(:read, Email) && tab_active == :emails
           .tab-pane.active.show{role: :tabpanel, aria: {labelledby: :emails}}
             = render template: '/admin/job_applications/emails', locals: {job_application: @job_application}

--- a/app/views/admin/users/_user.html.haml
+++ b/app/views/admin/users/_user.html.haml
@@ -14,7 +14,10 @@
               .d-flex
                 = image_user_tag user.photo, width: 32, class: 'mr-2'
                 = user.full_name
-                - if last_job_application_resume_url
+                - if user.profile.resume.present?
+                  %div{data: {controller: "rich-tooltip", bs_custom_class: "tooltip-rich", bs_placement: "right"}, title: "<object data='#{admin_user_resume_path(user)}' style='margin-left: 10px; bottom: 0;' class='position-fixed' height='600px' width='800px' type='application/pdf'></object>"}
+                    = fa_icon "file-lines", class: "ml-2"
+                - elsif last_job_application_resume_url
                   %div{data: {controller: "rich-tooltip", bs_custom_class: "tooltip-rich", bs_placement: "right"}, title: "<object data='#{last_job_application_resume_url}' style='margin-left: 10px; bottom: 0;' class='position-fixed' height='600px' width='800px' type='application/pdf'></object>"}
                     = fa_icon "file-lines", class: "ml-2"
             .col-12.category-experience-levels

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -11,7 +11,7 @@
         .border-right{class: job_application_modal_section_classes}
           .tab-content
             .tab-pane.fade.active.show
-              = render template: '/admin/job_applications/cvlm', locals: {job_application: @user.last_job_application, only_first: true}
+              = render template: '/admin/job_applications/cvlm', locals: {user: @user, job_application: @user.last_job_application, only_first: true}
     .col-12.col-md-4{class: job_application_modal_section_classes}
       - unless @user.new_record?
         = render partial: 'actions', locals: { user: @user }

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -35,7 +35,16 @@
 
         = render partial: '/profile_foreign_languages/form', locals: { profile_form: profile_form, name_prefix: "job_application[user_attributes][profile_attributes]" }
 
-    %h2.rf-h3= t('.documents')
+        %h2.rf-h3= t('.documents')
+
+        .d-flex.align-items-end.rf-mb-3w
+          %div
+            - label = profile_form.object.resume.blank? ? t('.resume') : t('.resume_html')
+            = profile_form.input :resume, label:, as: :file, required: profile_form.object.resume.blank?
+          %div.rf-ml-3w
+            - if profile_form.object.resume.present?
+              = link_to profile_form.object.resume_file_name, account_profiles_resume_path, target: '_blank'
+
     - job_application_files = @job_application.job_application_files.to_a
     - current_state = JobApplication.states[@job_application.state]
     - if @job_offer.spontaneous

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -115,6 +115,8 @@ fr:
       documents: "Vos documents"
       your_internet_presence: "Votre présence sur internet"
       your_account_creation: "Votre création de compte"
+      resume: "CV"
+      resume_html: "CV <abbr title='obligatoire'>*</abbr>"
   job_offers:
     no_bookmarks:
       title: Vous n'avez pas encore d'offres favorites

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -237,6 +237,8 @@ fr:
     profiles:
       edit:
         title: "Mon profil candidat"
+        resume: "CV (PDF uniquement, max 2Mo)"
+        resume_html: "CV (PDF uniquement, max 2Mo) <abbr title='obligatoire'>*</abbr>"
       update:
         success: "Profil mis à jour !"
     users:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,7 @@ Rails.application.routes.draw do
   authenticate :user do
     namespace "account", path: "espace-candidat" do
       resource :profiles, path: "mon-profil", only: [] do
+        resource :resume, only: :show
         collection do
           get :edit
           patch :update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
       resources :preferred_users
     end
     resources :users, path: "candidats", except: %i[create] do
+      resource :resume, only: %i[show]
       collection do
         post :multi_select
       end

--- a/db/migrate/20241002131847_add_resume_file_name_to_profiles.rb
+++ b/db/migrate/20241002131847_add_resume_file_name_to_profiles.rb
@@ -1,0 +1,3 @@
+class AddResumeFileNameToProfiles < ActiveRecord::Migration[7.1]
+  def change = add_column :profiles, :resume_file_name, :string
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_21_073757) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_02_131847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -723,6 +723,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_21_073757) do
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "availability_range_id"
     t.uuid "age_range_id"
+    t.string "resume_file_name"
     t.index ["age_range_id"], name: "index_profiles_on_age_range_id"
     t.index ["availability_range_id"], name: "index_profiles_on_availability_range_id"
     t.index ["experience_level_id"], name: "index_profiles_on_experience_level_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -577,7 +577,8 @@ user.build_profile(
   category_experience_levels_attributes: {
     "0" => { category_id: Category.first.id, experience_level_id: ExperienceLevel.all.sample.id },
     "1" => { category_id: Category.last.id, experience_level_id: ExperienceLevel.all.sample.id }
-  }
+  },
+  resume: file
 )
 user.skip_confirmation_notification!
 user.save!
@@ -648,7 +649,8 @@ user_candidate_of_all.build_profile(
   category_experience_levels_attributes: {
     "0" => { category_id: Category.first.id, experience_level_id: ExperienceLevel.all.sample.id },
     "1" => { category_id: Category.last.id, experience_level_id: ExperienceLevel.all.sample.id }
-  }
+  },
+  resume: file
 )
 user_candidate_of_all.skip_confirmation_notification!
 user_candidate_of_all.save!
@@ -694,7 +696,8 @@ JobOffer.where.not(contract_duration_id: nil).where.not(id: [job_offer4.id, job_
       category_experience_levels_attributes: {
         "0" => { category_id: Category.first.id, experience_level_id: ExperienceLevel.all.sample.id },
         "1" => { category_id: Category.last.id, experience_level_id: ExperienceLevel.all.sample.id }
-      }
+      },
+      resume: file
     )
     user.skip_confirmation_notification!
     user.save!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -330,12 +330,6 @@ AvailabilityRange.create!(name: "Disponible sous 1 mois")
 AvailabilityRange.create!(name: "Disponible sous 2 mois")
 AvailabilityRange.create!(name: "Disponible sous 3 mois ou plus")
 
-resume = JobApplicationFileType.create!(
-  name: "CV",
-  kind: :applicant_provided,
-  from_state: :initial,
-  by_default: true
-)
 cover_letter = JobApplicationFileType.create!(
   name: "Lettre de Motivation",
   kind: :applicant_provided,
@@ -589,7 +583,6 @@ job_application = JobApplication.new { |ja|
   ja.job_offer = job_offer
   ja.user = user
 }
-job_application.job_application_files.build(content: file, job_application_file_type: resume)
 job_application.job_application_files.build(content: file, job_application_file_type: cover_letter)
 job_application.save!
 
@@ -609,7 +602,6 @@ job_application2 = JobApplication.new { |ja|
   ja.job_offer = job_offer2
   ja.user = user
 }
-job_application2.job_application_files.build(content: file, job_application_file_type: resume)
 job_application2.job_application_files.build(content: file, job_application_file_type: cover_letter)
 job_application2.save!
 
@@ -710,7 +702,6 @@ JobOffer.where.not(contract_duration_id: nil).where.not(id: [job_offer4.id, job_
       ja.created_at = 1.upto(6).map { |x| x.days.ago }
       ja.experiences_fit_job_offer = boolean_choices.sample
     }
-    job_application.job_application_files.build(content: file, job_application_file_type: resume)
     job_application.job_application_files.build(content: file, job_application_file_type: cover_letter)
     job_application.job_offer.initial!
     job_application.save!
@@ -740,7 +731,6 @@ JobOffer.where.not(contract_duration_id: nil).where.not(id: [job_offer4.id, job_
     ja.job_offer = job_offer
     ja.user = user_candidate_of_all
   }
-  job_application.job_application_files.build(content: file, job_application_file_type: resume)
   job_application.job_application_files.build(content: file, job_application_file_type: cover_letter)
   job_application.job_offer.initial!
   job_application.save!

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -10,6 +10,15 @@ FactoryBot.define do
     study_level { StudyLevel.all.sample }
     experience_level { ExperienceLevel.all.sample }
     has_corporate_experience { false }
+
+    trait :with_resume do
+      resume do
+        Rack::Test::UploadedFile.new(
+          Rails.root.join("spec/fixtures/files/document.pdf"),
+          "application/pdf"
+        )
+      end
+    end
   end
 end
 
@@ -22,6 +31,7 @@ end
 #  has_corporate_experience :boolean
 #  is_currently_employed    :boolean
 #  profileable_type         :string
+#  resume_file_name         :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  age_range_id             :uuid

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,7 +47,6 @@ end
 #  encrypted_password               :string           default(""), not null
 #  failed_attempts                  :integer          default(0), not null
 #  first_name                       :string
-#  gender                           :integer          default("other")
 #  job_applications_count           :integer          default(0), not null
 #  last_name                        :string
 #  last_sign_in_at                  :datetime

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -4,11 +4,12 @@ require "rails_helper"
 
 RSpec.describe Profile do
   describe "validations" do
-    let(:profile) { build(:profile) }
+    it { expect(build(:profile)).to be_valid }
 
-    it { expect(profile).to be_valid }
+    it { expect(build(:profile, :with_resume)).to be_valid }
 
     it "has correct gender" do
+      profile = build(:profile)
       profile.gender = 2
       expect(profile.gender).to eq("male")
     end
@@ -80,6 +81,7 @@ end
 #  has_corporate_experience :boolean
 #  is_currently_employed    :boolean
 #  profileable_type         :string
+#  resume_file_name         :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  age_range_id             :uuid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -229,7 +229,6 @@ end
 #  encrypted_password               :string           default(""), not null
 #  failed_attempts                  :integer          default(0), not null
 #  first_name                       :string
-#  gender                           :integer          default("other")
 #  job_applications_count           :integer          default(0), not null
 #  last_name                        :string
 #  last_sign_in_at                  :datetime

--- a/spec/requests/account/profiles_spec.rb
+++ b/spec/requests/account/profiles_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Account::Profiles" do
           study_level_id:,
           experience_level_id:,
           has_corporate_experience: true,
+          resume: fixture_file_upload("document.pdf", "application/pdf"),
           category_experience_levels_attributes: {
             "0": {
               category_id:,
@@ -61,6 +62,8 @@ RSpec.describe "Account::Profiles" do
       it { expect(profile.category_experience_levels.first.category_id).to eq(category_id) }
 
       it { expect(profile.category_experience_levels.first.experience_level_id).to eq(experience_level_id) }
+
+      it { expect(profile.resume).to be_present }
     end
 
     describe "response" do

--- a/spec/requests/account/resumes_spec.rb
+++ b/spec/requests/account/resumes_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Account::Resumes" do
+  let(:user) { create(:confirmed_user) }
+
+  before { sign_in user }
+
+  describe "GET /espace-candidat/mon-profil/resume" do
+    subject(:show_request) { get account_profiles_resume_path }
+
+    before { show_request }
+
+    it { expect(response).to be_successful }
+
+    it { expect(response.headers["Content-Type"]).to eq "application/pdf" }
+  end
+end

--- a/spec/requests/admin/resumes_spec.rb
+++ b/spec/requests/admin/resumes_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Resumes" do
+  before { sign_in create(:administrator) }
+
+  describe "GET /admin/users/:user_id/resume" do
+    subject(:show_request) { get admin_user_resume_path(user) }
+
+    let(:user) { create(:user, profile: create(:profile, :with_resume)) }
+
+    before { show_request }
+
+    it { expect(response).to be_successful }
+
+    it { expect(response.headers["Content-Type"]).to eq "application/pdf" }
+  end
+end

--- a/spec/requests/job_offers_spec.rb
+++ b/spec/requests/job_offers_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe "JobOffers" do
                 availability_range_id: AvailabilityRange.first.id,
                 experience_level_id: ExperienceLevel.first.id,
                 study_level_id: StudyLevel.first.id,
+                resume: fixture_file_upload("document.pdf", "application/pdf"),
                 profile_foreign_languages_attributes: {
                   "0" => {
                     foreign_language_id: ForeignLanguage.first.id,
@@ -228,6 +229,8 @@ RSpec.describe "JobOffers" do
         it { expect(profile.departments.count).to eq(2) }
 
         it { expect(profile.departments.pluck(:id)).to match([Department.first.id, Department.last.id]) }
+
+        it { expect(profile.resume).to be_present }
       end
     end
 
@@ -248,6 +251,7 @@ RSpec.describe "JobOffers" do
                 availability_range_id: AvailabilityRange.first.id,
                 experience_level_id: ExperienceLevel.first.id,
                 study_level_id: StudyLevel.first.id,
+                resume: fixture_file_upload("document.pdf", "application/pdf"),
                 profile_foreign_languages_attributes: {
                   "0" => {
                     foreign_language_id: ForeignLanguage.first.id,
@@ -352,6 +356,8 @@ RSpec.describe "JobOffers" do
         it { expect(profile.departments.count).to eq(2) }
 
         it { expect(profile.departments.pluck(:id)).to match([Department.first.id, Department.last.id]) }
+
+        it { expect(profile.resume).to be_present }
       end
     end
   end

--- a/spec/requests/job_offers_spec.rb
+++ b/spec/requests/job_offers_spec.rb
@@ -288,6 +288,8 @@ RSpec.describe "JobOffers" do
 
       it { expect(post_request).to redirect_to(successful_job_offer_path(job_offer.slug)) }
 
+      it { expect { post_request }.not_to change { user.reload.profile } }
+
       describe "created job application" do
         before { post_request }
 

--- a/spec/tasks/maintenance/populate_resumes_task_spec.rb
+++ b/spec/tasks/maintenance/populate_resumes_task_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe PopulateResumesTask do
+    describe "#process" do
+      subject(:process) { described_class.process(profile) }
+      let(:profile) { create(:profile) }
+
+      before { profile.profileable.job_applications << create(:job_application, :with_job_application_file) }
+
+      it { expect { process }.to change { profile.reload.resume.present? }.from(false).to(true) }
+    end
+  end
+end

--- a/spec/tasks/maintenance/remove_resume_job_application_file_type_task_spec.rb
+++ b/spec/tasks/maintenance/remove_resume_job_application_file_type_task_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe RemoveResumeJobApplicationFileTypeTask do
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+      let!(:element) { create(:job_application_file_type, name: "CV") }
+
+      it { expect { process }.to change(JobApplicationFileType, :count).by(-1) }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Dans cette PR, on ajoute le CV au profil utilisateur. 

Le CV est donc éditable sur la page "Mon profil candidat".

Le CV du profil est ensuite réutilisé sur le formulaire de candidature.

En back office, le CV du profil est affiché : 
- dans le Vivier
- sur la page d'une candidature
- lors de l'export des CV

# ⚠️ Déploiement ⚠️ 

- [x] jouer la tâche `PopulateResumesTask`
- [x] jouer la tâche `RemoveResumeJobApplicationFileTypeTask`

# Review app

https://erecrutement-cvd-staging-pr1817.osc-fr1.scalingo.io

# Links

Closes #1793

# Screenshots

![image](https://github.com/user-attachments/assets/29a89d61-4ef1-4d6f-92b9-e198143252f5)

![image](https://github.com/user-attachments/assets/e742f6ba-9193-4377-8f1c-473aef4b4ccb)

![image](https://github.com/user-attachments/assets/490b50e5-6d0a-4a71-affe-c5247e156f5e)

![image](https://github.com/user-attachments/assets/74040a2b-98df-434e-992a-9de65a2aaddf)



