### PR TITLE
:wrench: Add activable maintenance mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       RAILS_ENV: test
       NODE_ENV: test
-    
+
     services:
       postgres:
         image: postgres:latest
@@ -38,7 +38,7 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           bundle install --jobs 4 --retry 3 --path vendor/bundle
-      
+
       - name: Set up database
         env:
           DATABASE_URL_TEST: postgresql://cvd:postgres@localhost/cvd_test
@@ -48,7 +48,7 @@ jobs:
         run: |
           bundle exec rails tmp:clear
           bundle exec rails assets:precompile
-          
+
       - name: RSpec
         run: bundle exec rspec --fail-fast --format documentation
         env:
@@ -60,10 +60,3 @@ jobs:
           FRANCE_CONNECT_HOST: not.a.real.host.test-franceconnect.fr
           SECURE_CONTENT: true
 
-      - name: Upload Capybara screenshots
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: capybara-artifacts
-          path: /home/runner/work/**/tmp/capybara/*.png
-          retention-days: 5

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :redirect_to_maintenance_mode, if: :maintenance_mode_activated?
   before_action :basic_auth, if: -> { ENV["BASIC_AUTH"].present? }
 
   layout :layout_by_resource
@@ -18,6 +19,10 @@ class ApplicationController < ActionController::Base
   helper_method :current_organization
 
   private
+
+  def redirect_to_maintenance_mode = redirect_to maintenance_path
+
+  def maintenance_mode_activated? = ENV["MAINTENANCE_MODE"] == "true"
 
   def basic_auth
     authenticate_or_request_with_http_basic do |u1, p1|

--- a/app/controllers/maintenances_controller.rb
+++ b/app/controllers/maintenances_controller.rb
@@ -1,0 +1,12 @@
+class MaintenancesController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  layout "application"
+
+  helper_method :current_organization
+
+  def show
+  end
+
+  private
+
+  def current_organization = @current_organization ||= Organization.first
+end

--- a/app/views/maintenances/show.html.haml
+++ b/app/views/maintenances/show.html.haml
@@ -1,0 +1,7 @@
+- @page_title = "Mode maintenance"
+.rf-container.rf-py-12w
+  .rf-grid-row
+    .rf-col-12.rf-h2
+      L'application est en cours de maintenance.
+      %br
+      Merci de réessayer plus tard.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,7 @@ Rails.application.routes.draw do
   resources :pages, only: %w[show]
   resource :robots, only: %w[show]
   resource :sitemap
+  resource :maintenance, only: %w[show]
 
   root to: "homepages#show"
 end


### PR DESCRIPTION
# Description

Dans cette PR, on ajoute le mode maintenance. Il est activable en définissant la variables d'environnement `MAINTENANCE_MODE` à la valeur `true`.

Lorsque le mode maintenance est activé, l'application n'affiche qu'un seul écran (cf capture ci-dessous). Aucune fonctionnalité de l'application ne peut être utilisée. Tous les liens redirigent vers cette page.

# Review app

https://erecrutement-cvd-staging-pr19006.osc-fr1.scalingo.io

# Links

Closes #1888

# Screenshots

![CleanShot 2025-02-03 at 08 49 53@2x](https://github.com/user-attachments/assets/544b00a0-ad07-4501-bdfb-824b22604268)
