### PR TITLE
Allow to download profile resumes

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -19,6 +19,8 @@ class DownloadsController < ApplicationController
     case params[:resource_type]
     when "User"
       User
+    when "Profile"
+      Profile
     else
       throw "Invalid resource type"
     end
@@ -28,6 +30,8 @@ class DownloadsController < ApplicationController
     case params[:attribute_name]
     when "photo"
       resource.photo
+    when "resume"
+      resource.resume
     else
       throw "Invalid attribute"
     end

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -4,24 +4,32 @@ require "rails_helper"
 
 RSpec.describe "Downloads" do
   describe "GET /downloads/:id" do
-    subject(:show_request) { get download_path(resource, resource_type: "User", attribute_name: "photo"), headers: }
+    shared_examples "a downloadable resource" do |resource_type, attribute_name, content_type|
+      subject(:show_request) { get download_path(resource, resource_type:, attribute_name:), headers: }
 
-    before { show_request }
+      before { show_request }
 
-    let(:resource) { create(:user, :with_photo) }
+      context "when the secret key is invalid" do
+        let(:headers) { {"X-Download-Secret-Key" => "invalid"} }
 
-    context "when the secret key is invalid" do
-      let(:headers) { {"X-Download-Secret-Key" => "invalid"} }
+        it { expect(response).to be_unauthorized }
+      end
 
-      it { expect(response).to be_unauthorized }
+      context "when the secret key is valid" do
+        let(:headers) { {"X-Download-Secret-Key" => ENV["DOWNLOAD_SECRET_KEY"]} }
+
+        it { expect(response).to be_successful }
+
+        it { expect(response.headers["Content-Type"]).to eq(content_type) }
+      end
     end
 
-    context "when the secret key is valid" do
-      let(:headers) { {"X-Download-Secret-Key" => ENV["DOWNLOAD_SECRET_KEY"]} }
+    it_behaves_like "a downloadable resource", "User", "photo", "image/jpeg" do
+      let(:resource) { create(:user, :with_photo) }
+    end
 
-      it { expect(response).to be_successful }
-
-      it { expect(response.headers["Content-Type"]).to eq "image/jpeg" }
+    it_behaves_like "a downloadable resource", "Profile", "resume", "application/pdf" do
+      let(:resource) { create(:profile, :with_resume) }
     end
   end
 end


### PR DESCRIPTION
# Description

De même qu'on permet de télécharger la photo d'un `User`, on permet maintenant de télécharger le CV d'un `Profile`. C'est utile dans le cadre de la fusion DGA > CVD. Le endpoint n'est utilisable qu'avec une clé secrète.

# Links

Related to #1886
