### PR TITLE
Update admin self account form

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -62,7 +62,6 @@ class Admin::AccountsController < Admin::BaseController
 
   def administrator_params
     params.require(:administrator).permit(
-      :title,
       :first_name,
       :last_name,
       :photo,

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -65,7 +65,6 @@ class Admin::AccountsController < Admin::BaseController
       :first_name,
       :last_name,
       :photo,
-      :email,
       :current_password,
       :password,
       :password_confirmation

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -9,15 +9,17 @@
         .row
           .col-12.col-md-6
             = f.input :first_name
+
           .col-12.col-md-6
             = f.input :last_name
+
         .row
           .col-12.col-md-6
-            = f.input :title, placeholder: false, disabled: true
+            = f.input :email, placeholder: false, disabled: true
+
+        .row
           .col-12.col-md-6
             = f.input :photo
-
-        = f.input :email, placeholder: false, disabled: true
 
         .row
           .col-12.col-md-6
@@ -26,19 +28,30 @@
             .col-12.col-md-6
               %label
                 = t('simple_form.labels.administrator.ace_ate')
-              = f.input :ace, as: :boolean
-              = f.input :ate, as: :boolean
+              .d-flex
+                = f.input :ace, disabled: true, wrapper_html: {class: 'mr-3'}
+                = f.input :ate, disabled: true
 
         - unless @administrator.functional_administrator?
           .row
             .col-12.col-md-6
               = f.input :employers, as: :string, required: true, disabled: true, input_html: {value: @administrator.employers.pluck(:code).join(', ')}
 
-        = f.input :current_password, placeholder: false
+        .row
+          .col-12.col-md-6
+            = f.input :title, placeholder: false, disabled: true
 
-        = f.input :password, placeholder: false
+        .row
+          .col-12.col-md-6
+            = f.input :current_password, placeholder: false
 
-        = f.input :password_confirmation, placeholder: false
+        .row
+          .col-12.col-md-6
+            = f.input :password, placeholder: false
+
+        .row
+          .col-12.col-md-6
+            = f.input :password_confirmation, placeholder: false
 
       .form-actions.text-right.mt-4
         %ul.list-inline.mb-0

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -32,7 +32,7 @@
                   - else
                     = submodel_form.association :employer, collection: [@administrator.employer], label: false, include_blank: false, input_html: {class: 'custom-select'}
 
-        = f.input :email, placeholder: false
+        = f.input :email, placeholder: false, disabled: true
 
         = f.input :current_password, placeholder: false
         = f.input :password, placeholder: false

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -17,25 +17,27 @@
           .col-12.col-md-6
             = f.input :photo
 
-        - if @administrator.employer?
-          - %i(supervisor_administrator grand_employer_administrator).each do |submodel|
-            .my-2= t(".mention_#{submodel}_html")
-            = f.simple_fields_for(submodel, (@administrator.send(submodel) || Administrator.new)) do |submodel_form|
-              - submodel_form.object.ensure_employer_is_set = true
-              = submodel_form.input :ensure_employer_is_set, as: :hidden
-              .row
-                .col-12.col-md-8
-                  = submodel_form.input :email, required: true, label: false, placeholder: true
-                .col-12.col-md-4
-                  - if submodel == :grand_employer_administrator
-                    = submodel_form.association :employer, collection: [@administrator.employer.parent], label: false, include_blank: false, input_html: {class: 'custom-select'}
-                  - else
-                    = submodel_form.association :employer, collection: [@administrator.employer], label: false, include_blank: false, input_html: {class: 'custom-select'}
-
         = f.input :email, placeholder: false, disabled: true
 
+        .row
+          .col-12.col-md-6
+            = f.input :roles, as: :string, required: true, disabled: true, input_html: {value: @administrator.roles.map { |role| I18n.t("activerecord.attributes.administrator/roles.#{role}") }.join(', ')}
+          - if @administrator.employment_authority?
+            .col-12.col-md-6
+              %label
+                = t('simple_form.labels.administrator.ace_ate')
+              = f.input :ace, as: :boolean
+              = f.input :ate, as: :boolean
+
+        - unless @administrator.functional_administrator?
+          .row
+            .col-12.col-md-6
+              = f.input :employers, as: :string, required: true, disabled: true, input_html: {value: @administrator.employers.pluck(:code).join(', ')}
+
         = f.input :current_password, placeholder: false
+
         = f.input :password, placeholder: false
+
         = f.input :password_confirmation, placeholder: false
 
       .form-actions.text-right.mt-4

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -13,7 +13,7 @@
             = f.input :last_name
         .row
           .col-12.col-md-6
-            = f.input :title, placeholder: false
+            = f.input :title, placeholder: false, disabled: true
           .col-12.col-md-6
             = f.input :photo
 

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -73,6 +73,7 @@ fr:
         employers: "Chaîne d'emploi"
         employer: "Employeur"
         grand_employer: "Grand Employeur"
+        roles: "Rôles"
         role: "Rôle"
         ace: ACE
         ate: ATE

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Admin::Accounts" do
+RSpec.describe Admin::AccountsController do
   let(:administrator) { create(:administrator) }
 
   before { sign_in administrator }

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Admin::AccountsController do
       {
         administrator: {
           first_name:,
-          email:,
           current_password: attributes_for(:administrator)[:password],
           password: new_password,
           password_confirmation: new_password
@@ -51,7 +50,6 @@ RSpec.describe Admin::AccountsController do
       }
     end
     let(:first_name) { "Sebastien" }
-    let(:email) { "test@example.com" }
     let(:new_password) { "A perflectly plausible password 1234!" }
 
     it "redirects to admin_account_path" do
@@ -60,10 +58,6 @@ RSpec.describe Admin::AccountsController do
 
     it "updates the account" do
       expect { update_request }.to change { administrator.reload.first_name }.to(first_name)
-    end
-
-    it "updates the account email" do
-      expect { update_request }.to change { administrator.reload.unconfirmed_email }.to(email)
     end
 
     it "updates the administrator's password" do


### PR DESCRIPTION
# Description

On modifie la façon dont les administrateur·rices peuvent modifier leur propre compte, sur l'URL `/admin/account`.

1. Prénom : modifiable
2. Nom : modifiable
3. Email : non modifiable
4. Photo : modifiable
5. Rôles : non modifiable, affichage conditionnel
6. Autorité d'emploi : non modifiable, affichage conditionnel
7. Chaîne d'emploi : non modifiable, affichage conditionnel
8. Fonction : non modifiable
9. Mot de passe actuel : modifiable
10. Mot de passe : modifiable
11. Confirmation du mot de passe : modifiable

Pour "Autorité d'emploi : ACE / ATE", j'ai pris le parti de les afficher sous forme de checkbox plutôt que d'input texte. En effet, sous forme d'input texte, si ACE et ATE sont faux, il n'y a pas de valeur à afficher dans l'input, ce qui me semble peu clair pour l'utilisateur·rice.

# Review app

https://erecrutement-cvd-staging-pr2029.osc-fr1.scalingo.io

# Links

Closes #1929

# Screenshots

<img width="1689" height="1372" alt="image" src="https://github.com/user-attachments/assets/2461efff-17e8-4817-abc2-bd7c707de651" />
