### PR TITLE
[Fix] Create a new job offer as employer

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -92,7 +92,6 @@ class Admin::JobOffersController < Admin::BaseController
 
     @job_offer = JobOffer.new_from_source(params[:job_offer_id])
     @job_offer ||= JobOffer.new_from_scratch(current_administrator)
-    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.organization = current_organization
   end
 
@@ -105,7 +104,6 @@ class Admin::JobOffersController < Admin::BaseController
   def create
     @job_offer.owner = current_administrator
     @job_offer.organization = current_organization
-    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.cleanup_actor_administrator_dep(current_administrator, current_organization)
 
     respond_to do |format|

--- a/app/controllers/concerns/job_offer_state_actions.rb
+++ b/app/controllers/concerns/job_offer_state_actions.rb
@@ -8,7 +8,6 @@ module JobOfferStateActions
     @job_offer = JobOffer.new(job_offer_params)
     @job_offer.owner = current_administrator
     @job_offer.organization = current_organization
-    @job_offer.employer = current_administrator.employer unless current_administrator.admin?
     @job_offer.job_offer_actors.each do |job_offer_actor|
       if job_offer_actor.administrator
         job_offer_actor.administrator.inviter ||= current_administrator

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -36,7 +36,7 @@
                           - grouped_options = Employer.roots.map{|x| [x.name, x.children]}
                           = f.association :employer, collection: grouped_options, as: :grouped_select, group_method: :last, input_html: {class: 'custom-select'}
                         - else
-                          = f.association :employer, collection: current_administrator.employers.map{|x| [x.code, x.id]}, disabled: true, include_blank: false
+                          = f.association :employer, collection: current_administrator.employers.map{|x| [x.code, x.id]}, disabled: @job_offer.persisted?, include_blank: false
                       .col-12.col-md-3
                         = f.association :bop
                     .row{data: { controller: 'location' }}

--- a/app/views/admin/job_offers/_form.html.haml
+++ b/app/views/admin/job_offers/_form.html.haml
@@ -36,8 +36,7 @@
                           - grouped_options = Employer.roots.map{|x| [x.name, x.children]}
                           = f.association :employer, collection: grouped_options, as: :grouped_select, group_method: :last, input_html: {class: 'custom-select'}
                         - else
-                          - employers = [current_administrator.employer]
-                          = f.association :employer, collection: employers.map{|x| [x.code, x.id]}, disabled: true, include_blank: false
+                          = f.association :employer, collection: current_administrator.employers.map{|x| [x.code, x.id]}, disabled: true, include_blank: false
                       .col-12.col-md-3
                         = f.association :bop
                     .row{data: { controller: 'location' }}


### PR DESCRIPTION
# Description

Lors de la création d'une offre d'emploi en tant qu'employeur, l'application présente une erreur 500. La raison est qu'on utilise dans ce formulaire l'attribut `administrator.employer`, qui est déprécié.

Pour corriger, on utilise à la place la relation `administrator.employers`, qui remplace le précédent.

Par ailleurs, on modifie la règle de gestion : 

1/ En tant que Employeur Recruteur, je peux changer l'employeur d'une offre d'emploi lors de la création de celle-ci

2/ En tant que Employeur Recruteur, je ne peux pas changer l'employeur d'une offre d'emploi lors de l'édition de celle-ci

# Review app

https://erecrutement-cvd-staging-pr2038.osc-fr1.scalingo.io

# Links

Closes #2036
