### PR TITLE
Skip maintenance mode for downloads

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DownloadsController < ApplicationController
+  skip_before_action :redirect_to_maintenance_mode, :redirect_permanently
   before_action :authenticate_request
 
   def show = send_data(attribute.read, filename: attribute.filename, type: attribute.content_type)


### PR DESCRIPTION
# Description

Dans le cadre de la fusion des instances DGA > CVD, on doit pouvoir télécharger des éléments, même si l'application est en maintenance.
