### PR TITLE
Notify employer recruiter when email is sent by user

### DIFF
--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -16,7 +16,7 @@ class Account::EmailsController < Account::BaseController
     @email = @job_application.emails.build(email_params)
 
     respond_to do |format|
-      if @email.save
+      if @email.send_from_user
         format.turbo_stream do
           s = turbo_stream.prepend("emails") {
             view_context.render partial: "email", locals: {email: @email}

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -2,6 +2,21 @@
 
 # Periodic notifications mailer
 class NotificationsMailer < ApplicationMailer
+  def new_email
+    @administrator = params[:administrator]
+    @job_application = params[:job_application]
+    @job_offer = @job_application.job_offer
+    @service_name = @administrator.organization.service_name
+
+    subject = t(
+      ".subject",
+      service_name: @service_name,
+      state: JobApplication.human_attribute_name("state/#{@job_application.state}")
+    )
+
+    mail to: @administrator.email, subject:
+  end
+
   def daily_summary(administrator, data, service_name)
     @data = data
     subject = t(".subject", service_name: service_name)

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -82,6 +82,7 @@ class Administrator < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
   scope :inactive, -> { where.not(deleted_at: nil) }
+  scope :employer_recruiters, -> { where("roles & ? != 0", 1 << ROLES[:employer_recruiter]) }
 
   enummer roles: ROLES
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -190,6 +190,8 @@ class JobApplication < ApplicationRecord
   scope :between, ->(a, b) { where(created_at: b..a) }
   scope :with_user, -> { where.not(user: nil) }
 
+  delegate :employer_recruiters, to: :job_offer, prefix: true
+
   def set_employer
     self.employer_id ||= job_offer.employer_id
   end

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -55,6 +55,8 @@ class JobOffer < ApplicationRecord
   has_many :job_applications, dependent: :destroy
   has_many :job_offer_actors, inverse_of: :job_offer, dependent: :destroy
   has_many :administrators, through: :job_offer_actors
+  has_many :employer_recruiters, -> { merge(Administrator.employer_recruiters) }, through: :job_offer_actors, source: :administrator
+
   accepts_nested_attributes_for :job_offer_actors
 
   %i[employer grand_employer supervisor_employer brh].each do |actor_role|

--- a/app/views/notifications_mailer/new_email.html.erb
+++ b/app/views/notifications_mailer/new_email.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
 </p>
 
 <p>

--- a/app/views/notifications_mailer/new_email.html.erb
+++ b/app/views/notifications_mailer/new_email.html.erb
@@ -1,0 +1,21 @@
+<p>
+  Bonjour <%= @administrator.full_name %>,
+</p>
+
+<p>
+  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to(@job_offer.title, @job_offer) %>.
+</p>
+
+<p>
+  Le/la candidat(e) <%= @job_application.user.full_name %> a répondu à votre proposition d’entretien.
+<br>
+  Pour y accéder, cliquez sur le lien suivant : <%= link_to(@job_offer.title, @job_offer) %>
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/notifications_mailer/new_email.html.erb
+++ b/app/views/notifications_mailer/new_email.html.erb
@@ -3,13 +3,13 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to(@job_offer.title, @job_offer) %>.
+  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
 </p>
 
 <p>
   Le/la candidat(e) <%= @job_application.user.full_name %> a répondu à votre proposition d’entretien.
 <br>
-  Pour y accéder, cliquez sur le lien suivant : <%= link_to(@job_offer.title, @job_offer) %>
+  Pour y accéder, cliquez sur le lien suivant : <%= link_to @job_offer.title, [:admin, @job_offer] %>
 </p>
 
 <p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -181,6 +181,8 @@ fr:
     notify_rejected:
       subject: "Votre candidature a été refusée"
   notifications_mailer:
+    new_email:
+      subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"
       generic_title: "Candidatures %{state}"

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe NotificationsMailer do
+  describe "new_email" do
+    subject(:mail) { described_class.with(administrator:, job_application:).new_email }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.new_email.subject",
+          service_name: administrator.organization.service_name,
+          state: JobApplication.human_attribute_name("state/#{job_application.state}")
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/Vous êtes notifié comme/) }
+  end
+end

--- a/spec/mailers/previews/notifications_preview.rb
+++ b/spec/mailers/previews/notifications_preview.rb
@@ -2,8 +2,10 @@
 
 # Preview all emails at http://localhost:3000/rails/mailers/notifications
 class NotificationsPreview < ActionMailer::Preview
-  # Preview this email at http://localhost:3000/rails/mailers/notifications/daily_summary
-  def daily_summary
-    NotificationsMailer.daily_summary
+  def new_email
+    job_application = JobApplication.find_by(state: :phone_meeting) || JobApplication.first
+    NotificationsMailer.with(administrator: Administrator.first, job_application:).new_email
   end
+
+  def daily_summary = NotificationsMailer.daily_summary
 end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe Administrator do
     end
   end
 
+  describe "scopes" do
+    describe "#employer_recruiters" do
+      subject(:employer_recruiters) { described_class.employer_recruiters }
+
+      let!(:matching) { create(:administrator, roles: [:functional_administrator, :employer_recruiter]) }
+      let!(:unmatching) { create(:administrator, roles: [:hr_manager, :payroll_manager]) }
+
+      it { is_expected.to match([matching]) }
+
+      it { is_expected.not_to include(unmatching) }
+    end
+  end
+
   describe "before_validation callbacks" do
     describe "#set_first_name" do
       subject(:save) { administrator.save! }

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -6,6 +6,96 @@ RSpec.describe Email do
   it { is_expected.to validate_presence_of(:subject) }
   it { is_expected.to validate_presence_of(:body) }
 
+  describe "#send_from_user" do
+    subject(:send_from_user) { email.send_from_user }
+
+    context "when the email can't be saved" do
+      let(:email) { described_class.new }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the email can be saved" do
+      shared_examples "an employer recruiter notification mailer" do
+        before do
+          create(:job_offer_actor, job_offer:, administrator:, role: :employer)
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            new_email: mailer_double
+          )
+          send_from_user
+        end
+
+        it { expect(NotificationsMailer).to have_received(:with).with(administrator:, job_application:) }
+
+        it { expect(NotificationsMailer).to have_received(:new_email) }
+      end
+
+      shared_examples "not a notification mailer" do
+        before do
+          allow(NotificationsMailer).to receive(:with)
+          send_from_user
+        end
+
+        it { expect(NotificationsMailer).not_to have_received(:with) }
+      end
+
+      context "when the job application has phone_meeting state and at least one employer recruiter" do
+        let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
+        let(:administrator) { create(:administrator, roles: [:employer_recruiter]) }
+        let(:job_offer) { create(:job_offer) }
+        let(:email) { build(:email, job_application:) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        it { is_expected.to be(true) }
+
+        it_behaves_like "an employer recruiter notification mailer"
+      end
+
+      context "when the job application has phone_meeting state and no employer recruiter" do
+        let(:job_application) { create(:job_application, state: :phone_meeting) }
+        let(:email) { build(:email, job_application:) }
+
+        it { is_expected.to be(true) }
+
+        it_behaves_like "not a notification mailer"
+      end
+
+      context "when the job application has to_be_met state and at least one employer recruiter" do
+        let(:job_application) { create(:job_application, job_offer:, state: :to_be_met) }
+        let(:administrator) { create(:administrator, roles: [:employer_recruiter]) }
+        let(:job_offer) { create(:job_offer) }
+        let(:email) { build(:email, job_application:) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        it { is_expected.to be(true) }
+
+        it_behaves_like "an employer recruiter notification mailer"
+      end
+
+      context "when the job application has to_be_met state and no employer recruiter" do
+        let(:job_application) { create(:job_application, state: :to_be_met) }
+        let(:email) { build(:email, job_application:) }
+
+        it { is_expected.to be(true) }
+
+        it_behaves_like "not a notification mailer"
+      end
+
+      context "when the job application has another state even with at least one employer recruiter" do
+        let(:job_application) { create(:job_application, job_offer:, state: :initial) }
+        let(:administrator) { create(:administrator, roles: [:employer_recruiter]) }
+        let(:job_offer) { create(:job_offer) }
+        let(:email) { build(:email, job_application:) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        it { is_expected.to be(true) }
+
+        it_behaves_like "not a notification mailer"
+      end
+    end
+  end
+
   describe "#mark_as_read!" do
     it "marks the email as read" do
       email = create(:email, is_unread: true)

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe JobApplication do
   let(:job_offer) { create(:job_offer) }
   let(:job_application) { create(:job_application, job_offer:) }
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:employer_recruiters).to(:job_offer).with_prefix(true) }
+  end
+
   describe "validations" do
     describe "#cant_be_accepted_twice" do
       subject(:acceptance) { job_application.accepted! }

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe JobOffer do
     it { is_expected.to have_many(:drawback_job_offers).dependent(:destroy) }
 
     it { is_expected.to have_many(:drawbacks).through(:drawback_job_offers) }
+
+    it { is_expected.to have_many(:administrators).through(:job_offer_actors) }
+
+    it { is_expected.to have_many(:employer_recruiters).through(:job_offer_actors) }
   end
 
   describe "delegations" do


### PR DESCRIPTION
# Description

Quand une offre d'emploi est à l'état : 
- phone meeting
- to be met

Et que le candidat envoie un message en front office

Alors un email de notification est envoyé à chaque employeur recruteur enregistré sur l'offre d'emploi.

# Review app

https://erecrutement-cvd-staging-pr2043.osc-fr1.scalingo.io

# Links

Closes #1975

# Screenshots

<img width="1450" height="810" alt="CleanShot 2026-01-26 at 08 09 46@2x" src="https://github.com/user-attachments/assets/68972759-e586-4abd-b359-68587451fb49" />


