### PR TITLE
Autocomplete input to transfer offer

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -148,9 +148,10 @@ class Admin::JobOffersController < Admin::BaseController
   # POST /admin/job_offers/1/transfer
   # POST /admin/job_offers/1/transfer.json
   def transfer
-    @job_offer.transfer(params[:transfer_email], current_administrator)
-    respond_to do |format|
-      format.html { redirect_to %i[admin job_offers], notice: t(".success") }
+    if @job_offer.transfer(params[:transfer_email])
+      redirect_to %i[admin job_offers], notice: t(".success")
+    else
+      render :new_transfer, status: :unprocessable_entity
     end
   end
 

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -298,13 +298,15 @@ class JobOffer < ApplicationRecord
     end
   end
 
-  def transfer(email, current_administrator)
-    administrator = Administrator.find_by(email: email.downcase) || Administrator.new(email: email)
-    administrator.inviter ||= current_administrator
-    administrator.organization = current_administrator.organization
-    administrator.save!
-    job_offer_actors.where(administrator: owner).update_all(administrator_id: administrator.id) # rubocop:disable Rails/SkipsModelValidations
-    update!(owner: administrator)
+  def transfer(email)
+    administrator = Administrator.find_by(email:)
+    if administrator.present?
+      job_offer_actors.where(administrator: owner).update_all(administrator_id: administrator.id) # rubocop:disable Rails/SkipsModelValidations
+      update(owner: administrator)
+    else
+      errors.add(:base, :transfer_administrator_not_found)
+      false
+    end
   end
 
   def benefit

--- a/app/views/admin/job_offers/new_transfer.html.haml
+++ b/app/views/admin/job_offers/new_transfer.html.haml
@@ -7,6 +7,6 @@
             .col-12.col-md-6
               .form-group.rf-input-group
                 = f.label :transfer_email, "Email du nouveau propriétaire de l'offre", class: "form-control-label rf-label"
-                = f.email_field :transfer_email, placeholder: 'Email', class: "form-control rf-input string optional"
+                = combobox_tag :transfer_email, admin_administrator_emails_path, placeholder: t('simple_form.placeholders.administrator.email')
           .form-actions.text-right.mt-4
             = f.submit t('.submit'), class: 'btn btn-primary btn-raised'

--- a/app/views/admin/job_offers/new_transfer.html.haml
+++ b/app/views/admin/job_offers/new_transfer.html.haml
@@ -8,5 +8,11 @@
               .form-group.rf-input-group
                 = f.label :transfer_email, "Email du nouveau propriétaire de l'offre", class: "form-control-label rf-label"
                 = combobox_tag :transfer_email, admin_administrator_emails_path, placeholder: t('simple_form.placeholders.administrator.email')
+
+          - if @job_offer.errors.any?
+            .row
+              .col-12
+                .alert.alert-danger= @job_offer.errors.full_messages.to_sentence
+
           .form-actions.text-right.mt-4
             = f.submit t('.submit'), class: 'btn btn-primary btn-raised'

--- a/app/views/admin/job_offers/new_transfer.html.haml
+++ b/app/views/admin/job_offers/new_transfer.html.haml
@@ -12,7 +12,7 @@
           - if @job_offer.errors.any?
             .row
               .col-12
-                .alert.alert-danger= @job_offer.errors.full_messages.to_sentence
+                .alert.alert-danger= @job_offer.errors.full_messages.to_sentence.html_safe
 
           .form-actions.text-right.mt-4
             = f.submit t('.submit'), class: 'btn btn-primary btn-raised'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -914,9 +914,9 @@ fr:
           title: "Disponibilités d'un·e candidat·e"
           add: "Ajouter"
           card_title:
-            zero: 'Aucune disponibilité pour le moment'
-            one: '1 disponibilité'
-            other: '%{count} disponibilités'
+            zero: "Aucune disponibilité pour le moment"
+            one: "1 disponibilité"
+            other: "%{count} disponibilités"
         new:
           title: "Ajouter une disponibilité"
         create:
@@ -1163,6 +1163,7 @@ fr:
           attributes:
             base:
               csp_or_mobilia: "CSP et/ou MOBILIA doit être rempli"
+              transfer_administrator_not_found: "Administrateur non trouvé"
             title:
               brackets: "ne doit pas contenir de parenthèse"
               f_h: "doit finir par F/H"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1163,7 +1163,7 @@ fr:
           attributes:
             base:
               csp_or_mobilia: "CSP et/ou MOBILIA doit être rempli"
-              transfer_administrator_not_found: "Administrateur non trouvé"
+              transfer_administrator_not_found: 'Ce mail n’a pas de compte existant, veuillez envoyer une demande de création de compte via le lien suivant : <a href="https://demarches-simplifiees.intradef.gouv.fr/commencer/demande-creation-compte-erecrutement">https://demarches-simplifiees.intradef.gouv.fr/commencer/demande-creation-compte-erecrutement</a>'
             title:
               brackets: "ne doit pas contenir de parenthèse"
               f_h: "doit finir par F/H"

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -416,6 +416,23 @@ RSpec.describe JobOffer do
       end
     end
   end
+
+  describe "#transfer" do
+    subject { job_offer.transfer(email) }
+
+    let(:job_offer) { create(:job_offer) }
+    let(:email) { "test@example.com" }
+
+    context "when email is used by an administrator" do
+      before { create(:administrator, email:) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when email is not used by an administrator" do
+      it { is_expected.to be(false) }
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Description

On utilise un autocomplete avec les comptes des administrateurs·rices pour transférer une offre d'emploi (plutôt qu'une saisie libre d'adresse email).

# Review app

https://erecrutement-cvd-staging-pr2026.osc-fr1.scalingo.io

# Links

Closes #1962

# Screenshots


https://github.com/user-attachments/assets/e4a9e66e-3d82-4f37-90eb-b98887c59a1d


