### PR TITLE
Search for admin emails with autocomplete select

### DIFF
--- a/app/controllers/admin/administrator_emails_controller.rb
+++ b/app/controllers/admin/administrator_emails_controller.rb
@@ -1,0 +1,19 @@
+class Admin::AdministratorEmailsController < Admin::BaseController
+  skip_load_and_authorize_resource
+
+  helper_method :next_page
+
+  def index = @administrators = administrators.page(params[:page]).per_page(10)
+
+  private
+
+  def administrators
+    if params[:q].present?
+      Administrator.search_email(params[:q])
+    else
+      Administrator.all
+    end
+  end
+
+  def next_page = @administrators.next_page.presence
+end

--- a/app/javascript/controllers/job_offer_management_controller.js
+++ b/app/javascript/controllers/job_offer_management_controller.js
@@ -3,7 +3,6 @@ import Url from 'domurl'
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-
   removeRecord(event) {
     let node = event.currentTarget
 
@@ -23,7 +22,7 @@ export default class extends Controller {
 
   addFields(event) {
     let node = event.currentTarget
-    let emailField = node.previousElementSibling.querySelector('input[type=email]')
+    let emailField = node.previousElementSibling.querySelector('input[name=email]')
     if (emailField == null) {
       emailField = node.previousElementSibling.querySelector('select')
     }

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -9,6 +9,9 @@ class Administrator < ApplicationRecord
   include DeactivationFlow
   before_save :remove_mark_for_deactivation
 
+  include PgSearch::Model
+  pg_search_scope :search_email, against: :email, using: {tsearch: {prefix: true}}
+
   #####################################
   # Relationships
   belongs_to :organization

--- a/app/views/admin/administrator_emails/index.turbo_stream.erb
+++ b/app/views/admin/administrator_emails/index.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= async_combobox_options @administrators.pluck(:email), next_page: %>

--- a/app/views/admin/job_offers/_form_actors.html.haml
+++ b/app/views/admin/job_offers/_form_actors.html.haml
@@ -24,7 +24,7 @@
                         - options = options_from_collection_for_select(Cmg.all, 'email', 'email')
                         = select_tag :email, options, include_blank: true, class: 'form-control', id: "email_#{actor_role}"
                       - else
-                        = email_field_tag :email, nil, placeholder: t('simple_form.labels.defaults.email'), class: 'form-control', id: "email_#{actor_role}"
+                        = combobox_tag "email", admin_administrator_emails_path, placeholder: t('simple_form.labels.defaults.email'), id: "email_#{actor_role}"
                     - url = add_actor_admin_job_offers_url(role: actor_role, job_offer_id: job_offer_id)
                     - data = { action: "job-offer-management#addFields", url: url}
                     = link_to('#', class: 'btn btn-primary btn-raised mb-0 d-flex flex-row align-items-center', data: data) do

--- a/spec/requests/admin/administrator_emails_spec.rb
+++ b/spec/requests/admin/administrator_emails_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::AdministratorEmailsController do
+  let(:administrator) { create(:administrator) }
+
+  before { sign_in administrator }
+
+  describe "GET #index" do
+    subject(:index) { get admin_administrator_emails_path, params: {q: "administrator"}, as: :turbo_stream }
+
+    before { index }
+
+    it { expect(response).to be_successful }
+
+    it { expect(response).to render_template(:index) }
+  end
+end


### PR DESCRIPTION
# Description

Dans cette PR, dans l'édition de l'offre d'emploi, on remplace la saisie libre de l'email de l'acteur à ajouter par un select auto completable.


# Review app

https://erecrutement-cvd-staging-pr2011.osc-fr1.scalingo.io

# Links

Closes #1925

# Screenshots



https://github.com/user-attachments/assets/f0fa72e6-0a79-4759-be8f-3e5e38f9ece1

