### PR TITLE
:bug: Don't crash on missing job app file type

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -198,7 +198,7 @@ class JobApplication < ApplicationRecord
     ary_start = [0, 0]
     ary = job_application_files.each_with_object(ary_start) { |job_application_file, memo|
       memo[0] += 1
-      memo[1] += 1 if job_application_file.waiting_validation? && job_application_file.job_application_file_type.notification
+      memo[1] += 1 if job_application_file.waiting_validation? && job_application_file.job_application_file_type&.notification
     }
     self.files_count, self.files_unread_count = ary
   end


### PR DESCRIPTION
# Description

À cause de la suppression du type de fichier "CV", il y a un crash dans le calcul des notifications d'une offre d'emploi. Ici, pour résoudre le problème, on évite de crash si le type d'un fichier est manquant.
