### PR TITLE
Don't audit preselection

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -69,7 +69,7 @@ class Admin::JobOffersController < Admin::BaseController
   # GET /admin/job_offers/1/board
   # GET /admin/job_offers/1/board.json
   def board
-    @job_applications = @job_offer.job_applications.group_by(&:state)
+    @job_applications = @job_offer.job_applications.includes(:user).group_by(&:state)
     request.xhr? && render(layout: false)
   end
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -9,7 +9,7 @@ class JobApplication < ApplicationRecord
   audited except: %i[files_count files_unread_count emails_count
     emails_administrator_unread_count emails_user_unread_count
     administrator_notifications_count
-    skills_fit_job_offer experiences_fit_job_offer]
+    skills_fit_job_offer experiences_fit_job_offer preselection]
   has_associated_audits
 
   include PgSearch::Model

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -205,7 +205,7 @@ class JobApplication < ApplicationRecord
   end
 
   def compute_emails_count
-    ary = emails.reload.each_with_object([0, 0]) { |obj, memo|
+    ary = emails.reload.includes(:sender).each_with_object([0, 0]) { |obj, memo|
       if obj.is_unread?
         memo[0] += 1 if obj.sender.is_a?(User)
         memo[1] += 1 if obj.sender.is_a?(Administrator)


### PR DESCRIPTION
# Description

Quand on présélectionne un·e candidat·e, on souhaite que cela n'apparaisse pas dans l'audit.

# Review app

https://erecrutement-cvd-staging-pr2025.osc-fr1.scalingo.io

# Links

Closes #2020

# Screenshots

## Avant

<img width="646" height="676" alt="image" src="https://github.com/user-attachments/assets/7c10f5f3-0aee-4b5d-9261-b1a7afaaba3b" />


## Après

<img width="574" height="656" alt="CleanShot 2025-10-30 at 11 23 27" src="https://github.com/user-attachments/assets/f39f7ab3-f8cb-4970-bdc6-31d2c5b0613d" />

