### PR TITLE
Notify hr manager when job app state becomes contract drafting

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -17,6 +17,17 @@ class NotificationsMailer < ApplicationMailer
     mail to: @administrator.email, subject:
   end
 
+  def contract_drafting
+    @administrator = params[:administrator]
+    @job_application = params[:job_application]
+    @job_offer = @job_application.job_offer
+    @service_name = @administrator.organization.service_name
+    @employer_recruiters = @job_application.job_offer_employer_recruiters
+    @hr_managers = @job_application.job_offer_hr_managers
+
+    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+  end
+
   def daily_summary(administrator, data, service_name)
     @data = data
     subject = t(".subject", service_name: service_name)

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -83,6 +83,7 @@ class Administrator < ApplicationRecord
   scope :active, -> { where(deleted_at: nil) }
   scope :inactive, -> { where.not(deleted_at: nil) }
   scope :employer_recruiters, -> { where("roles & ? != 0", 1 << ROLES[:employer_recruiter]) }
+  scope :hr_managers, -> { where("roles & ? != 0", 1 << ROLES[:hr_manager]) }
 
   enummer roles: ROLES
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -56,7 +56,7 @@ class JobApplication < ApplicationRecord
 
   before_validation :set_employer
   before_save :compute_notifications_counter
-  after_update :notify_new_state, if: -> { new_state_requires_notification? }
+  after_update :notify_applicant_new_state, if: -> { new_state_requires_applicant_notification? }
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze
@@ -104,7 +104,7 @@ class JobApplication < ApplicationRecord
 
   aasm column: :state, enum: true do
     state :initial, initial: true
-    state :phone_meeting, before_enter: proc { notify_new_state(:phone_meeting) }
+    state :phone_meeting, before_enter: proc { notify_applicant_new_state(:phone_meeting) }
     state :to_be_met
     state :financial_estimate
     state :accepted
@@ -351,9 +351,11 @@ class JobApplication < ApplicationRecord
 
   def has_accepted_other_job_application? = user.job_applications.where(state: "accepted").where.not(id: id).empty?
 
-  def notify_new_state = ApplicantNotificationsMailer.with(user:, job_offer:, state:).notify_new_state.deliver_later
+  def notify_applicant_new_state
+    ApplicantNotificationsMailer.with(user:, job_offer:, state:).notify_new_state.deliver_later
+  end
 
-  def new_state_requires_notification? = saved_change_to_state? && NOTIFICATION_STATES.include?(state.to_s)
+  def new_state_requires_applicant_notification? = saved_change_to_state? && NOTIFICATION_STATES.include?(state.to_s)
 
   class << self
     def processing_states

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -57,6 +57,7 @@ class JobApplication < ApplicationRecord
   before_validation :set_employer
   before_save :compute_notifications_counter
   after_update :notify_applicant_new_state, if: -> { new_state_requires_applicant_notification? }
+  after_update :notify_hr_managers_contract_drafting, if: -> { saved_change_to_state? && contract_drafting? }
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze
@@ -195,7 +196,7 @@ class JobApplication < ApplicationRecord
   scope :between, ->(a, b) { where(created_at: b..a) }
   scope :with_user, -> { where.not(user: nil) }
 
-  delegate :employer_recruiters, to: :job_offer, prefix: true
+  delegate :employer_recruiters, :hr_managers, to: :job_offer, prefix: true
 
   def set_employer
     self.employer_id ||= job_offer.employer_id
@@ -356,6 +357,16 @@ class JobApplication < ApplicationRecord
   end
 
   def new_state_requires_applicant_notification? = saved_change_to_state? && NOTIFICATION_STATES.include?(state.to_s)
+
+  def notify_hr_managers_contract_drafting
+    job_offer_hr_managers.each do |administrator|
+      notify_hr_manager_contract_drafting(administrator)
+    end
+  end
+
+  def notify_hr_manager_contract_drafting(administrator)
+    NotificationsMailer.with(administrator:, job_application: self).contract_drafting.deliver_later
+  end
 
   class << self
     def processing_states

--- a/app/models/job_application/rejectable.rb
+++ b/app/models/job_application/rejectable.rb
@@ -7,7 +7,7 @@ module JobApplication::Rejectable
     validate :missing_rejection_reason, if: -> { rejected && rejection_reason.blank? }
 
     before_save :cleanup_rejection_reason, unless: -> { rejected }
-    after_update :notify_rejected, if: -> { saved_change_to_rejected? && rejected }
+    after_update :notify_applicant_rejected, if: -> { saved_change_to_rejected? && rejected }
 
     scope :rejecteds, -> { where(rejected: true) }
     scope :not_rejecteds, -> { where(rejected: false) }
@@ -23,5 +23,7 @@ module JobApplication::Rejectable
 
   def cleanup_rejection_reason = self.rejection_reason = nil
 
-  def notify_rejected = ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+  def notify_applicant_rejected
+    ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+  end
 end

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -56,6 +56,7 @@ class JobOffer < ApplicationRecord
   has_many :job_offer_actors, inverse_of: :job_offer, dependent: :destroy
   has_many :administrators, through: :job_offer_actors
   has_many :employer_recruiters, -> { merge(Administrator.employer_recruiters) }, through: :job_offer_actors, source: :administrator
+  has_many :hr_managers, -> { merge(Administrator.hr_managers) }, through: :job_offer_actors, source: :administrator
 
   accepts_nested_attributes_for :job_offer_actors
 

--- a/app/views/notifications_mailer/contract_drafting.html.erb
+++ b/app/views/notifications_mailer/contract_drafting.html.erb
@@ -1,0 +1,53 @@
+<p>
+  Bonjour <%= @administrator.full_name %>,
+</p>
+
+<p>
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+</p>
+
+<p>
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape validation dossier complet.
+</p>
+
+<% if @employer_recruiters.any? || @hr_managers.any? %>
+  <p>
+    Pour information, les personnes liées à cette offre sont :
+  </p>
+
+  <% if @employer_recruiters.any? %>
+    <p>
+      Employeur(s) :
+    </p>
+
+    <ul>
+      <% @employer_recruiters.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @hr_managers.any? %>
+    <p>
+      Gestionnaire(s) :
+    </p>
+
+    <ul>
+      <% @hr_managers.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
+<p>
+  Pour y accéder, cliquez sur le lien suivant : <%= link_to(@job_offer.title, [:admin, @job_offer]) %>
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/notifications_mailer/contract_drafting.html.erb
+++ b/app/views/notifications_mailer/contract_drafting.html.erb
@@ -3,11 +3,11 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
 </p>
 
 <p>
-  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape validation dossier complet.
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape Validation dossier complet.
 </p>
 
 <% if @employer_recruiters.any? || @hr_managers.any? %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -183,6 +183,8 @@ fr:
   notifications_mailer:
     new_email:
       subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"
+    contract_drafting:
+      subject: "[%{service_name}] Notification « Gestionnaire » - Validation dossier complet"
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"
       generic_title: "Candidatures %{state}"

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -39,6 +39,6 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.to).to match([administrator.email]) }
 
-    it { expect(mail.body.encoded).to match(/à l'étape validation dossier complet/) }
+    it { expect(mail.body.encoded).to match(/à l'étape Validation dossier complet/) }
   end
 end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -19,6 +19,26 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.to).to match([administrator.email]) }
 
-    it { expect(mail.body.encoded).to match(/Vous êtes notifié comme/) }
+    it { expect(mail.body.encoded).to match(/a répondu à votre proposition d’entretien/) }
+  end
+
+  describe "contract_drafting" do
+    subject(:mail) { described_class.with(administrator:, job_application:).contract_drafting }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.contract_drafting.subject",
+          service_name: administrator.organization.service_name
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/à l'étape validation dossier complet/) }
   end
 end

--- a/spec/mailers/previews/notifications_preview.rb
+++ b/spec/mailers/previews/notifications_preview.rb
@@ -4,7 +4,14 @@
 class NotificationsPreview < ActionMailer::Preview
   def new_email
     job_application = JobApplication.find_by(state: :phone_meeting) || JobApplication.first
-    NotificationsMailer.with(administrator: Administrator.first, job_application:).new_email
+    administrator = Administrator.employer_recruiters.first || Administrator.first
+    NotificationsMailer.with(administrator:, job_application:).new_email
+  end
+
+  def contract_drafting
+    job_application = JobApplication.find_by(state: :contract_drafting) || JobApplication.first
+    administrator = Administrator.hr_managers.first || Administrator.first
+    NotificationsMailer.with(administrator:, job_application:).contract_drafting
   end
 
   def daily_summary = NotificationsMailer.daily_summary

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe Administrator do
 
       it { is_expected.not_to include(unmatching) }
     end
+
+    describe "#hr_managers" do
+      subject(:hr_managers) { described_class.hr_managers }
+
+      let!(:matching) { create(:administrator, roles: [:functional_administrator, :hr_manager]) }
+      let!(:unmatching) { create(:administrator, roles: [:employer_recruiter, :payroll_manager]) }
+
+      it { is_expected.to match([matching]) }
+
+      it { is_expected.not_to include(unmatching) }
+    end
   end
 
   describe "before_validation callbacks" do

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe JobApplication::Rejectable do
   end
 
   describe "after_update callbacks" do
-    describe "#notify_rejected" do
+    describe "#notify_applicant_rejected" do
       subject(:rejection) { job_application.update!(rejected: true, rejection_reason: create(:rejection_reason)) }
 
       let(:job_application) { create(:job_application) }

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe JobApplication do
 
   describe "delegations" do
     it { is_expected.to delegate_method(:employer_recruiters).to(:job_offer).with_prefix(true) }
+
+    it { is_expected.to delegate_method(:hr_managers).to(:job_offer).with_prefix(true) }
   end
 
   describe "validations" do
@@ -219,6 +221,47 @@ RSpec.describe JobApplication do
 
       context "when required files are missing" do
         it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
+    end
+  end
+
+  describe "after_update callbacks" do
+    describe "#notify_hr_managers_contract_drafting" do
+      subject(:contract_drafting) { job_application.contract_drafting! }
+
+      let(:job_application) { create(:job_application, state: :accepted) }
+
+      context "when the job application has at least one hr_manager" do
+        let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          create(:job_offer_actor, job_offer: job_application.job_offer, administrator:, role: :employer)
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_drafting: mailer_double
+          )
+          contract_drafting
+        end
+
+        it { expect(NotificationsMailer).to have_received(:with).with(administrator:, job_application:) }
+
+        it { expect(NotificationsMailer).to have_received(:contract_drafting) }
+      end
+
+      context "when the job application doesn't have any hr managers" do
+        let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_drafting: mailer_double
+          )
+          contract_drafting
+        end
+
+        it { expect(NotificationsMailer).not_to have_received(:with) }
       end
     end
   end

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe JobOffer do
     it { is_expected.to have_many(:administrators).through(:job_offer_actors) }
 
     it { is_expected.to have_many(:employer_recruiters).through(:job_offer_actors) }
+
+    it { is_expected.to have_many(:hr_managers).through(:job_offer_actors) }
   end
 
   describe "delegations" do


### PR DESCRIPTION

# Description

Quand une candidature passe à l'état `contract_drafting` ("validation dossier complet"), on envoie un email à tous les gestionnaires RH affectés à l'offre correspondante.

# Review app

https://erecrutement-cvd-staging-pr2044.osc-fr1.scalingo.io

# Links

Closes #1976

# Screenshots

<img width="1926" height="1218" alt="CleanShot 2026-01-27 at 08 51 40@2x" src="https://github.com/user-attachments/assets/42e73210-d4c6-4981-8941-6a2595088076" />

