### PR TITLE
Change filtering on contract start and publication date

### DIFF
--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -115,7 +115,11 @@ class JobOffersController < ApplicationController
 
     @job_offers = @job_offers.where(category_id: searched_category_ids) if searched_category_ids.present?
 
-    @job_offers = @job_offers.where("contract_start_on <= ?", contract_start_on) if contract_start_on.present?
+    if contract_start_on.present?
+      start_of_month = contract_start_on.beginning_of_month
+      end_of_month = contract_start_on.end_of_month
+      @job_offers = @job_offers.where(contract_start_on: start_of_month..end_of_month)
+    end
     @job_offers = @job_offers.where("published_at >= ?", published_at) if published_at.present?
 
     @job_offers = @job_offers.bookmarked(current_user) if params[:bookmarked].present? && user_signed_in?

--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -120,7 +120,12 @@ class JobOffersController < ApplicationController
       end_of_month = contract_start_on.end_of_month
       @job_offers = @job_offers.where(contract_start_on: start_of_month..end_of_month)
     end
-    @job_offers = @job_offers.where("published_at >= ?", published_at) if published_at.present?
+
+    if published_at.present?
+      start_of_month = published_at.beginning_of_month
+      end_of_month = published_at.end_of_month
+      @job_offers = @job_offers.where(published_at: start_of_month..end_of_month)
+    end
 
     @job_offers = @job_offers.bookmarked(current_user) if params[:bookmarked].present? && user_signed_in?
 


### PR DESCRIPTION
# Description

On change la façon dont les offres d'emploi sont filtrées, pour les deux critères suivants : 
- date de prise de fonction souhaitée
- date de publication de l'offre

Dans les deux cas on applique la règle suivante : 

> Les résultats du filtre prendront en compte l'intégralité du mois.
> Si le candidat entre la date du 02/02/2025, il aura toutes les offres avec une prise de fonction / publiées durant le mois de février.

# Review app

https://erecrutement-cvd-staging-pr1911.osc-fr1.scalingo.io

# Links

Closes #1908