### PR TITLE
Fix search error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,17 +17,7 @@ class User < ApplicationRecord
   include Suspendable
   include DeletionFlow
   include PgSearch::Model
-  pg_search_scope :search_full_text,
-    against: [:first_name, :last_name],
-    ignoring: :accents,
-    associated_against: {
-      job_offers: {
-        identifier: "A",
-        title: "A",
-        description: "B",
-        location: "C"
-      }
-    }
+  pg_search_scope :search_full_text, against: [:first_name, :last_name], ignoring: :accents
 
   belongs_to :organization
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -129,6 +129,30 @@ RSpec.describe "Admin::Users" do
         it { expect(response.body).not_to include(user_no_foreign_language.full_name) }
       end
     end
+
+    describe "searching and filtering users on job application state" do
+      let(:initial_user) { create(:user, first_name: "René") }
+      let(:accepted_user) { create(:user, first_name: "René") }
+
+      let(:params) {
+        {
+          q: {job_applications_state_in: ["initial"]},
+          s: "René"
+        }
+      }
+
+      before do
+        create(:job_application, user: initial_user, state: "initial")
+        create(:job_application, user: accepted_user, state: "accepted")
+        index_request
+      end
+
+      it { expect(response).to be_successful }
+
+      it { expect(response.body).to include(initial_user.full_name) }
+
+      it { expect(response.body).not_to include(accepted_user.full_name) }
+    end
     # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 


### PR DESCRIPTION

# Description

Une erreur se produit lors de la recherche en texte intégral et du filtrage simultané sur l'état des candidatures. Le bug provient d'un conflit entre `pg_search_scope` (utilisé pour la recherche en texte) et `ransack` (utilisé pour les filtres).

Pour le corriger, nous supprimons la possibilité de rechercher en texte intégral dans l'identifiant / le titre / la description / la localisation des offres d'emploi (au niveau de `pg_search_scope`), ce qui ne semblait pas pertinent de toutes façons.

Nous ajoutons également des tests pour couvrir ce cas d'erreur.

# Review app

https://erecrutement-cvd-staging-pr1920.osc-fr1.scalingo.io

# Links

Closes #1918
