### PR TITLE
Add download endpoint

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class DownloadsController < ApplicationController
+  before_action :authenticate_request
+
+  def show = send_data(attribute.read, filename: attribute.filename, type: attribute.content_type)
+
+  private
+
+  def authenticate_request
+    head :unauthorized unless request.headers["X-Download-Secret-Key"] == ENV["DOWNLOAD_SECRET_KEY"]
+  end
+
+  def resource = @resource ||= sanitize_resource_type.find(params[:id])
+
+  def attribute = @attribute ||= sanitize_attribute
+
+  def sanitize_resource_type
+    case params[:resource_type]
+    when "User"
+      User
+    else
+      throw "Invalid resource type"
+    end
+  end
+
+  def sanitize_attribute
+    case params[:attribute_name]
+    when "photo"
+      resource.photo
+    else
+      throw "Invalid attribute"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :downloads, only: %i[show]
   resources :pages, only: %w[show]
   resource :robots, only: %w[show]
   resource :sitemap

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Downloads" do
+  describe "GET /downloads/:id" do
+    subject(:show_request) { get download_path(resource, resource_type: "User", attribute_name: "photo"), headers: }
+
+    before { show_request }
+
+    let(:resource) { create(:user, :with_photo) }
+
+    context "when the secret key is invalid" do
+      let(:headers) { {"X-Download-Secret-Key" => "invalid"} }
+
+      it { expect(response).to be_unauthorized }
+    end
+
+    context "when the secret key is valid" do
+      let(:headers) { {"X-Download-Secret-Key" => ENV["DOWNLOAD_SECRET_KEY"]} }
+
+      it { expect(response).to be_successful }
+
+      it { expect(response.headers["Content-Type"]).to eq "image/jpeg" }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add an endpoint to allow to download a file (for exemple a user's photo), given :
- the resource ID
- the resource type
- the attribute name

For now it can be used only with "User" resource type and "photo" attribute name, but it will be extended later for futur needs.

The endpoint requires a "X-Download-Secret-Key" header to be valid, or it returns "unauthorized".

