### PR TITLE
Search for admin emails with autocomplete select

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ gem "prawn-table" # Add tables to PDFs
 
 gem "maintenance_tasks", "~> 2.7" # Database maintenance tasks (data migrations, etc.)
 
+gem "hotwire_combobox" # Modern autocomplete
+
 group :development, :test do
   gem "brakeman", require: false
   gem "debug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,11 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     hashie (5.0.0)
+    hotwire_combobox (0.4.0)
+      platform_agent (>= 1.0.1)
+      rails (>= 7.0.7.2)
+      stimulus-rails (>= 1.2)
+      turbo-rails (>= 1.2)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.14.1)
@@ -337,6 +342,9 @@ GEM
     phony_rails (0.15.0)
       activesupport (>= 3.0)
       phony (>= 2.18.12)
+    platform_agent (1.0.1)
+      activesupport (>= 5.2.0)
+      useragent (~> 0.16.3)
     prawn (2.5.0)
       matrix (~> 0.4)
       pdf-core (~> 0.10.0)
@@ -546,6 +554,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    useragent (0.16.11)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -610,6 +619,7 @@ DEPENDENCIES
   groupdate
   guard-rspec
   haml-rails
+  hotwire_combobox
   inherited_resources
   invisible_captcha
   jbuilder (~> 2.11)

--- a/app/assets/stylesheets/_combobox.scss
+++ b/app/assets/stylesheets/_combobox.scss
@@ -1,0 +1,13 @@
+
+.hw-combobox {
+  // the fieldset container, wraps the whole component
+  width: 100%;
+}
+
+.hw-combobox__main__wrapper {
+  // wraps the input (combobox) and options list (listbox)
+  @extend .form-control;
+
+  width: 100%;
+  border-radius: revert;
+}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -6,6 +6,7 @@
 @import './common';
 @import './devise';
 @import './board';
+@import './combobox';
 
 $fa-font-path: ".";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";

--- a/app/controllers/admin/administrator_emails_controller.rb
+++ b/app/controllers/admin/administrator_emails_controller.rb
@@ -1,0 +1,19 @@
+class Admin::AdministratorEmailsController < Admin::BaseController
+  skip_load_and_authorize_resource
+
+  helper_method :next_page
+
+  def index = @administrators = administrators.page(params[:page]).per_page(10)
+
+  private
+
+  def administrators
+    if params[:q].present?
+      Administrator.search_email(params[:q])
+    else
+      Administrator.all
+    end
+  end
+
+  def next_page = @administrators.next_page.presence
+end

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -86,3 +86,9 @@ document.addEventListener('turbo:load', function () {
     dateFormat: 'Y-m-d'
   })
 })
+
+import { Application } from "@hotwired/stimulus"
+const application = Application.start()
+
+import HwComboboxController from "@josefarias/hotwire_combobox"
+application.register("hw-combobox", HwComboboxController)

--- a/app/javascript/controllers/job_offer_management_controller.js
+++ b/app/javascript/controllers/job_offer_management_controller.js
@@ -3,7 +3,6 @@ import Url from 'domurl'
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-
   removeRecord(event) {
     let node = event.currentTarget
 
@@ -23,7 +22,7 @@ export default class extends Controller {
 
   addFields(event) {
     let node = event.currentTarget
-    let emailField = node.previousElementSibling.querySelector('input[type=email]')
+    let emailField = node.previousElementSibling.querySelector('input[name=email]')
     if (emailField == null) {
       emailField = node.previousElementSibling.querySelector('select')
     }

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -9,6 +9,9 @@ class Administrator < ApplicationRecord
   include DeactivationFlow
   before_save :remove_mark_for_deactivation
 
+  include PgSearch::Model
+  pg_search_scope :search_email, against: :email, using: {tsearch: {prefix: true}}
+
   #####################################
   # Relationships
   belongs_to :organization

--- a/app/views/admin/administrator_emails/index.turbo_stream.erb
+++ b/app/views/admin/administrator_emails/index.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= async_combobox_options @administrators.pluck(:email), next_page: %>

--- a/app/views/admin/job_offers/_form_actors.html.haml
+++ b/app/views/admin/job_offers/_form_actors.html.haml
@@ -24,7 +24,7 @@
                         - options = options_from_collection_for_select(Cmg.all, 'email', 'email')
                         = select_tag :email, options, include_blank: true, class: 'form-control', id: "email_#{actor_role}"
                       - else
-                        = email_field_tag :email, nil, placeholder: t('simple_form.labels.defaults.email'), class: 'form-control', id: "email_#{actor_role}"
+                        = combobox_tag "email", admin_administrator_emails_path, placeholder: t('simple_form.labels.defaults.email'), id: "email_#{actor_role}"
                     - url = add_actor_admin_job_offers_url(role: actor_role, job_offer_id: job_offer_id)
                     - data = { action: "job-offer-management#addFields", url: url}
                     = link_to('#', class: 'btn btn-primary btn-raised mb-0 d-flex flex-row align-items-center', data: data) do

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -6,6 +6,7 @@
     %meta{name: "viewport", content: "width=device-width, initial-scale=1, shrink-to-fit=no"}
     %meta{name: 'turbo-cache-control', content: 'no-preview'}
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Roboto:300,400,400i,500|Roboto+Mono:400,500', 'data-turbo-track': 'reload'
+    = combobox_style_tag
     = javascript_include_tag 'admin', 'data-turbo-track': 'reload', defer: true
     = stylesheet_link_tag 'admin', media: 'all', 'data-turbo-track': 'reload', defer: true
     = csrf_meta_tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
       mount Sidekiq::Web => "/sidekiq"
       mount MaintenanceTasks::Engine => "/maintenance_tasks"
     end
-
+    resources :administrator_emails, only: :index
     resource :account do
       member do
         get :change_email, :change_password, :photo

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@gouvfr/dsfr": "^0.6.0",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^7.3.0",
+    "@josefarias/hotwire_combobox": "^0.4.0",
     "@rails/request.js": "^0.0.11",
     "@rails/ujs": "^6.1.3",
     "autoprefixer": "^10.4.19",

--- a/spec/requests/admin/administrator_emails_spec.rb
+++ b/spec/requests/admin/administrator_emails_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::AdministratorEmailsController do
+  let(:administrator) { create(:administrator) }
+
+  before { sign_in administrator }
+
+  describe "GET #index" do
+    subject(:index) { get admin_administrator_emails_path, params: {q: "administrator"}, as: :turbo_stream }
+
+    before { index }
+
+    it { expect(response).to be_successful }
+
+    it { expect(response).to render_template(:index) }
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,6 +183,11 @@
   resolved "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz"
   integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
 
+"@josefarias/hotwire_combobox@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@josefarias/hotwire_combobox/-/hotwire_combobox-0.4.0.tgz#9dc7040b4a107e797ad598e54773c1031cab960c"
+  integrity sha512-NcFKEfHYrL/2iQkqCy3z+PVJ+08roD1TM6I2M4/fUaoU0tE7g+LScbSzBu/76pNUxbRLg3qppqNvSGauu1yFNw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"


### PR DESCRIPTION
# Description

Dans cette PR, dans l'édition de l'offre d'emploi, on remplace la saisie libre de l'email de l'acteur à ajouter par un select auto completable.


# Review app

https://erecrutement-cvd-staging-pr1939.osc-fr1.scalingo.io

# Links

Closes #1925

# Screenshots



https://github.com/user-attachments/assets/f0fa72e6-0a79-4759-be8f-3e5e38f9ece1

