### PR TITLE
:bug: Fixes crashes when user is deleted

### DIFF
--- a/app/controllers/admin/job_applications_controller.rb
+++ b/app/controllers/admin/job_applications_controller.rb
@@ -27,11 +27,13 @@ class Admin::JobApplicationsController < Admin::BaseController
   # GET /admin/candidatures/1
   # GET /admin/candidatures/1.json
   def show
-    if action_name == "show"
-      user = @job_application.user
+    user = @job_application.user
+    if user.blank?
+      redirect_to admin_job_offer_path(@job_application.job_offer), notice: t(".user_deleted")
+    else
       @other_job_applications = user && user.job_applications.where.not(id: @job_application.id)
+      render action: :show, layout: layout_choice
     end
-    render action: :show, layout: layout_choice
   end
 
   alias_method :cvlm, :show

--- a/app/views/admin/job_offers/_job_application.html.haml
+++ b/app/views/admin/job_offers/_job_application.html.haml
@@ -13,8 +13,11 @@
         = job_application.aasm.human_state
   .card-body
     - if can?(:manage, job_application)
-      = link_to [:admin, @job_offer, job_application] do
+      - if job_application.user.blank?
         = render "/admin/job_applications/job_application_card_body", job_application: job_application
+      - else
+        = link_to [:admin, @job_offer, job_application] do
+          = render "/admin/job_applications/job_application_card_body", job_application: job_application
     - else
       .job-application-modal-link
         = render "/admin/job_applications/job_application_card_body", job_application: job_application

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -225,7 +225,6 @@ fr:
         ongoing_none: "Aucune candidature en cours"
       job_application:
         created_at: "Candidaté il y a %{time_ago_in_words}"
-      show:
     emails:
       create:
         success: "Courriel envoyé !"
@@ -289,6 +288,8 @@ fr:
       update:
         success: "Vos informations ont été mises à jour"
     job_applications:
+      show:
+        user_deleted: Ce compte candidat a été supprimé
       index:
         job_applications_filtered:
           zero: "Aucun résultat de recherche"


### PR DESCRIPTION
# Description

Lorsqu'un compte user était supprimé, l'application crashait à l'ouverture d'une candidature.

Pour reproduire le bug : 
1. Se connecter en tant qu'admin et ouvrir une offre d'emploi qui a des candidatures
2. Ouvrir une candidature et supprimer le compte
3. Ouvrir une deuxième fois cette candidature 

=> l'application crashe

Ici, on résout le problème en empêchant l'ouverture d'une candidature dont le user a été supprimé.

# Review app

https://erecrutement-cvd-staging-pr1845.osc-fr1.scalingo.io

# Links

https://www.rorvswild.com/applications/136161/errors/56333966

https://www.rorvswild.com/applications/136160/errors/56295050