### PR TITLE
Notify user by email when job application state changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,8 +129,8 @@ GEM
       activesupport
       tzinfo
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
     counter_culture (3.5.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -358,7 +358,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (3.0.10)
+    rack (3.2.1)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-oauth2 (1.19.0)
@@ -424,7 +424,7 @@ GEM
       ffi (~> 1.0)
     redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.17.0)
+    redis-client (0.25.3)
       connection_pool
     regexp_parser (2.8.3)
     reline (0.4.2)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -62,7 +62,7 @@ class Admin::UsersController < Admin::InheritedResourcesController
         format.html { render :edit }
         format.js do
           @notification = t(".failure")
-          render :update, status: :unprocessable_entity
+          render :update, status: :unprocessable_content
         end
       end
     end

--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -73,6 +73,15 @@ class ApplicantNotificationsMailer < ApplicationMailer
     @user = params[:user]
     @job_offer = params[:job_offer]
     @state = JobApplication.human_attribute_name("state/#{params[:state]}")
+    @service_name = @job_offer.organization.service_name
+
+    mail to: @user.email, subject: t(".subject")
+  end
+
+  def notify_rejected
+    @user = params[:user]
+    @job_offer = params[:job_offer]
+    @service_name = @job_offer.organization.service_name
 
     mail to: @user.email, subject: t(".subject")
   end

--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -68,4 +68,12 @@ class ApplicantNotificationsMailer < ApplicationMailer
 
     mail to: @user.email, subject: t(".subject")
   end
+
+  def notify_new_state
+    @user = params[:user]
+    @job_offer = params[:job_offer]
+    @state = JobApplication.human_attribute_name("state/#{params[:state]}")
+
+    mail to: @user.email, subject: t(".subject")
+  end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -55,6 +55,7 @@ class JobApplication < ApplicationRecord
   before_save :compute_notifications_counter
   before_save :cleanup_rejection_reason, unless: proc { |ja| ja.rejected_state? }
   after_update :notify_new_state, if: -> { new_state_requires_notification? }
+  after_update :notify_rejected, if: -> { rejected_state_requires_notification? }
 
   FINISHED_STATES = %w[rejected phone_meeting_rejected after_meeting_rejected affected].freeze
   REJECTED_STATES = %w[rejected phone_meeting_rejected after_meeting_rejected].freeze
@@ -313,6 +314,10 @@ class JobApplication < ApplicationRecord
   def notify_new_state = ApplicantNotificationsMailer.with(user:, job_offer:, state:).notify_new_state.deliver_later
 
   def new_state_requires_notification? = saved_change_to_state? && NOTIFICATION_STATES.include?(state.to_s)
+
+  def notify_rejected = ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+
+  def rejected_state_requires_notification? = saved_change_to_state? && REJECTED_STATES.include?(state.to_s)
 
   class << self
     def rejected_states

--- a/app/views/applicant_notifications_mailer/notify_new_state.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_new_state.html.erb
@@ -1,0 +1,29 @@
+<p>
+  Bonjour <%= @user.full_name %>,
+</p>
+
+<p>
+  Vous recevez ce message parce que vous avez candidaté à l'offre
+  <%= @job_offer.identifier %> "<%= @job_offer.title %>".
+</p>
+
+<p>
+  Votre candidature est passée à l'étape
+  <%= @state %> !
+  Vous avez probablement de nouvelles actions à effectuer.
+</p>
+
+<p>
+  Veuillez-vous connecter à votre espace
+  <a href="<%= account_job_applications_url %>">
+    Mes candidatures.
+  </a>
+</p>
+
+<p>
+Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/applicant_notifications_mailer/notify_rejected.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_rejected.html.erb
@@ -1,0 +1,25 @@
+<p>
+  Bonjour <%= @user.full_name %>,
+</p>
+
+<p>
+  Vous recevez ce message parce que vous avez candidaté à l'offre
+  <%= @job_offer.identifier %> "<%= @job_offer.title %>".
+</p>
+
+<p>
+  Malheureusement, après l’étude de votre candidature, nous ne pourrons pas y donner une suite favorable.
+</p>
+
+<p>
+  Nous vous invitons à rester à l'écoute des offres que nous serons amenées à proposer dans les prochains mois sur notre site
+  <%= link_to @service_name, ENV.fetch('DEFAULT_HOST') %>.
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -177,6 +177,8 @@ fr:
       subject: "Nouvelle offre"
     notify_new_state:
       subject: "Votre candidature : nouvelle étape"
+    notify_rejected:
+      subject: "Votre candidature a été refusée"
   notifications_mailer:
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -175,6 +175,8 @@ fr:
   applicant_notifications_mailer:
     send_job_offer:
       subject: "Nouvelle offre"
+    notify_new_state:
+      subject: "Votre candidature : nouvelle étape"
   notifications_mailer:
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -46,22 +46,18 @@ RSpec.describe Admin::UsersController do
     context "with invalid params" do
       let(:user_params) { {phone: ""} }
 
+      before { update }
+
       context "when format is HTML" do
         let(:format) { :html }
 
-        it "returns a success response (i.e. to display the 'edit' template)" do
-          update
-          expect(response).to be_successful
-        end
+        it { expect(response).to be_successful }
       end
 
       context "when format is JS" do
         let(:format) { :js }
 
-        it "returns unprocessable_entity" do
-          update
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
+        it { expect(response).to have_http_status(:unprocessable_content) }
       end
     end
   end

--- a/spec/factories/employers.rb
+++ b/spec/factories/employers.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :employer do
     name { Faker::Company.unique.name }
-    code { Faker::Code.unique.asin }
+    code { SecureRandom.hex(3) }
   end
 end
 

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ApplicantNotificationsMailer do
-  let(:job_offer) { create(:job_offer) }
-  let(:organization) { job_offer.organization }
-  let(:job_application) { create(:job_application, job_offer: job_offer) }
-  let(:email) { create(:email, job_application: job_application) }
-  let(:mail) { described_class.new_email(email.id) }
-
   describe "new_email" do
+    let(:job_offer) { create(:job_offer) }
+    let(:organization) { job_offer.organization }
+    let(:job_application) { create(:job_application, job_offer: job_offer) }
+    let(:email) { create(:email, job_application: job_application) }
+    let(:mail) { described_class.new_email(email.id) }
+
     context "when from organization without inbound email configured" do
       it "renders the headers" do
         expect(mail.subject).to eq("New email")
@@ -41,5 +41,18 @@ RSpec.describe ApplicantNotificationsMailer do
         expect(mail.body.encoded).to match(/vous pouvez répondre à cet email directement/)
       end
     end
+  end
+
+  describe "notify_new_state" do
+    subject(:notify_new_state) { described_class.with(user:, job_offer:, state:).notify_new_state }
+
+    let(:job_application) { build_stubbed(:job_application) }
+    let(:user) { job_application.user }
+    let(:job_offer) { job_application.job_offer }
+    let(:state) { "phone_meeting" }
+
+    it { expect(notify_new_state.subject).to eq("Votre candidature : nouvelle étape") }
+
+    it { expect(notify_new_state.body.encoded).to match(/Votre candidature est passée à l'étape/) }
   end
 end

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -55,4 +55,16 @@ RSpec.describe ApplicantNotificationsMailer do
 
     it { expect(notify_new_state.body.encoded).to match(/Votre candidature est passée à l'étape/) }
   end
+
+  describe "notify_rejected" do
+    subject(:notify_rejected) { described_class.with(user:, job_offer:).notify_rejected }
+
+    let(:job_application) { build_stubbed(:job_application) }
+    let(:user) { job_application.user }
+    let(:job_offer) { job_application.job_offer }
+
+    it { expect(notify_rejected.subject).to eq("Votre candidature a été refusée") }
+
+    it { expect(notify_rejected.body.encoded).to match(/nous ne pourrons pas y donner une suite favorable/) }
+  end
 end

--- a/spec/mailers/previews/applicant_notifications_preview.rb
+++ b/spec/mailers/previews/applicant_notifications_preview.rb
@@ -14,4 +14,11 @@ class ApplicantNotificationsPreview < ActionMailer::Preview
       state: "phone_meeting"
     ).notify_new_state
   end
+
+  def notify_rejected
+    ApplicantNotificationsMailer.with(
+      user: User.first,
+      job_offer: JobOffer.first
+    ).notify_rejected
+  end
 end

--- a/spec/mailers/previews/applicant_notifications_preview.rb
+++ b/spec/mailers/previews/applicant_notifications_preview.rb
@@ -6,4 +6,12 @@ class ApplicantNotificationsPreview < ActionMailer::Preview
   def new_email
     ApplicantNotificationsMailer.new_email
   end
+
+  def notify_new_state
+    ApplicantNotificationsMailer.with(
+      user: User.first,
+      job_offer: JobOffer.first,
+      state: "phone_meeting"
+    ).notify_new_state
+  end
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -55,6 +55,24 @@ RSpec.describe JobApplication do
         it { expect { state_change }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_new_state) }
       end
     end
+
+    describe "#notify_rejected" do
+      subject(:rejection) { job_application.update!(state:) }
+
+      described_class::REJECTED_STATES.each do |rejected_state|
+        context "when the state is a rejected state (#{rejected_state})" do
+          let(:state) { rejected_state }
+
+          it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
+        end
+      end
+
+      context "when the state is not a rejected state" do
+        let(:state) { "phone_meeting" }
+
+        it { expect { rejection }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
+      end
+    end
   end
 
   it "correcties tell rejected state" do


### PR DESCRIPTION
# Description

On envoie automatiquement une notification à l'utilisateur·rice quand le statut de sa candidature évolue : 
- vers un état positif : on envoie l'email "Votre candidature : nouvelle étape"
- vers un rejet / désistement : on envoie l'email "Votre candidature a été refusée"

# Review app

https://erecrutement-cvd-staging-pr2010.osc-fr1.scalingo.io

# Links

Closes #1933

# Screenshots

![CleanShot 2025-03-30 at 11 14 58@2x](https://github.com/user-attachments/assets/92a2b575-c2c0-44b1-b29d-8adffd63d1e9)

![CleanShot 2025-03-30 at 11 15 10@2x](https://github.com/user-attachments/assets/d8d4aa54-054c-460e-86d7-2da1a9b6f57f)
