### PR TITLE
Add captcha to registration pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 
 gem "aasm"
 gem "acts_as_list"
+gem "altcha-rails"
 gem "audited"
 gem "awesome_nested_set"
 gem "cancancan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    altcha-rails (0.0.6)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -596,6 +597,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   acts_as_list
+  altcha-rails
   annotate
   audited
   awesome_nested_set

--- a/app/controllers/altcha_controller.rb
+++ b/app/controllers/altcha_controller.rb
@@ -1,0 +1,5 @@
+class AltchaController < ApplicationController
+  def new
+    render json: Altcha::Challenge.create.to_json
+  end
+end

--- a/app/models/altcha_solution.rb
+++ b/app/models/altcha_solution.rb
@@ -1,0 +1,46 @@
+class AltchaSolution < ApplicationRecord
+  validates :algorithm, :challenge, :salt, :signature, :number, presence: true
+  attr_accessor :took
+
+  def self.verify_and_save(base64encoded)
+    p = JSON.parse(Base64.decode64(base64encoded)) rescue nil # rubocop:disable Style/RescueModifier
+    return false if p.nil?
+
+    submission = Altcha::Submission.new(p)
+    return false unless submission.valid?
+
+    solution = new(p)
+
+    begin
+      solution.save
+    rescue ActiveRecord::RecordNotUnique
+      # Replay attack
+      false
+    end
+  end
+
+  def self.cleanup
+    # Replay attacks are protected by the time stamp in the salt of the challenge for
+    # the duration configured in the timeout. All solutions in the database that older
+    # can be deleted.
+    AltchaSolution.where("created_at < ?", Time.now - Altcha.timeout).delete_all # rubocop:disable Rails/TimeZone
+  end
+end
+
+# == Schema Information
+#
+# Table name: altcha_solutions
+#
+#  id         :bigint           not null, primary key
+#  algorithm  :string
+#  challenge  :string
+#  number     :integer
+#  salt       :string
+#  signature  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_altcha_solutions  (algorithm,challenge,salt,signature,number) UNIQUE
+#

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,6 +1,8 @@
 .rf-text--lead.rf-mb-3w
   = @page_title = t(".forgot_your_password")
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  %altcha-widget{challengeurl: altcha_url, delay: 500, overlay: true, hidelogo: true, hidefooter: true}
+
   = f.error_notification
   = f.input :email, required: true, autofocus: true, label: false, placeholder: true
   .rf-input-group

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,6 +5,8 @@
   = render "devise/shared/france_connect"
 
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  %altcha-widget{challengeurl: altcha_url, delay: 500, overlay: true, hidelogo: true, hidefooter: true}
+
   = f.error_notification
   = f.input :email, required: true, autofocus: true
   %div{data: {controller: "password-visibility password-rules"}}

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -1,6 +1,8 @@
 - unless user_signed_in?
   = render "devise/shared/france_connect"
 = simple_form_for(@job_application, url: [:send_application, @job_offer], method: :post, data: { turbo: true, controller: "form-save", form_save_target: "form", action: "change->form-save#saveFormData submit->form-save#clearFormData" }) do |f|
+  %altcha-widget{challengeurl: altcha_url, delay: 500, overlay: true, hidelogo: true, hidefooter: true}
+
   .form-inputs.mt-3
     - if f.object.errors["user.profile.base"].present?
       = f.error_notification message: f.object.errors["user.profile.base"].to_sentence

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
     = yield :meta if content_for?(:meta)
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
     = stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload', defer: true
+    %script{src: "https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js", type: "module"}
     = csrf_meta_tags
     = csp_meta_tag
     = favicon_link_tag asset_path('favicon-16x16.png'), rel: 'icon', type: 'image/png', sizes: '16x16'

--- a/config/initializers/altcha.rb
+++ b/config/initializers/altcha.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Altcha.setup do |config|
+  config.algorithm = "SHA-256"
+  config.num_range = (50_000..500_000)
+  config.timeout = 5.minutes
+  config.hmac_key = ENV["ALTCHA_HMAC_KEY"]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
   get "/politique-confidentialite", to: redirect("/pages/politique-de-confidentialite")
   get "/suivi", to: redirect("/pages/suivi-d-audience-et-vie-privee")
 
+  get "/altcha", to: "altcha#new"
+
   # Domains check
   get "/.well-known/pki-validation/:file_name" => "domain_validations#show", :as => :domain_validations
 

--- a/db/migrate/20251027081555_create_altcha_solutions.rb
+++ b/db/migrate/20251027081555_create_altcha_solutions.rb
@@ -1,0 +1,15 @@
+class CreateAltchaSolutions < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:altcha_solutions) do |t|
+      t.string :algorithm
+      t.string :challenge
+      t.string :salt
+      t.string :signature
+      t.integer :number
+
+      t.timestamps
+    end
+
+    add_index :altcha_solutions, [ :algorithm, :challenge, :salt, :signature, :number ], unique: true, name: 'index_altcha_solutions'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_07_061120) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_27_081555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -99,6 +99,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_07_061120) do
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_age_ranges_on_name"
     t.index ["position"], name: "index_age_ranges_on_position"
+  end
+
+  create_table "altcha_solutions", force: :cascade do |t|
+    t.string "algorithm"
+    t.string "challenge"
+    t.string "salt"
+    t.string "signature"
+    t.integer "number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["algorithm", "challenge", "salt", "signature", "number"], name: "index_altcha_solutions", unique: true
   end
 
   create_table "archiving_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
# Description

On ajoute un captcha sur les pages qui permettent de s'enregistrer, c'est à dire : 
- la page de création de compte
- la page pour postuler à une offre d'emploi

La solution technique employée est Altcha : https://altcha.org/fr/

> ALTCHA propose une protection anti-spam respectueuse de la vie privée, une alternative globalement conforme et accessible aux CAPTCHAs. Protège contre le spam et les abus sans suivre les utilisateurs, en respectant le RGPD, le CCPA et d'autres réglementations tout en garantissant une expérience sans friction.

# Review app

https://erecrutement-cvd-staging-pr2023.osc-fr1.scalingo.io

# Screenshots


https://github.com/user-attachments/assets/4337e36d-1366-4c01-b6c2-c22f46606a8b


https://github.com/user-attachments/assets/25bb83bb-6091-40a2-8e6f-ddaf8d643da8

