### PR TITLE
Allow functional admin to edit their own information

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -68,12 +68,13 @@ class Admin::AccountsController < Admin::BaseController
       :current_password,
       :password,
       :password_confirmation,
-      :email
+      :email,
+      :title
     )
     if @administrator.functional_administrator?
       admin_params
     else
-      admin_params.except(:email)
+      admin_params.except(:email, :title)
     end
   end
 

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -61,14 +61,20 @@ class Admin::AccountsController < Admin::BaseController
   end
 
   def administrator_params
-    params.require(:administrator).permit(
+    admin_params = params.require(:administrator).permit(
       :first_name,
       :last_name,
       :photo,
       :current_password,
       :password,
-      :password_confirmation
+      :password_confirmation,
+      :email
     )
+    if @administrator.functional_administrator?
+      admin_params
+    else
+      admin_params.except(:email)
+    end
   end
 
   def administrator_params_without_password

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -21,18 +21,18 @@
           .col-12.col-md-6
             = f.input :photo
 
-        .row
-          .col-12.col-md-6
-            = f.input :roles, as: :string, required: true, disabled: true, input_html: {value: @administrator.roles.map { |role| I18n.t("activerecord.attributes.administrator/roles.#{role}") }.join(', ')}
-          - if @administrator.employment_authority?
-            .col-12.col-md-6
-              %label
-                = t('simple_form.labels.administrator.ace_ate')
-              .d-flex
-                = f.input :ace, disabled: true, wrapper_html: {class: 'mr-3'}
-                = f.input :ate, disabled: true
-
         - unless @administrator.functional_administrator?
+          .row
+            .col-12.col-md-6
+              = f.input :roles, as: :string, required: true, disabled: true, input_html: {value: @administrator.roles.map { |role| I18n.t("activerecord.attributes.administrator/roles.#{role}") }.join(', ')}
+            - if @administrator.employment_authority?
+              .col-12.col-md-6
+                %label
+                  = t('simple_form.labels.administrator.ace_ate')
+                .d-flex
+                  = f.input :ace, disabled: true, wrapper_html: {class: 'mr-3'}
+                  = f.input :ate, disabled: true
+
           .row
             .col-12.col-md-6
               = f.input :employers, as: :string, required: true, disabled: true, input_html: {value: @administrator.employers.pluck(:code).join(', ')}

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -39,7 +39,7 @@
 
         .row
           .col-12.col-md-6
-            = f.input :title, placeholder: false, disabled: true
+            = f.input :title, placeholder: false, disabled: !@administrator.functional_administrator?
 
         .row
           .col-12.col-md-6

--- a/app/views/admin/accounts/_form_administrator.html.haml
+++ b/app/views/admin/accounts/_form_administrator.html.haml
@@ -15,7 +15,7 @@
 
         .row
           .col-12.col-md-6
-            = f.input :email, placeholder: false, disabled: true
+            = f.input :email, placeholder: false, disabled: !@administrator.functional_administrator?
 
         .row
           .col-12.col-md-6

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -45,12 +45,14 @@ RSpec.describe Admin::AccountsController do
           first_name:,
           current_password: attributes_for(:administrator)[:password],
           password: new_password,
-          password_confirmation: new_password
+          password_confirmation: new_password,
+          email: email
         }
       }
     end
     let(:first_name) { "Sebastien" }
     let(:new_password) { "A perflectly plausible password 1234!" }
+    let(:email) { "new_email@example.com" }
 
     it "redirects to admin_account_path" do
       expect(update_request).to redirect_to(admin_account_path)
@@ -68,6 +70,18 @@ RSpec.describe Admin::AccountsController do
       allow_any_instance_of(Administrator).to receive(:update).and_return(false)
 
       expect(update_request).to render_template(:show)
+    end
+
+    describe "email update" do
+      context "when the admin is functional administrator" do
+        it { expect { update_request }.to change { administrator.reload.unconfirmed_email }.to(email) }
+      end
+
+      context "when the admin is not functional administrator" do
+        before { administrator.update!(roles: [:payroll_manager]) }
+
+        it { expect { update_request }.not_to change { administrator.reload.unconfirmed_email } }
+      end
     end
   end
 end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -46,13 +46,15 @@ RSpec.describe Admin::AccountsController do
           current_password: attributes_for(:administrator)[:password],
           password: new_password,
           password_confirmation: new_password,
-          email: email
+          email:,
+          title:
         }
       }
     end
     let(:first_name) { "Sebastien" }
     let(:new_password) { "A perflectly plausible password 1234!" }
     let(:email) { "new_email@example.com" }
+    let(:title) { "Functional Administrator" }
 
     it "redirects to admin_account_path" do
       expect(update_request).to redirect_to(admin_account_path)
@@ -81,6 +83,18 @@ RSpec.describe Admin::AccountsController do
         before { administrator.update!(roles: [:payroll_manager]) }
 
         it { expect { update_request }.not_to change { administrator.reload.unconfirmed_email } }
+      end
+    end
+
+    describe "title update" do
+      context "when the admin is functional administrator" do
+        it { expect { update_request }.to change { administrator.reload.title }.to(title) }
+      end
+
+      context "when the admin is not functional administrator" do
+        before { administrator.update!(roles: [:payroll_manager]) }
+
+        it { expect { update_request }.not_to change { administrator.reload.title } }
       end
     end
   end


### PR DESCRIPTION
# Description

Dans cette PR on permet à l'administrateur fonctionnel de modifier ses propres informations, en particulier : 
- son adresse email
- sa fonction

On retire également le champ "Rôles", conformément à #1928.

# Review app

https://erecrutement-cvd-staging-pr2031.osc-fr1.scalingo.io

# Links

Closes #2030 
Related to #1928 
Related to #1929

# Screenshots

<img width="1699" height="1312" alt="CleanShot 2025-11-24 at 08 48 59" src="https://github.com/user-attachments/assets/a1cf6a63-3c27-47cc-b2a7-a77f73c27eac" />

