### PR TITLE
Fix drag n drop file upload

### DIFF
--- a/app/controllers/concerns/send_file_content.rb
+++ b/app/controllers/concerns/send_file_content.rb
@@ -2,7 +2,6 @@
 
 module SendFileContent
   extend ActiveSupport::Concern
-  include ActionController::Live
 
   def send_job_application_file_content
     send_data(
@@ -11,7 +10,5 @@ module SendFileContent
       type: "application/pdf",
       disposition: "inline"
     )
-  ensure
-    response.stream.close if response.stream.respond_to?(:close)
   end
 end

--- a/app/views/account/job_application_files/_file_name_upload.html.haml
+++ b/app/views/account/job_application_files/_file_name_upload.html.haml
@@ -2,12 +2,12 @@
 - is_validated_value = job_application_file.is_validated
 - hint_text = hint_text_for_file(job_application, job_application_file)
 - klasses = ["is-validated-#{ is_validated_value }"]
-- html = { id: "job_application_file_#{file_type.name.parameterize}", class: klasses, "data-file-drop-target" => "form" }
+- html = { id: "job_application_file_#{file_type.name.parameterize}", class: klasses, "data-file-drop-target" => "form", "data-controller" => "file-drop" }
 - options = { html: html, namespace: file_type.name.parameterize }
 = turbo_frame_tag dom_id(job_application_file.job_application_file_type) do
   %h3= file_type.name
   .rf-mb-1w= hint_text
-  - data = { controller: "file-drop", action: "dragenter->file-drop#highlight dragover->file-drop#highlight dragleave->file-drop#unhighlight drop->file-drop#unhighlight drop->file-drop#setFile" }
+  - data = { action: "dragenter->file-drop#highlight dragover->file-drop#highlight dragleave->file-drop#unhighlight drop->file-drop#unhighlight drop->file-drop#setFile" }
   = simple_form_for([:account, job_application, job_application_file], options) do |f|
     %label
       .rf-card.rf-card--no-arrow.rf-card--no-full-height.rf-mb-3w.hidden-file-input{ data: data }


### PR DESCRIPTION
# Description

L'upload de documents par drag n drop ne fonctionnait pas sur la page "Mes candidatures > Mes documents". On corrige le problème, qui venait d'un contrôleur stimulus placé au mauvais endroit.

On supprime également le `ActionController::Live`, qui n'était pas utilisé, et qui empêchait la page de s'afficher en environnement de développement.

# Review app

https://erecrutement-cvd-staging-pr1922.osc-fr1.scalingo.io

# Links

Closes #1914
