### PR TITLE
Don't crash users export when profile is missing

### DIFF
--- a/lib/services/exporter/users.rb
+++ b/lib/services/exporter/users.rb
@@ -29,7 +29,7 @@ class Exporter::Users < Exporter::Base
   end
 
   def format_job_application(job_application, index)
-    profile = job_application.user.profile
+    profile = job_application.user.profile.presence || job_application.user.build_profile
     [
       nil,
       job_application.job_offer.employer.name,


### PR DESCRIPTION
# Description

Si jamais un profil est nul au moment de l'export des users, l'export provoque une erreur. On corrige cette erreur ici de sorte que l'export fonctionne même si un profil est manquant.

# Links

https://www.rorvswild.com/applications/136160/errors/55653632
