### PR TITLE
Update JobApplicationFileType

### DIFF
--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -6,6 +6,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
   protected
 
   def permitted_fields
-    %i[name description kind content from_state to_state required notification]
+    %i[name description kind content from_state to_state required required_from_state required_to_state notification]
   end
 end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -6,6 +6,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
   protected
 
   def permitted_fields
-    %i[name description kind content from_state to_state by_default notification]
+    %i[name description kind content from_state to_state required by_default notification]
   end
 end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -6,6 +6,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
   protected
 
   def permitted_fields
-    %i[name description kind content from_state by_default notification]
+    %i[name description kind content from_state to_state by_default notification]
   end
 end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -6,6 +6,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
   protected
 
   def permitted_fields
-    %i[name description kind content from_state by_default notification spontaneous]
+    %i[name description kind content from_state by_default notification]
   end
 end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -6,6 +6,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
   protected
 
   def permitted_fields
-    %i[name description kind content from_state to_state required by_default notification]
+    %i[name description kind content from_state to_state required notification]
   end
 end

--- a/app/helpers/admin/job_applications_helper.rb
+++ b/app/helpers/admin/job_applications_helper.rb
@@ -68,7 +68,7 @@ module Admin::JobApplicationsHelper
     return unless job_application
 
     target_state = JobApplication.states["initial"]
-    target_file_type = JobApplicationFileType.where(by_default: true, from_state: target_state, kind: :applicant_provided)
+    target_file_type = JobApplicationFileType.where(from_state: target_state, kind: :applicant_provided)
     job_application_files = job_application.job_application_files.where(job_application_file_type: target_file_type).joins(:job_application_file_type).order("job_application_file_types.position")
     job_application_file = job_application_files.limit(1).first
     if job_application_file&.document_content&.present?

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -85,6 +85,9 @@ application.register("subcheckbox", SubcheckboxController)
 import TimeoutableController from "./timeoutable_controller"
 application.register("timeoutable", TimeoutableController)
 
+import ToggleVisibilityController from "./toggle_visibility_controller"
+application.register("toggle-visibility", ToggleVisibilityController)
+
 import TrixEditorController from "./trix_editor_controller"
 application.register("trix-editor", TrixEditorController)
 

--- a/app/javascript/controllers/toggle_visibility_controller.js
+++ b/app/javascript/controllers/toggle_visibility_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["radioWrapper", "toggleable"];
+
+  connect() {
+    this.toggle();
+  }
+
+  toggle() {
+    if (this.isChecked()) {
+      this.showToggleable();
+    } else {
+      this.hideToggleable();
+    }
+  }
+
+  // private
+
+  isChecked() {
+    return (
+      this.radioWrapperTarget.querySelector("input:checked").value === "true"
+    );
+  }
+
+  showToggleable() {
+    for (let toggleable of this.toggleableTargets) {
+      toggleable.classList.remove("d-none");
+    }
+  }
+
+  hideToggleable() {
+    for (let toggleable of this.toggleableTargets) {
+      toggleable.classList.add("d-none");
+    }
+  }
+}

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -197,6 +197,18 @@ class Administrator < ApplicationRecord
     self.marked_for_deactivation_on = nil
   end
 
+  def can_upload?(job_application_file_type)
+    if functional_administrator?
+      true
+    elsif (hr_manager? || payroll_manager?) && job_application_file_type.manager_provided?
+      true
+    elsif employer_recruiter? && job_application_file_type.employer_provided?
+      true
+    else
+      false
+    end
+  end
+
   private
 
   def set_first_name = self.first_name = first_name_from(email)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -246,7 +246,7 @@ class JobApplication < ApplicationRecord
 
       if existing_file
         result[:must_be_provided_files] << existing_file
-      elsif (current_state_as_val >= from_state_as_val) && file_type.by_default
+      elsif current_state_as_val >= from_state_as_val
         virgin = job_application_files.build(job_application_file_type: file_type)
         result[:must_be_provided_files] << virgin
       else
@@ -321,7 +321,7 @@ class JobApplication < ApplicationRecord
   def complete_files_before_draft_contract
     return if state.to_s != "contract_drafting"
 
-    default_types = JobApplicationFileType.by_default(:accepted).pluck(:id)
+    default_types = JobApplicationFileType.for_applicant(:accepted).pluck(:id)
     validated_types = job_application_files.where(is_validated: true).pluck(:job_application_file_type_id)
 
     return if (default_types - validated_types).blank?

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -88,7 +88,7 @@ class JobApplication < ApplicationRecord
     initial: 0,
     phone_meeting: 2,
     to_be_met: 5,
-    financial_estimate: 12,
+    financial_estimate: 6,
     accepted: 7,
     contract_drafting: 8,
     contract_feedback_waiting: 9,

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -14,6 +14,8 @@ class JobApplicationFile < ApplicationRecord
   validates :content, presence: true, unless: proc { |file| file.do_not_provide_immediately }
   validates :job_application_file_type_id, uniqueness: {scope: :job_application_id} # rubocop:disable Rails/UniqueValidationWithoutIndex
 
+  delegate :state, to: :job_application, prefix: true
+
   before_validation do
     if job_application_file_existing_id
       existing = JobApplicationFile.find_by(id: job_application_file_existing_id)
@@ -40,6 +42,12 @@ class JobApplicationFile < ApplicationRecord
   def waiting_validation?
     is_validated == 0
   end
+
+  def downloadable? = job_application_state < max_downloadable_state
+
+  private
+
+  def max_downloadable_state = job_application_file_type.required_to_state
 end
 
 # == Schema Information

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -64,6 +64,7 @@ end
 #  notification      :boolean          default(TRUE)
 #  position          :integer
 #  to_state          :integer          default("affected")
+#  required          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -13,7 +13,7 @@ class JobApplicationFileType < ApplicationRecord
   #####################################
   # Validations
 
-  validates :name, :kind, :from_state, presence: true
+  validates :name, :kind, :from_state, :to_state, presence: true
 
   #####################################
   # Enums
@@ -25,10 +25,12 @@ class JobApplicationFileType < ApplicationRecord
   }
 
   enum from_state: JobApplication.states
+  enum to_state: JobApplication.states, _prefix: true
 
-  scope :by_default_before, ->(state) {
+  scope :for_states_around, ->(state) {
     where(by_default: true, kind: :applicant_provided)
       .where("from_state <= ?", JobApplication.states[state])
+      .where("to_state > ?", JobApplication.states[state])
   }
 
   scope :by_default, ->(state) {
@@ -61,6 +63,7 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
+#  to_state          :integer          default("affected")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -14,6 +14,7 @@ class JobApplicationFileType < ApplicationRecord
   # Validations
 
   validates :name, :kind, :from_state, :to_state, presence: true
+  validates :required_from_state, :required_to_state, if: -> { required? }, presence: true
 
   #####################################
   # Enums
@@ -26,6 +27,8 @@ class JobApplicationFileType < ApplicationRecord
 
   enum from_state: JobApplication.states
   enum to_state: JobApplication.states, _prefix: true
+  enum required_from_state: JobApplication.states, _prefix: true
+  enum required_to_state: JobApplication.states, _prefix: true
 
   scope :for_states_around, ->(state) {
     where(kind: :applicant_provided)
@@ -34,6 +37,11 @@ class JobApplicationFileType < ApplicationRecord
   }
 
   scope :for_applicant, ->(state) { where(kind: :applicant_provided, from_state: JobApplication.states[state]) }
+  scope :required, ->(state) {
+    where(required: true)
+      .where("required_from_state < ?", JobApplication.states[state])
+      .where("required_to_state > ?", JobApplication.states[state])
+  }
 
   #####################################
   # Relations
@@ -51,16 +59,18 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                :uuid             not null, primary key
-#  content_file_name :string
-#  description       :string
-#  from_state        :integer
-#  kind              :integer
-#  name              :string
-#  notification      :boolean          default(TRUE)
-#  position          :integer
-#  to_state          :integer          default("affected")
-#  required          :boolean          default(FALSE), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id                  :uuid             not null, primary key
+#  content_file_name   :string
+#  description         :string
+#  from_state          :integer
+#  kind                :integer
+#  name                :string
+#  notification        :boolean          default(TRUE)
+#  position            :integer
+#  required            :boolean          default(FALSE), not null
+#  required_from_state :integer          default(0)
+#  required_to_state   :integer          default(11)
+#  to_state            :integer          default("affected")
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -63,7 +63,6 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
-#  spontaneous       :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -21,23 +21,19 @@ class JobApplicationFileType < ApplicationRecord
     applicant_provided: 10,
     manager_provided: 11,
     employer_provided: 12,
-    template: 20,
-    admin_only: 30,
     check_only_admin_only: 40
   }
 
   enum from_state: JobApplication.states
 
   scope :by_default_before, ->(state) {
-    where(
-      by_default: true, kind: %i[applicant_provided template]
-    ).where("from_state <= ?", JobApplication.states[state])
+    where(by_default: true, kind: :applicant_provided)
+      .where("from_state <= ?", JobApplication.states[state])
   }
 
   scope :by_default, ->(state) {
-    where(
-      by_default: true, kind: %i[applicant_provided template]
-    ).where(from_state: JobApplication.states[state])
+    where(by_default: true, kind: :applicant_provided)
+      .where(from_state: JobApplication.states[state])
   }
 
   #####################################

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -39,7 +39,7 @@ class JobApplicationFileType < ApplicationRecord
   scope :for_applicant, ->(state) { where(kind: :applicant_provided, from_state: JobApplication.states[state]) }
   scope :required, ->(state) {
     where(required: true)
-      .where("required_from_state < ?", JobApplication.states[state])
+      .where("required_from_state <= ?", JobApplication.states[state])
       .where("required_to_state > ?", JobApplication.states[state])
   }
 

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -28,15 +28,12 @@ class JobApplicationFileType < ApplicationRecord
   enum to_state: JobApplication.states, _prefix: true
 
   scope :for_states_around, ->(state) {
-    where(by_default: true, kind: :applicant_provided)
+    where(kind: :applicant_provided)
       .where("from_state <= ?", JobApplication.states[state])
       .where("to_state > ?", JobApplication.states[state])
   }
 
-  scope :by_default, ->(state) {
-    where(by_default: true, kind: :applicant_provided)
-      .where(from_state: JobApplication.states[state])
-  }
+  scope :for_applicant, ->(state) { where(kind: :applicant_provided, from_state: JobApplication.states[state]) }
 
   #####################################
   # Relations
@@ -55,7 +52,6 @@ end
 # Table name: job_application_file_types
 #
 #  id                :uuid             not null, primary key
-#  by_default        :boolean          default(FALSE)
 #  content_file_name :string
 #  description       :string
 #  from_state        :integer

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -19,6 +19,8 @@ class JobApplicationFileType < ApplicationRecord
   # Enums
   enum kind: {
     applicant_provided: 10,
+    manager_provided: 11,
+    employer_provided: 12,
     template: 20,
     admin_only: 30,
     check_only_admin_only: 40

--- a/app/tasks/maintenance/migrate_job_application_file_type_kinds_task.rb
+++ b/app/tasks/maintenance/migrate_job_application_file_type_kinds_task.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateJobApplicationFileTypeKindsTask < MaintenanceTasks::Task
+    JAFT = {
+      "822c87f5-096c-4805-a344-26fa4a7c1a06" => :employer_provided, # "Fiche d'agrément", "admin_only"
+      "249cf8e5-34c9-4210-8697-24f8166d18d1" => :employer_provided, # "Proposition salariale à signer par le candidat", "template"
+      "36aa90ee-3431-4eff-bd0d-f7ab3b9400bf" => :employer_provided, # "Arrêté du 4 mai 1988", "template"
+      "14af7c55-ffdb-4a6e-89b2-532def672405" => :employer_provided, # "Guide ICT/TCT", "template"
+      "c316a36c-8579-479f-b01b-f8bfd774b94a" => :employer_provided, # "Fiche de poste", "admin_only"
+      "4088a171-ffe3-40d2-a013-4c1781d64268" => :manager_provided, # "Contrat", "template"
+      "46769401-af7e-42a4-b657-389c487b1dc9" => :applicant_provided, # "Arrêté de détachement de l'administration d'origine", "template"
+      "d22929e0-0da4-4846-a79a-d11f1797df99" => :manager_provided # "Formulaire \"Prise en charge transport\" à compléter", "template"
+    }
+    def collection = JobApplicationFileType.where(id: JAFT.keys)
+
+    def process(element) = element.update!(kind: JAFT[element.id])
+  end
+end

--- a/app/views/account/job_application_files/_file_name_template.html.haml
+++ b/app/views/account/job_application_files/_file_name_template.html.haml
@@ -1,3 +1,0 @@
-.rf-mb-3w
-  %h3= job_application_file.job_application_file_type.name
-  = link_to "Télécharger le fichier", [:account, job_application, job_application_file, {format: :pdf}], target: '_blank'

--- a/app/views/account/job_application_files/index.html.haml
+++ b/app/views/account/job_application_files/index.html.haml
@@ -1,5 +1,5 @@
 - job_application_files = @job_application.job_application_files.to_a
-- job_application_file_types = JobApplicationFileType.by_default_before(@job_application.state)
+- job_application_file_types = JobApplicationFileType.for_states_around(@job_application.state)
 - job_application_file_types.each do |job_application_file_type|
   - job_application_file = job_application_files.detect { |x| x.job_application_file_type == job_application_file_type }
   - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)

--- a/app/views/account/job_application_files/index.html.haml
+++ b/app/views/account/job_application_files/index.html.haml
@@ -3,8 +3,4 @@
 - job_application_file_types.each do |job_application_file_type|
   - job_application_file = job_application_files.detect { |x| x.job_application_file_type == job_application_file_type }
   - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)
-  - if job_application_file_type.kind == "template"
-    - if !job_application_file.new_record?
-      = render partial: 'file_name_template', locals: {job_application_file: job_application_file, job_application: @job_application}
-  - else
-    = render partial: 'file_name_upload', locals: {job_application_file: job_application_file, job_application: @job_application}
+  = render partial: 'file_name_upload', locals: {job_application_file: job_application_file, job_application: @job_application}

--- a/app/views/admin/inherited_resources/_element.html.haml
+++ b/app/views/admin/inherited_resources/_element.html.haml
@@ -10,6 +10,8 @@
     %td
       = JobApplication.human_attribute_name("state/#{element.from_state}")
     %td
+      = JobApplication.human_attribute_name("state/#{element.to_state}")
+    %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
     %td
       = element.by_default? ? t('.affirmative') : t('.negative')

--- a/app/views/admin/inherited_resources/_element.html.haml
+++ b/app/views/admin/inherited_resources/_element.html.haml
@@ -13,8 +13,6 @@
       = JobApplication.human_attribute_name("state/#{element.to_state}")
     %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
-    %td
-      = element.by_default? ? t('.affirmative') : t('.negative')
   - if resource_class.reflect_on_association(:job_offers)
     %td.text-center
       = element.job_offers.publicly_visible.count

--- a/app/views/admin/inherited_resources/index.html.haml
+++ b/app/views/admin/inherited_resources/index.html.haml
@@ -18,7 +18,6 @@
             %th= resource_class.human_attribute_name(:from_state)
             %th= resource_class.human_attribute_name(:to_state)
             %th= resource_class.human_attribute_name(:kind)
-            %th= resource_class.human_attribute_name(:by_default)
           - if resource_class == Employer
             %th= resource_class.human_attribute_name(:code)
           - if resource_class.reflect_on_association(:job_offers)

--- a/app/views/admin/inherited_resources/index.html.haml
+++ b/app/views/admin/inherited_resources/index.html.haml
@@ -16,6 +16,7 @@
           %th= resource_class.human_attribute_name(:name)
           - if resource_class == JobApplicationFileType
             %th= resource_class.human_attribute_name(:from_state)
+            %th= resource_class.human_attribute_name(:to_state)
             %th= resource_class.human_attribute_name(:kind)
             %th= resource_class.human_attribute_name(:by_default)
           - if resource_class == Employer

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -1,10 +1,6 @@
 - file = job_application_file
 - type = file.job_application_file_type
 - job_application = file.job_application
-- # binding.pry if type.name == "CV"
-- # binding.pry if type.name == "Carte "
-- # binding.pry if type.name == "Pièce facultatif"
-- # binding.pry if type.name == "Bulletins paie "
 .d-flex.align-items-center.border.py-1.px-2.file{id: dom_id(file)}
   - if file.document_content.present?
     .text-truncate= type.name

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -40,8 +40,9 @@
       = link_to [:uncheck, :admin, @job_application, file], class: klasses, title: t('.uncheck'), remote: true, method: :post do
         = fa_icon "xmark"
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}
-      - url = [:admin, job_application, file, {format: :pdf}]
-      = link_to t('.download'), url, target: "_blank", class: "btn btn-primary btn-raised btn-sm mb-0"
+      - if file.downloadable?
+        - url = [:admin, job_application, file, {format: :pdf}]
+        = link_to t('.download'), url, target: "_blank", class: "btn btn-primary btn-raised btn-sm mb-0"
     - elsif file.persisted?
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}
       - url = [:admin, job_application, file]

--- a/app/views/admin/job_application_files/_job_application_file_upload.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file_upload.html.haml
@@ -1,5 +1,6 @@
-= form_for [:admin, job_application, job_application_file], namespace: file_type.name.parameterize, remote: true, html: {class: 'edit_job_application_file auto-submit'} do |form|
-  = form.label :content, fa_icon('arrow-up'), class: 'btn btn-raised btn-sm mb-0 mr-1', title: t('.help')
-  = form.file_field :content
-  - if job_application_file.new_record?
-    = form.hidden_field :job_application_file_type_id
+- if current_administrator.can_upload?(file_type)
+  = form_for [:admin, job_application, job_application_file], namespace: file_type.name.parameterize, remote: true, html: {class: 'edit_job_application_file auto-submit'} do |form|
+    = form.label :content, fa_icon('arrow-up'), class: 'btn btn-raised btn-sm mb-0 mr-1', title: t('.help')
+    = form.file_field :content
+    - if job_application_file.new_record?
+      = form.hidden_field :job_application_file_type_id

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -1,5 +1,5 @@
 - target_state = JobApplication.states["initial"]
-- target_file_type = JobApplicationFileType.where(by_default: true, from_state: target_state, kind: :applicant_provided)
+- target_file_type = JobApplicationFileType.where(from_state: target_state, kind: :applicant_provided)
 - job_application_files = job_application.job_application_files.where(job_application_file_type: target_file_type).joins(:job_application_file_type).order('job_application_file_types.position')
 - job_application_files = job_application_files.limit(1) if defined?(only_first) && only_first
 
@@ -35,4 +35,3 @@
       .card-subheader.bg-secondary
       %div
         %object{data: pdf_url, type: "application/pdf", width: "100%", height: "500px"}
-

--- a/app/views/admin/settings/inherited_resources/_element.html.haml
+++ b/app/views/admin/settings/inherited_resources/_element.html.haml
@@ -23,6 +23,8 @@
     %td
       = JobApplication.human_attribute_name("state/#{element.from_state}")
     %td
+      = JobApplication.human_attribute_name("state/#{element.to_state}")
+    %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
     %td
       = element.by_default? ? t('.affirmative') : t('.negative')

--- a/app/views/admin/settings/inherited_resources/_element.html.haml
+++ b/app/views/admin/settings/inherited_resources/_element.html.haml
@@ -27,7 +27,7 @@
     %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
     %td
-      = element.by_default? ? t('.affirmative') : t('.negative')
+      = element.required? ? t('.affirmative') : t('.negative')
   - elsif resource_class == OrganizationDefault
     %td
       = OrganizationDefault.human_attribute_name("kind/#{element.kind}")

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -15,7 +15,6 @@
           = f.input :from_state, collection: states, prompt: true
           = f.input :to_state, collection: states, prompt: true
           = f.input :required, as: :radio_buttons
-          = f.input :by_default
           = f.input :notification
         - elsif resource.is_a?(Cmg)
           = f.input :email

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -13,6 +13,7 @@
           = f.input :content
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
           = f.input :from_state, collection: states, prompt: true
+          = f.input :to_state, collection: states, prompt: true
           = f.input :by_default
           = f.input :notification
         - elsif resource.is_a?(Cmg)

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -15,7 +15,6 @@
           = f.input :from_state, collection: states, prompt: true
           = f.input :by_default
           = f.input :notification
-          = f.input :spontaneous, as: :boolean
         - elsif resource.is_a?(Cmg)
           = f.input :email
         - elsif resource.is_a?(EmailTemplate)

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -14,6 +14,7 @@
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
           = f.input :from_state, collection: states, prompt: true
           = f.input :to_state, collection: states, prompt: true
+          = f.input :required, as: :radio_buttons
           = f.input :by_default
           = f.input :notification
         - elsif resource.is_a?(Cmg)

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -1,7 +1,7 @@
 - resource.parent_id = params[:parent_id] if params[:parent_id].present? && resource.new_record?
 .card
   .card-body
-    = simple_form_for([:admin, :settings, resource]) do |f|
+    = simple_form_for([:admin, :settings, resource], html: { data: {controller: "toggle-visibility" } }) do |f|
       = f.error_notification
       = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
       .form-inputs
@@ -14,7 +14,9 @@
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
           = f.input :from_state, collection: states, prompt: true
           = f.input :to_state, collection: states, prompt: true
-          = f.input :required, as: :radio_buttons
+          = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
+          = f.input :required_from_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
+          = f.input :required_to_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           = f.input :notification
         - elsif resource.is_a?(Cmg)
           = f.input :email

--- a/app/views/admin/settings/inherited_resources/_table.html.haml
+++ b/app/views/admin/settings/inherited_resources/_table.html.haml
@@ -14,7 +14,7 @@
           %th= resource_class.human_attribute_name(:from_state)
           %th= resource_class.human_attribute_name(:to_state)
           %th= resource_class.human_attribute_name(:kind)
-          %th= resource_class.human_attribute_name(:by_default)
+          %th= resource_class.human_attribute_name(:required)
         - if resource_class == Employer
           %th= resource_class.human_attribute_name(:code)
         - if resource_class == StudyLevel

--- a/app/views/admin/settings/inherited_resources/_table.html.haml
+++ b/app/views/admin/settings/inherited_resources/_table.html.haml
@@ -12,6 +12,7 @@
         %th= resource_class.human_attribute_name(:name)
         - if resource_class == JobApplicationFileType
           %th= resource_class.human_attribute_name(:from_state)
+          %th= resource_class.human_attribute_name(:to_state)
           %th= resource_class.human_attribute_name(:kind)
           %th= resource_class.human_attribute_name(:by_default)
         - if resource_class == Employer

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -50,7 +50,7 @@
     - if @job_offer.spontaneous
       - job_application_file_types = JobApplicationFileType.where(spontaneous: true)
     - else
-      - job_application_file_types = JobApplicationFileType.where(by_default: true).where("from_state <= ?", current_state).where(kind: %i(applicant_provided template)).all
+      - job_application_file_types = JobApplicationFileType.where("from_state <= ?", current_state).where(kind: :applicant_provided).all
     - job_application_file_types.each do |job_application_file_type, index|
       - job_application_file = job_application_files.detect{|x| x.job_application_file_type == job_application_file_type}
       - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1161,7 +1161,7 @@ fr:
               cant_accept_before_delay: "Un délai de 30 jours après la publication de l'offre sur CSP doit être respecté avant d'accepter une candidature"
               cant_accept_remaining_initial_job_applications: "Toutes les nouvelles candidatures doivent être traitées avant d'accepter une candidature"
               complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
-              required_files_missing: "Des documents obligatoires sont manquants"
+              required_files_missing: "Des documents obligatoires sont manquants ou non validés"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
               cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1247,6 +1247,8 @@ fr:
         kind: "Type"
         by_default: "Par défaut"
         kind/applicant_provided: "Fourni par le candidat"
+        kind/manager_provided: "Fourni par le gestionnaire"
+        kind/employer_provided: "Fourni par l'employeur"
         kind/template: "Modèle de fichiers"
         kind/admin_only: "Seulement admin"
         kind/check_only_admin_only: "Fichier géré hors outil"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1243,7 +1243,8 @@ fr:
         state/end_user_state_7: "Contrat reçu"
         state/end_user_state_8: "Affectée"
       job_application_file_type:
-        from_state: "État"
+        from_state: "État de début"
+        to_state: "État de fin"
         kind: "Type"
         by_default: "Par défaut"
         kind/applicant_provided: "Fourni par le candidat"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -354,7 +354,7 @@ fr:
         download: "Télécharger"
         do_not_ask: "Ne plus demander"
       job_application_file_upload:
-        help: "Téléverser un fichier à la place de l'utilisateur"
+        help: "Téléverser un fichier"
       uncheck:
         success: "Fichier invalidé !"
     rejections:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1245,6 +1245,7 @@ fr:
       job_application_file_type:
         from_state: "État de début"
         to_state: "État de fin"
+        required: "Obligatoire"
         kind: "Type"
         by_default: "Par défaut"
         kind/applicant_provided: "Fourni par le candidat"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -849,9 +849,9 @@ fr:
             one: "1 type de fichier"
             other: "%{count} types de fichier"
         new:
-          title: "Ajouter un nouveau type de fichier"
+          title: "Paramétrage du fichier"
         edit:
-          title: "Modifier le type de fichier '%{name}'"
+          title: "Paramétrage du fichier '%{name}'"
         create:
           success: "Type de fichier créé !"
         update:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1249,8 +1249,6 @@ fr:
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"
         kind/employer_provided: "Fourni par l'employeur"
-        kind/template: "Modèle de fichiers"
-        kind/admin_only: "Seulement admin"
         kind/check_only_admin_only: "Fichier géré hors outil"
       job_offer:
         title: "Intitulé du poste"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1247,7 +1247,6 @@ fr:
         to_state: "État de fin"
         required: "Obligatoire"
         kind: "Type"
-        by_default: "Par défaut"
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"
         kind/employer_provided: "Fourni par l'employeur"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1161,6 +1161,7 @@ fr:
               cant_accept_before_delay: "Un délai de 30 jours après la publication de l'offre sur CSP doit être respecté avant d'accepter une candidature"
               cant_accept_remaining_initial_job_applications: "Toutes les nouvelles candidatures doivent être traitées avant d'accepter une candidature"
               complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
+              required_files_missing: "Des documents obligatoires sont manquants"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
               cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
@@ -1246,6 +1247,8 @@ fr:
         from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"
+        required_from_state: "Obligatoire à partir de l'état"
+        required_to_state: "Plus obligatoire à partir de l'état"
         kind: "Type"
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -64,7 +64,6 @@ fr:
         foreign_language_level: Niveau de langue étrangère
         category_html: "<span>Domaine professionnel <abbr title='obligatoire'>*</abbr></span>"
         level: "Categorie / Niveau de l'offre"
-        spontaneous: "Candidature spontanée"
         job_applications_count: "Candidatures"
       administrator:
         current_password: "Mot de passe actuel"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -102,7 +102,6 @@ fr:
         from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"
-        by_default: "Visible dès que l'état défini précédemment est atteint ?"
       job_offer:
         title: "Intitulé du poste"
         professional_category: "Catégorie professionnelle"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -246,6 +246,9 @@ fr:
         resume: "Format PDF, max. 2Mo"
         cover_letter: "Format PDF, max. 2Mo"
         website_url: "LinkedIn, Viadeo, portfolio, etc."
+      job_application_file_type:
+        from_state: "État à partir duquel le fichier sera visible"
+        to_state: "État à partir duquel le fichier ne sera plus visible"
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"
         days_before_publishing: "Indiquez un nombre de jours ouvrés. Laissez à 0 ou vide pour supprimer complètement le délai avant publication"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -102,6 +102,8 @@ fr:
         from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"
+        required_from_state: "Obligatoire à partir de l'état"
+        required_to_state: "Plus obligatoire à partir de l'état"
       job_offer:
         title: "Intitulé du poste"
         professional_category: "Catégorie professionnelle"
@@ -248,6 +250,8 @@ fr:
       job_application_file_type:
         from_state: "État à partir duquel le fichier sera visible"
         to_state: "État à partir duquel le fichier ne sera plus visible"
+        required_from_state: "Si le fichier n’est pas inséré, vous ne pourrez pas faire passer le candidat à l'étape suivante"
+        required_to_state: "Le fichier ne sera plus visible"
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"
         days_before_publishing: "Indiquez un nombre de jours ouvrés. Laissez à 0 ou vide pour supprimer complètement le délai avant publication"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -100,7 +100,7 @@ fr:
       job_application_file_type:
         kind: "Type"
         content: "Fichier"
-        from_state: "État à partir duquel ce type de fichier est visible"
+        from_state: "État de début"
         by_default: "Visible dès que l'état défini précédemment est atteint ?"
       job_offer:
         title: "Intitulé du poste"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -101,6 +101,7 @@ fr:
         content: "Fichier"
         from_state: "État de début"
         to_state: "État de fin"
+        required: "Obligatoire"
         by_default: "Visible dès que l'état défini précédemment est atteint ?"
       job_offer:
         title: "Intitulé du poste"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -100,6 +100,7 @@ fr:
         kind: "Type"
         content: "Fichier"
         from_state: "État de début"
+        to_state: "État de fin"
         by_default: "Visible dès que l'état défini précédemment est atteint ?"
       job_offer:
         title: "Intitulé du poste"

--- a/db/migrate/20251201074929_remove_spontaneous_from_job_application_file_type.rb
+++ b/db/migrate/20251201074929_remove_spontaneous_from_job_application_file_type.rb
@@ -1,0 +1,5 @@
+class RemoveSpontaneousFromJobApplicationFileType < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :job_application_file_types, :spontaneous, :boolean, null: false
+  end
+end

--- a/db/migrate/20251218071752_add_to_state_to_job_application_file_types.rb
+++ b/db/migrate/20251218071752_add_to_state_to_job_application_file_types.rb
@@ -1,0 +1,3 @@
+class AddToStateToJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change = add_column :job_application_file_types, :to_state, :integer, default: 11 # affected
+end

--- a/db/migrate/20251222074506_add_required_to_job_application_file_types.rb
+++ b/db/migrate/20251222074506_add_required_to_job_application_file_types.rb
@@ -1,0 +1,3 @@
+class AddRequiredToJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change = add_column :job_application_file_types, :required, :boolean, null: false, default: false
+end

--- a/db/migrate/20251226081020_remove_by_default_from_job_application_file_types.rb
+++ b/db/migrate/20251226081020_remove_by_default_from_job_application_file_types.rb
@@ -1,0 +1,3 @@
+class RemoveByDefaultFromJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change = remove_column :job_application_file_types, :by_default, :boolean, default: false
+end

--- a/db/migrate/20251226084435_add_required_from_state_and_required_to_state_to_job_application_file_types.rb
+++ b/db/migrate/20251226084435_add_required_from_state_and_required_to_state_to_job_application_file_types.rb
@@ -1,0 +1,6 @@
+class AddRequiredFromStateAndRequiredToStateToJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :job_application_file_types, :required_from_state, :integer, default: 0 # initial
+    add_column :job_application_file_types, :required_to_state, :integer, default: 11 # affected
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_07_061120) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_01_074929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -377,7 +377,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_07_061120) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "from_state"
     t.boolean "notification", default: true
-    t.boolean "spontaneous", default: false
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_01_074929) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_18_071752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -377,6 +377,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_01_074929) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "from_state"
     t.boolean "notification", default: true
+    t.integer "to_state", default: 11
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_18_071752) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_22_074506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -378,6 +378,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_18_071752) do
     t.integer "from_state"
     t.boolean "notification", default: true
     t.integer "to_state", default: 11
+    t.boolean "required", default: false, null: false
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_26_081020) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_26_084435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -378,6 +378,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_26_081020) do
     t.boolean "notification", default: true
     t.integer "to_state", default: 11
     t.boolean "required", default: false, null: false
+    t.integer "required_from_state", default: 0
+    t.integer "required_to_state", default: 11
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_22_074506) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_26_081020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -371,7 +371,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_22_074506) do
     t.string "description"
     t.integer "kind"
     t.string "content_file_name"
-    t.boolean "by_default", default: false
     t.integer "position"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -353,30 +353,26 @@ cover_letter = JobApplicationFileType.create!(
   name: "Lettre de Motivation",
   kind: :applicant_provided,
   from_state: :initial,
-  to_state: :accepted,
-  by_default: true
+  to_state: :accepted
 )
 JobApplicationFileType.create!(
   name: "Copie des diplômes",
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_received,
-  by_default: true
+  to_state: :contract_received
 )
 JobApplicationFileType.create!(
   name: "Justificatif de domicile de moins de 6 mois",
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_received,
-  by_default: true
+  to_state: :contract_received
 )
 JobApplicationFileType.create!(
   name: "Carte d'identité",
   description: "Carte nationale d’identité recto/verso ou passeport",
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :affected,
-  by_default: true
+  to_state: :affected
 )
 description = "Attestation de carte vitale ou copie de carte vitale " \
   "(mentionnant le n° INSEE)"
@@ -385,8 +381,7 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_received,
-  by_default: true
+  to_state: :contract_received
 )
 description = "Certificat médical d’aptitude fourni par le médecin de l’établissement" \
   " ou à défaut par un médecin agréé"
@@ -395,8 +390,7 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_received,
-  by_default: true
+  to_state: :contract_received
 )
 description = "RIB original au format BIC/IBAN comportant le logo de la banque au nom du " \
   " signataire du contrat (les RIB sur compte épargne ne sont pas acceptés)"
@@ -405,16 +399,14 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :affected,
-  by_default: true
+  to_state: :affected
 )
 name = "Copie d'un titre de transport (si vous postulez en Île-de-france)"
 JobApplicationFileType.create!(
   name: name,
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_feedback_waiting,
-  by_default: true
+  to_state: :contract_feedback_waiting
 )
 description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant au moment " \
   "de la date d’effet du recrutement"
@@ -423,30 +415,26 @@ JobApplicationFileType.create!(
   description: description,
   kind: :manager_provided,
   from_state: :accepted,
-  to_state: :contract_feedback_waiting,
-  by_default: true
+  to_state: :contract_feedback_waiting
 )
 JobApplicationFileType.create!(
   name: "FICE transmis à officier sécurité",
   kind: :check_only_admin_only,
   from_state: :accepted,
-  to_state: :affected,
-  by_default: true
+  to_state: :affected
 )
 JobApplicationFileType.create!(
   name: "Demande de B2",
   kind: :check_only_admin_only,
   from_state: :accepted,
-  to_state: :affected,
-  by_default: true
+  to_state: :affected
 )
 JobApplicationFileType.create!(
   name: "Copie du livret de famille",
   description: "Seulement si marié",
   kind: :applicant_provided,
   from_state: :accepted,
-  to_state: :contract_feedback_waiting,
-  by_default: false
+  to_state: :contract_feedback_waiting
 )
 
 job_offer = JobOffer.new { |j|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -413,7 +413,7 @@ description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant 
 JobApplicationFileType.create!(
   name: "Fiche de poste",
   description: description,
-  kind: :admin_only,
+  kind: :manager_provided,
   from_state: :accepted,
   by_default: true
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -353,18 +353,21 @@ cover_letter = JobApplicationFileType.create!(
   name: "Lettre de Motivation",
   kind: :applicant_provided,
   from_state: :initial,
+  to_state: :accepted,
   by_default: true
 )
 JobApplicationFileType.create!(
   name: "Copie des diplômes",
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_received,
   by_default: true
 )
 JobApplicationFileType.create!(
   name: "Justificatif de domicile de moins de 6 mois",
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_received,
   by_default: true
 )
 JobApplicationFileType.create!(
@@ -372,6 +375,7 @@ JobApplicationFileType.create!(
   description: "Carte nationale d’identité recto/verso ou passeport",
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :affected,
   by_default: true
 )
 description = "Attestation de carte vitale ou copie de carte vitale " \
@@ -381,6 +385,7 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_received,
   by_default: true
 )
 description = "Certificat médical d’aptitude fourni par le médecin de l’établissement" \
@@ -390,6 +395,7 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_received,
   by_default: true
 )
 description = "RIB original au format BIC/IBAN comportant le logo de la banque au nom du " \
@@ -399,6 +405,7 @@ JobApplicationFileType.create!(
   description: description,
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :affected,
   by_default: true
 )
 name = "Copie d'un titre de transport (si vous postulez en Île-de-france)"
@@ -406,6 +413,7 @@ JobApplicationFileType.create!(
   name: name,
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_feedback_waiting,
   by_default: true
 )
 description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant au moment " \
@@ -415,18 +423,21 @@ JobApplicationFileType.create!(
   description: description,
   kind: :manager_provided,
   from_state: :accepted,
+  to_state: :contract_feedback_waiting,
   by_default: true
 )
 JobApplicationFileType.create!(
   name: "FICE transmis à officier sécurité",
   kind: :check_only_admin_only,
   from_state: :accepted,
+  to_state: :affected,
   by_default: true
 )
 JobApplicationFileType.create!(
   name: "Demande de B2",
   kind: :check_only_admin_only,
   from_state: :accepted,
+  to_state: :affected,
   by_default: true
 )
 JobApplicationFileType.create!(
@@ -434,6 +445,7 @@ JobApplicationFileType.create!(
   description: "Seulement si marié",
   kind: :applicant_provided,
   from_state: :accepted,
+  to_state: :contract_feedback_waiting,
   by_default: false
 )
 

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :job_application_file_type do
     name { "CV" }
     from_state { :initial }
+    to_state { :phone_meeting }
     kind { :applicant_provided }
     by_default { true }
   end
@@ -22,6 +23,7 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
+#  to_state          :integer          default("affected")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     from_state { :initial }
     to_state { :phone_meeting }
     kind { :applicant_provided }
-    by_default { true }
   end
 end
 
@@ -15,7 +14,6 @@ end
 # Table name: job_application_file_types
 #
 #  id                :uuid             not null, primary key
-#  by_default        :boolean          default(FALSE)
 #  content_file_name :string
 #  description       :string
 #  from_state        :integer

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -22,7 +22,6 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
-#  spontaneous       :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -24,6 +24,7 @@ end
 #  notification      :boolean          default(TRUE)
 #  position          :integer
 #  to_state          :integer          default("affected")
+#  required          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -13,16 +13,18 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                :uuid             not null, primary key
-#  content_file_name :string
-#  description       :string
-#  from_state        :integer
-#  kind              :integer
-#  name              :string
-#  notification      :boolean          default(TRUE)
-#  position          :integer
-#  to_state          :integer          default("affected")
-#  required          :boolean          default(FALSE), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id                  :uuid             not null, primary key
+#  content_file_name   :string
+#  description         :string
+#  from_state          :integer
+#  kind                :integer
+#  name                :string
+#  notification        :boolean          default(TRUE)
+#  position            :integer
+#  required            :boolean          default(FALSE), not null
+#  required_from_state :integer          default(0)
+#  required_to_state   :integer          default(11)
+#  to_state            :integer          default("affected")
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -318,6 +318,75 @@ RSpec.describe Administrator do
       it { expect { transfer }.not_to change { job_offer.reload.owner } }
     end
   end
+
+  describe "#can_upload?" do
+    subject(:can_upload?) { administrator.can_upload?(job_application_file_type) }
+
+    let(:administrator) { build(:administrator, roles: [role]) }
+    let(:job_application_file_type) { build(:job_application_file_type, kind:) }
+
+    context "when the administrator role is functional_adminitrator" do
+      let(:role) { :functional_administrator }
+      let(:kind) { :manager_provided }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the administrator role is hr_manager" do
+      let(:role) { :hr_manager }
+
+      context "when the job application file type is manager provided" do
+        let(:kind) { :manager_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is payroll_manager" do
+      let(:role) { :payroll_manager }
+
+      context "when the job application file type is manager provided" do
+        let(:kind) { :manager_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is employer_recruiter" do
+      let(:role) { :employer_recruiter }
+
+      context "when the job application file type is employer_provided" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :applicant_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is something else" do
+      let(:role) { :employment_authority }
+      let(:kind) { :manager_provided }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe JobApplicationFile do
+  describe "delegations" do
+    it { is_expected.to delegate_method(:state).to(:job_application).with_prefix(true) }
+  end
+
+  describe "#downloadable?" do
+    subject(:downloadable) { job_application_file.downloadable? }
+
+    let(:job_application_file) { build(:job_application_file, job_application:, job_application_file_type:) }
+    let(:job_application) { build(:job_application, state: current_state) }
+    let(:job_application_file_type) { build(:job_application_file_type, required_to_state: max_downloadable_state) }
+
+    context "when the current state is before the max downloadable state" do
+      let(:current_state) { :initial }
+      let(:max_downloadable_state) { :phone_meeting }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the current state is afterr the max downloadable state" do
+      let(:current_state) { :phone_meeting }
+      let(:max_downloadable_state) { :phone_meeting }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe JobApplicationFileType do
     it { is_expected.to validate_presence_of(:from_state) }
 
     it { is_expected.to validate_presence_of(:to_state) }
+
+    context "when required" do
+      subject { build(:job_application_file_type, required: true) }
+
+      it { is_expected.to validate_presence_of(:required_from_state) }
+      it { is_expected.to validate_presence_of(:required_to_state) }
+    end
   end
 
   describe "scopes" do
@@ -21,6 +28,24 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.to match([jaft_around]) }
       it { is_expected.not_to include(jaft_not_around) }
     end
+
+    describe "#required" do
+      subject { described_class.required(:to_be_met) }
+
+      let!(:jaft_required) do
+        create(:job_application_file_type, required: true, required_from_state: :phone_meeting, required_to_state: :accepted)
+      end
+      let!(:jaft_not_around) do
+        create(:job_application_file_type, required: true, required_from_state: :contract_drafting, required_to_state: :affected)
+      end
+      let!(:jaft_not_required) do
+        create(:job_application_file_type, required: false, required_from_state: :phone_meeting, required_to_state: :accepted)
+      end
+
+      it { is_expected.to match([jaft_required]) }
+      it { is_expected.not_to include(jaft_not_around) }
+      it { is_expected.not_to include(jaft_not_required) }
+    end
   end
 end
 
@@ -28,17 +53,18 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                :uuid             not null, primary key
-#  content_file_name :string
-#  description       :string
-#  from_state        :integer
-#  kind              :integer
-#  name              :string
-#  notification      :boolean          default(TRUE)
-#  position          :integer
-#  required          :boolean          default(FALSE), not null
-#  to_state          :integer
-#  to_state          :integer          default("affected")
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id                  :uuid             not null, primary key
+#  content_file_name   :string
+#  description         :string
+#  from_state          :integer
+#  kind                :integer
+#  name                :string
+#  notification        :boolean          default(TRUE)
+#  position            :integer
+#  required            :boolean          default(FALSE), not null
+#  required_from_state :integer          default(0)
+#  required_to_state   :integer          default(11)
+#  to_state            :integer          default("affected")
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -29,7 +29,6 @@ end
 # Table name: job_application_file_types
 #
 #  id                :uuid             not null, primary key
-#  by_default        :boolean          default(FALSE)
 #  content_file_name :string
 #  description       :string
 #  from_state        :integer

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -37,6 +37,7 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
+#  required          :boolean          default(FALSE), not null
 #  to_state          :integer
 #  to_state          :integer          default("affected")
 #  created_at        :datetime         not null

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -3,7 +3,25 @@
 require "rails_helper"
 
 RSpec.describe JobApplicationFileType do
-  it { is_expected.to validate_presence_of(:name) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+
+    it { is_expected.to validate_presence_of(:from_state) }
+
+    it { is_expected.to validate_presence_of(:to_state) }
+  end
+
+  describe "scopes" do
+    describe "#for_states_around" do
+      subject { described_class.for_states_around(:accepted) }
+
+      let!(:jaft_around) { create(:job_application_file_type, from_state: :to_be_met, to_state: :contract_drafting) }
+      let!(:jaft_not_around) { create(:job_application_file_type, from_state: :contract_drafting, to_state: :affected) }
+
+      it { is_expected.to match([jaft_around]) }
+      it { is_expected.not_to include(jaft_not_around) }
+    end
+  end
 end
 
 # == Schema Information
@@ -19,6 +37,8 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
+#  to_state          :integer
+#  to_state          :integer          default("affected")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -19,7 +19,6 @@ end
 #  name              :string
 #  notification      :boolean          default(TRUE)
 #  position          :integer
-#  spontaneous       :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe JobApplication do
       end
     end
 
-    describe "complete_required_files" do
+    describe "required_files_are_validated" do
       subject(:chante_state) { job_application.to_be_met! }
 
       let!(:job_application) { create(:job_application, state: :phone_meeting) }
@@ -179,10 +179,16 @@ RSpec.describe JobApplication do
         create(:job_application_file_type, required: true, required_from_state: :phone_meeting, required_to_state: :accepted)
       end
 
-      context "when required files are present" do
-        before { create(:job_application_file, job_application:, job_application_file_type:) }
+      context "when required files are present and validated" do
+        before { create(:job_application_file, job_application:, job_application_file_type:).check! }
 
         it { is_expected.to be(true) }
+      end
+
+      context "when required files are present but not validated" do
+        before { create(:job_application_file, job_application:, job_application_file_type:).uncheck! }
+
+        it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
       end
 
       context "when required files are missing" do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -170,6 +170,25 @@ RSpec.describe JobApplication do
         expect(job_application.contract_drafting!).to be(true)
       end
     end
+
+    describe "complete_required_files" do
+      subject(:chante_state) { job_application.to_be_met! }
+
+      let!(:job_application) { create(:job_application, state: :phone_meeting) }
+      let!(:job_application_file_type) do
+        create(:job_application_file_type, required: true, required_from_state: :phone_meeting, required_to_state: :accepted)
+      end
+
+      context "when required files are present" do
+        before { create(:job_application_file, job_application:, job_application_file_type:) }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when required files are missing" do
+        it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
+    end
   end
 end
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -79,18 +79,9 @@ RSpec.describe JobApplication do
 
   describe "files_to_be_provided" do
     before do
-      create(
-        :job_application_file_type,
-        name: "CV", from_state: :initial, kind: :applicant_provided, by_default: true
-      )
-      create(
-        :job_application_file_type,
-        name: "LM", from_state: :initial, kind: :applicant_provided, by_default: true
-      )
-      create(
-        :job_application_file_type,
-        name: "FILE", from_state: :to_be_met, kind: :applicant_provided, by_default: true
-      )
+      create(:job_application_file_type, name: "CV", from_state: :initial, kind: :applicant_provided)
+      create(:job_application_file_type, name: "LM", from_state: :initial, kind: :applicant_provided)
+      create(:job_application_file_type, name: "FILE", from_state: :to_be_met, kind: :applicant_provided)
     end
 
     let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
@@ -140,23 +131,10 @@ RSpec.describe JobApplication do
   describe "complete_files_before_draft_contract" do
     let(:job_application) { create(:job_application, state: :accepted) }
     let!(:jaft_1) do
-      create(
-        :job_application_file_type,
-        name: "File 1", from_state: :accepted, kind: :applicant_provided, by_default: true
-      )
+      create(:job_application_file_type, name: "File 1", from_state: :accepted, kind: :applicant_provided)
     end
     let!(:jaft_2) do
-      create(
-        :job_application_file_type,
-        name: "File 2", from_state: :to_be_met, kind: :applicant_provided, by_default: true
-      )
-    end
-
-    before do
-      create(
-        :job_application_file_type,
-        name: "File 3", from_state: :accepted, kind: :applicant_provided, by_default: false
-      )
+      create(:job_application_file_type, name: "File 2", from_state: :to_be_met, kind: :applicant_provided)
     end
 
     context "when no files are filled" do
@@ -167,14 +145,8 @@ RSpec.describe JobApplication do
 
     context "when files are fill but not validated" do
       before do
-        create(
-          :job_application_file,
-          job_application: job_application, job_application_file_type: jaft_1
-        )
-        create(
-          :job_application_file,
-          job_application: job_application, job_application_file_type: jaft_2
-        )
+        create(:job_application_file, job_application: job_application, job_application_file_type: jaft_1)
+        create(:job_application_file, job_application: job_application, job_application_file_type: jaft_2)
       end
 
       it "cant pass to contract_drafting" do
@@ -194,7 +166,7 @@ RSpec.describe JobApplication do
         )
       end
 
-      it "cant pass to contract_drafting" do
+      it "can pass to contract_drafting" do
         expect(job_application.contract_drafting!).to be(true)
       end
     end


### PR DESCRIPTION
# Description

On applique ici les modifications prévues dans le ticket #1965 sur les `JobApplicationFileType`, c'est à dire : 
- mise à jour de wordings
- suppression de "spontané"
- ajout de nouveaux types
- suppression de certains types
- ajout d'une tâche de migration de types qui sont supprimés
- ajout de `to_state`
- ajout de `required`
- ajout de `required_from_state`
- ajout de `required_to_state`
- suppression de `by_default`

# Maintenance task

`Maintenance::MigrateJobApplicationFileTypeKindsTask`


# Review app

https://erecrutement-cvd-staging-pr2035.osc-fr1.scalingo.io

# Links

Closes #1965

# Screenshots

<img width="3022" height="1718" alt="CleanShot 2025-12-31 at 12 02 44@2x" src="https://github.com/user-attachments/assets/b2d443bb-8297-4618-a8cf-69931dfaabc3" />

<img width="3022" height="1718" alt="CleanShot 2025-12-31 at 12 03 03@2x" src="https://github.com/user-attachments/assets/492e224e-33ad-41ee-8853-b57aa40f903d" />


