### PR TITLE
Allow to download email attachments

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -23,6 +23,8 @@ class DownloadsController < ApplicationController
       Profile
     when "JobApplicationFile"
       JobApplicationFile
+    when "EmailAttachment"
+      EmailAttachment
     else
       throw "Invalid resource type"
     end

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -35,5 +35,9 @@ RSpec.describe "Downloads" do
     it_behaves_like "a downloadable resource", "JobApplicationFile", "content", "application/pdf" do
       let(:resource) { create(:job_application_file) }
     end
+
+    it_behaves_like "a downloadable resource", "EmailAttachment", "content", "application/pdf" do
+      let(:resource) { create(:email_attachment) }
+    end
   end
 end


### PR DESCRIPTION
# Description

On permet maintenant de télécharger le contenu d'un EmailAttachment. C'est utile dans le cadre de la fusion DGA > CVD. Le endpoint n'est utilisable qu'avec une clé secrète.

# Links

Related to #1886 
Related to #1889
Related to #1902