### PR TITLE
Transfer offers to existing admins only

### DIFF
--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -121,11 +121,10 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
 
   # POST /admin/settings/administrators/1/transfer
   def transfer
-    transfer = @administrator.transfer(params[:transfer_email])
-    if transfer.persisted?
+    if @administrator.transfer(params[:transfer_email])
       redirect_to %i[admin settings root], notice: t(".success")
     else
-      redirect_to edit_admin_settings_administrator_path(@administrator), notice: transfer.errors.full_messages.to_sentence
+      redirect_to edit_admin_settings_administrator_path(@administrator), notice: t(".error")
     end
   end
 

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -181,14 +181,13 @@ class Administrator < ApplicationRecord
   end
 
   def transfer(email)
-    administrator = Administrator.find_by(email: email.downcase) || Administrator.new(email: email)
-    administrator.inviter ||= self
-    administrator.organization = organization
-    if administrator.save
+    if (administrator = Administrator.find_by(email:))
       job_offer_actors.update_all(administrator_id: administrator.id) # rubocop:disable Rails/SkipsModelValidations
       owned_job_offers.update_all(owner_id: administrator.id) # rubocop:disable Rails/SkipsModelValidations
+      true
+    else
+      false
     end
-    administrator
   end
 
   def password_complexity

--- a/app/views/admin/settings/administrators/edit.html.haml
+++ b/app/views/admin/settings/administrators/edit.html.haml
@@ -9,8 +9,8 @@
         .row
           .col-12.col-md-6
             .form-group.rf-input-group
-              = f.label :transfer_email, "Email du nouveau propriétaire de l'offre", class: "form-control-label rf-label"
-              = f.email_field :transfer_email, placeholder: 'Email', class: "form-control rf-input string optional"
+              = f.label :transfer_email, t('.transfer_email_label'), class: "form-control-label rf-label"
+              = combobox_tag "transfer_email", admin_administrator_emails_path, placeholder: t('simple_form.labels.defaults.email')
         .form-actions.text-right.mt-4
           = f.submit t('.submit'), class: 'btn btn-primary btn-raised'
 .card.mt-2

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -378,6 +378,7 @@ fr:
         submit: "Transférer"
       transfer:
         success: "Annonce transférée !"
+        error: "L'annonce n'a pas pu être transférée, veuillez vérifier l'email du nouveau propriétaire"
       send_to_list:
         success: "Annonce diffusées !"
       feature:
@@ -649,6 +650,7 @@ fr:
         edit:
           title: "Modifier un compte utilisateur"
           transfer: "Transférer les offres"
+          transfer_email_label: "Email du nouveau propriétaire des offres"
           submit: "Transférer"
           list: "Liste des offres"
         deactivate:

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -216,50 +216,26 @@ RSpec.describe Administrator do
   end
 
   describe "#transfer" do
-    let(:email) { "any@email.org" }
+    subject(:transfer) { administrator.transfer(email) }
+
+    let(:administrator) { create(:administrator) }
     let!(:job_offer) { create(:job_offer, owner: administrator) }
 
     context "when the new administrator exists" do
-      let!(:new_administrator) { create(:administrator, email: email) }
+      let!(:new_administrator) { create(:administrator) }
+      let(:email) { new_administrator.email }
 
-      it "returns a persisted administrator" do
-        expect(administrator.transfer(email).persisted?).to be(true)
-      end
+      it { is_expected.to be(true) }
 
-      it "doesn't create an administrator" do
-        expect { administrator.transfer(email) }.not_to change(described_class, :count)
-      end
-
-      it "transfers the job offers to the new administrator" do
-        expect { administrator.transfer(email) }.to change { job_offer.reload.owner }.to(new_administrator)
-      end
+      it { expect { transfer }.to change { job_offer.reload.owner }.to(new_administrator) }
     end
 
     context "when the new administrator does not exist" do
-      it "returns a persisted administrator" do
-        expect(administrator.transfer(email).persisted?).to be(true)
-      end
+      let(:email) { "any@email.org" }
 
-      it "creates a new administrator" do
-        expect { administrator.transfer(email) }.to change(described_class, :count).by(1)
-      end
+      it { is_expected.to be(false) }
 
-      it "transfers the job offers to the new administrator" do
-        expect { administrator.transfer(email) }.to change { job_offer.reload.owner }
-      end
-    end
-
-    context "when the organization has an administrator email suffix which isn't used by the new administrator" do
-      before { administrator.organization.update!(administrator_email_suffix: "example.com") }
-
-      it "returns a unpersisted administrator with errors" do
-        expect(administrator.transfer(email).persisted?).to be(false)
-        expect(administrator.transfer(email).errors).to be_present
-      end
-
-      it "doesn't transfer the job offers" do
-        expect { administrator.transfer(email) }.not_to change { job_offer.reload.owner }
-      end
+      it { expect { transfer }.not_to change { job_offer.reload.owner } }
     end
   end
 end

--- a/spec/requests/admin/settings/administrators_spec.rb
+++ b/spec/requests/admin/settings/administrators_spec.rb
@@ -180,25 +180,22 @@ RSpec.describe "Admin::Settings::Administrators" do
   end
 
   describe "POST /admin/parametres/administrateurs/:id/transfer" do
-    subject(:transfer_request) {
-      post transfer_admin_settings_administrator_path(administrator), params: {transfer_email: transfer_email}
-    }
-
-    let(:administrator) { create(:administrator) }
-    let(:transfer_email) { "an.email.adress@example.com" }
-
-    context "when the transfer persisted" do
-      it "redirects to admin settings" do
-        expect(transfer_request).to redirect_to(admin_settings_root_path)
-      end
+    subject(:transfer_request) do
+      post transfer_admin_settings_administrator_path(administrator), params: {transfer_email:}
     end
 
-    context "when the transfer did not persist" do
-      before { allow_any_instance_of(Administrator).to receive(:persisted?).and_return(false) }
+    let(:administrator) { create(:administrator) }
 
-      it "redirects to the edit administrator settings" do
-        expect(transfer_request).to redirect_to(edit_admin_settings_administrator_path(administrator))
-      end
+    context "when the transfer is successful" do
+      let(:transfer_email) { create(:administrator).email }
+
+      it { expect(transfer_request).to redirect_to(admin_settings_root_path) }
+    end
+
+    context "when the transfer is not successful" do
+      let(:transfer_email) { "an.email.adress@example.com" }
+
+      it { expect(transfer_request).to redirect_to(edit_admin_settings_administrator_path(administrator)) }
     end
   end
 


### PR DESCRIPTION
# Description

Dans cette PR, on ne permet plus la création d'un compte admin lors du transfert des offres. Au contraire, on ne peut transférer des offres qu'à un compte admin existant.

# Review app

https://erecrutement-cvd-staging-pr1983.osc-fr1.scalingo.io

# Links

Closes #1961 

# Screenshots

![CleanShot 2025-06-10 at 08 42 53@2x](https://github.com/user-attachments/assets/891e6b0f-5cf8-429c-a040-d375578e3170)

