### PR TITLE
:recycle: Async deletion flow

### DIFF
--- a/app/jobs/administrator/deactivate_old_job.rb
+++ b/app/jobs/administrator/deactivate_old_job.rb
@@ -1,0 +1,5 @@
+class Administrator::DeactivateOldJob < ApplicationJob
+  queue_as :default
+
+  def perform = Administrator.deactivate_when_too_old!
+end

--- a/app/jobs/user/delete_old_job.rb
+++ b/app/jobs/user/delete_old_job.rb
@@ -1,0 +1,5 @@
+class User::DeleteOldJob < ApplicationJob
+  queue_as :default
+
+  def perform = User.destroy_when_too_old
+end

--- a/app/jobs/user/mark_for_deletion_job.rb
+++ b/app/jobs/user/mark_for_deletion_job.rb
@@ -1,0 +1,5 @@
+class User::MarkForDeletionJob < ApplicationJob
+  queue_as :default
+
+  def perform = User.mark_for_deletion
+end

--- a/app/models/concerns/deletion_flow.rb
+++ b/app/models/concerns/deletion_flow.rb
@@ -21,7 +21,9 @@ module DeletionFlow
           user.destroy
           ApplicantNotificationsMailer.deletion_notice(email, name, org_id).deliver_now
         end
+    end
 
+    def mark_for_deletion
       where("last_sign_in_at < ?", notice_period_target_date)
         .where(marked_for_deletion_on: nil)
         .find_each do |user|

--- a/clock.rb
+++ b/clock.rb
@@ -27,7 +27,7 @@ module Clockwork
   cond &&= ENV["DAYS_NOTICE_PERIOD_BEFORE_DEACTIVATION"].present?
   if cond
     every 1.day, "purge_administrators", at: "11:00" do
-      Administrator.deactivate_when_too_old!
+      Administrator::DeactivateOldJob.perform_later
     end
   end
 

--- a/clock.rb
+++ b/clock.rb
@@ -18,7 +18,8 @@ module Clockwork
   cond &&= ENV["DAYS_NOTICE_PERIOD_BEFORE_DELETION"].present?
   if cond
     every 1.day, "purge_users", at: "11:00" do
-      User.destroy_when_too_old
+      User::MarkForDeletionJob.perform_later
+      User::DeleteOldJob.perform_later
     end
   end
 

--- a/spec/jobs/administrator/deactivate_old_job_spec.rb
+++ b/spec/jobs/administrator/deactivate_old_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Administrator::DeactivateOldJob do
+  subject(:deactivate_old) { described_class.new.perform }
+
+  before do
+    allow(Administrator).to receive(:deactivate_when_too_old!)
+    deactivate_old
+  end
+
+  it { expect(Administrator).to have_received(:deactivate_when_too_old!) }
+end

--- a/spec/jobs/user/delete_old_job_spec.rb
+++ b/spec/jobs/user/delete_old_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe User::DeleteOldJob do
+  subject(:delete_old) { described_class.new.perform }
+
+  before do
+    allow(User).to receive(:destroy_when_too_old)
+    delete_old
+  end
+
+  it { expect(User).to have_received(:destroy_when_too_old) }
+end

--- a/spec/jobs/user/mark_for_deletion_job_spec.rb
+++ b/spec/jobs/user/mark_for_deletion_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe User::MarkForDeletionJob do
+  subject(:mark_for_deletion) { described_class.new.perform }
+
+  before do
+    allow(User).to receive(:mark_for_deletion)
+    mark_for_deletion
+  end
+
+  it { expect(User).to have_received(:mark_for_deletion) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe User do
       ENV["DAYS_NOTICE_PERIOD_BEFORE_DELETION"] = "20"
       user.reload
       described_class.destroy_when_too_old
+      described_class.mark_for_deletion
     end
 
     context "when connected long time ago" do


### PR DESCRIPTION
# Description

Comme décrit dans #1905, il semble que la gem clock ne soit pas capable d'exécuter des travaux lourds de manière synchrone. Dans ce refactoring, on déporte en asynchrone : 
- le marquage des users trop anciens comme "à supprimer"
- la suppression des users trop anciens
- la désactivation des admins trop anciens

# Review app

https://erecrutement-cvd-staging-pr1905.osc-fr1.scalingo.io

# Links

Closes #1905

