### PR TITLE
Allow to download JobApplicationFile contents

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -21,6 +21,8 @@ class DownloadsController < ApplicationController
       User
     when "Profile"
       Profile
+    when "JobApplicationFile"
+      JobApplicationFile
     else
       throw "Invalid resource type"
     end
@@ -32,6 +34,8 @@ class DownloadsController < ApplicationController
       resource.photo
     when "resume"
       resource.resume
+    when "content"
+      resource.content
     else
       throw "Invalid attribute"
     end

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -31,5 +31,9 @@ RSpec.describe "Downloads" do
     it_behaves_like "a downloadable resource", "Profile", "resume", "application/pdf" do
       let(:resource) { create(:profile, :with_resume) }
     end
+
+    it_behaves_like "a downloadable resource", "JobApplicationFile", "content", "application/pdf" do
+      let(:resource) { create(:job_application_file) }
+    end
   end
 end


### PR DESCRIPTION
# Description

De même qu'on permet de télécharger la photo d'un User, on permet maintenant de télécharger le contenu d'un JobApplicationFile. C'est utile dans le cadre de la fusion DGA > CVD. Le endpoint n'est utilisable qu'avec une clé secrète.

# Links

Related to #1886 
Related to #1889