### PR TITLE
Admins can or can't upload file depending on type

### DIFF
--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -197,6 +197,18 @@ class Administrator < ApplicationRecord
     self.marked_for_deactivation_on = nil
   end
 
+  def can_upload?(job_application_file_type)
+    if functional_administrator?
+      true
+    elsif (hr_manager? || payroll_manager?) && job_application_file_type.manager_provided?
+      true
+    elsif employer_recruiter? && job_application_file_type.employer_provided?
+      true
+    else
+      false
+    end
+  end
+
   private
 
   def set_first_name = self.first_name = first_name_from(email)

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -1,10 +1,6 @@
 - file = job_application_file
 - type = file.job_application_file_type
 - job_application = file.job_application
-- # binding.pry if type.name == "CV"
-- # binding.pry if type.name == "Carte "
-- # binding.pry if type.name == "Pièce facultatif"
-- # binding.pry if type.name == "Bulletins paie "
 .d-flex.align-items-center.border.py-1.px-2.file{id: dom_id(file)}
   - if file.document_content.present?
     .text-truncate= type.name

--- a/app/views/admin/job_application_files/_job_application_file_upload.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file_upload.html.haml
@@ -1,5 +1,6 @@
-= form_for [:admin, job_application, job_application_file], namespace: file_type.name.parameterize, remote: true, html: {class: 'edit_job_application_file auto-submit'} do |form|
-  = form.label :content, fa_icon('arrow-up'), class: 'btn btn-raised btn-sm mb-0 mr-1', title: t('.help')
-  = form.file_field :content
-  - if job_application_file.new_record?
-    = form.hidden_field :job_application_file_type_id
+- if current_administrator.can_upload?(file_type)
+  = form_for [:admin, job_application, job_application_file], namespace: file_type.name.parameterize, remote: true, html: {class: 'edit_job_application_file auto-submit'} do |form|
+    = form.label :content, fa_icon('arrow-up'), class: 'btn btn-raised btn-sm mb-0 mr-1', title: t('.help')
+    = form.file_field :content
+    - if job_application_file.new_record?
+      = form.hidden_field :job_application_file_type_id

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -354,7 +354,7 @@ fr:
         download: "Télécharger"
         do_not_ask: "Ne plus demander"
       job_application_file_upload:
-        help: "Téléverser un fichier à la place de l'utilisateur"
+        help: "Téléverser un fichier"
       uncheck:
         success: "Fichier invalidé !"
     rejections:

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -318,6 +318,75 @@ RSpec.describe Administrator do
       it { expect { transfer }.not_to change { job_offer.reload.owner } }
     end
   end
+
+  describe "#can_upload?" do
+    subject(:can_upload?) { administrator.can_upload?(job_application_file_type) }
+
+    let(:administrator) { build(:administrator, roles: [role]) }
+    let(:job_application_file_type) { build(:job_application_file_type, kind:) }
+
+    context "when the administrator role is functional_adminitrator" do
+      let(:role) { :functional_administrator }
+      let(:kind) { :manager_provided }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the administrator role is hr_manager" do
+      let(:role) { :hr_manager }
+
+      context "when the job application file type is manager provided" do
+        let(:kind) { :manager_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is payroll_manager" do
+      let(:role) { :payroll_manager }
+
+      context "when the job application file type is manager provided" do
+        let(:kind) { :manager_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is employer_recruiter" do
+      let(:role) { :employer_recruiter }
+
+      context "when the job application file type is employer_provided" do
+        let(:kind) { :employer_provided }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the job application file type is something else" do
+        let(:kind) { :applicant_provided }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when the administrator role is something else" do
+      let(:role) { :employment_authority }
+      let(:kind) { :manager_provided }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Description

Les administrateurs peuvent ou non téléverser un fichier, selon leur rôle et le type de fichier.
- un functional_administrator peut téléverser tout type de fichier
- un hr_manager ou un payroll_manager peut téléverser un fichier de type "fourni par le gestionnaire"
- un employer_recruiter peut téléverser un fichier de type "fourni par l'employeur"

Le bouton de téléversement n'apparaît pas si l'administrateur connecté n'a pas les droits pour téléverser un fichier.

# Review app

https://erecrutement-cvd-staging-pr2040.osc-fr1.scalingo.io

# Links

Closes #1966

# Screenshots

<img width="3024" height="1720" alt="CleanShot 2026-01-14 at 08 52 03@2x" src="https://github.com/user-attachments/assets/64098492-324f-409e-86eb-491362423c27" />
