### PR TITLE
:bug: Fix departments after applying

### DIFF
--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -70,7 +70,9 @@ class JobOffersController < ApplicationController
           job_application_params[:user_attributes].except(:profile_attributes)
         )
       end
-      @job_application.user.profile.assign_attributes(job_application_params[:user_attributes][:profile_attributes])
+      @job_application.user.profile.assign_attributes(
+        job_application_params[:user_attributes][:profile_attributes].except(:department_profiles_attributes)
+      )
       @job_application.user.profile.departments = departments
     end
 
@@ -244,5 +246,7 @@ class JobOffersController < ApplicationController
 
   def department_ids = department_profiles_attributes&.to_unsafe_h&.map { |_, department| department[:department_id] }
 
-  def department_profiles_attributes = job_application_params.dig(:user_attributes, :department_profiles_attributes)
+  def department_profiles_attributes
+    job_application_params.dig(:user_attributes, :profile_attributes, :department_profiles_attributes)
+  end
 end

--- a/spec/requests/job_offers_spec.rb
+++ b/spec/requests/job_offers_spec.rb
@@ -284,7 +284,10 @@ RSpec.describe "JobOffers" do
         }
       end
 
-      before { sign_in user }
+      before do
+        user.profile.departments = [Department.first, Department.last]
+        sign_in user
+      end
 
       it { expect { post_request }.not_to change(User, :count) }
 


### PR DESCRIPTION
# Description

Il y a un bug en production, qu'oncorrige ici. Il est reproductible de la manière suivante : 

## Procédure
1. Je m'authentifie en tant que user
2. Dans mon profil, je définis mes départements souhaités
3. Je postule à une offre sans changer les départements

## Ce qu'il se passe

Quand je retourne sur mon profil (ou si on regarde les données, ou en back office), le département "Aucun" est indiqué au lieu des départements souhaités par le user.

## Ce qu'il devrait se passer

Les départements souhaités par le user devraient être conservés.

# Review app

https://erecrutement-cvd-staging-pr1844.osc-fr1.scalingo.io
