### PR TITLE
Notify hr manager when job app state becomes contract feedback waiting

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -28,6 +28,17 @@ class NotificationsMailer < ApplicationMailer
     mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
   end
 
+  def contract_feedback_waiting
+    @administrator = params[:administrator]
+    @job_application = params[:job_application]
+    @job_offer = @job_application.job_offer
+    @service_name = @administrator.organization.service_name
+    @employer_recruiters = @job_application.job_offer_employer_recruiters
+    @hr_managers = @job_application.job_offer_hr_managers
+
+    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+  end
+
   def daily_summary(administrator, data, service_name)
     @data = data
     subject = t(".subject", service_name: service_name)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -58,6 +58,7 @@ class JobApplication < ApplicationRecord
   before_save :compute_notifications_counter
   after_update :notify_applicant_new_state, if: -> { new_state_requires_applicant_notification? }
   after_update :notify_hr_managers_contract_drafting, if: -> { saved_change_to_state? && contract_drafting? }
+  after_update :notify_hr_managers_contract_feedback_waiting, if: -> { saved_change_to_state? && contract_feedback_waiting? }
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze
@@ -366,6 +367,16 @@ class JobApplication < ApplicationRecord
 
   def notify_hr_manager_contract_drafting(administrator)
     NotificationsMailer.with(administrator:, job_application: self).contract_drafting.deliver_later
+  end
+
+  def notify_hr_managers_contract_feedback_waiting
+    job_offer_hr_managers.each do |administrator|
+      notify_hr_manager_contract_feedback_waiting(administrator)
+    end
+  end
+
+  def notify_hr_manager_contract_feedback_waiting(administrator)
+    NotificationsMailer.with(administrator:, job_application: self).contract_feedback_waiting.deliver_later
   end
 
   class << self

--- a/app/views/notifications_mailer/contract_drafting.html.erb
+++ b/app/views/notifications_mailer/contract_drafting.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
 </p>
 
 <p>

--- a/app/views/notifications_mailer/contract_feedback_waiting.html.erb
+++ b/app/views/notifications_mailer/contract_feedback_waiting.html.erb
@@ -1,0 +1,53 @@
+<p>
+  Bonjour <%= @administrator.full_name %>,
+</p>
+
+<p>
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+</p>
+
+<p>
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape contrat.
+</p>
+
+<% if @employer_recruiters.any? || @hr_managers.any? %>
+  <p>
+    Pour information, les personnes liées à cette offre sont :
+  </p>
+
+  <% if @employer_recruiters.any? %>
+    <p>
+      Employeur(s) :
+    </p>
+
+    <ul>
+      <% @employer_recruiters.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @hr_managers.any? %>
+    <p>
+      Gestionnaire(s) :
+    </p>
+
+    <ul>
+      <% @hr_managers.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
+<p>
+  Pour y accéder et procéder à une action, cliquez sur le lien suivant : <%= link_to(@job_offer.title, [:admin, @job_offer]) %>
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/notifications_mailer/contract_feedback_waiting.html.erb
+++ b/app/views/notifications_mailer/contract_feedback_waiting.html.erb
@@ -3,11 +3,11 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
 </p>
 
 <p>
-  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape contrat.
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape Contrat.
 </p>
 
 <% if @employer_recruiters.any? || @hr_managers.any? %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -185,6 +185,8 @@ fr:
       subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"
     contract_drafting:
       subject: "[%{service_name}] Notification « Gestionnaire » - Validation dossier complet"
+    contract_feedback_waiting:
+      subject: "[%{service_name}] Notification « Gestionnaire » - Contrat"
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"
       generic_title: "Candidatures %{state}"

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -59,6 +59,6 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.to).to match([administrator.email]) }
 
-    it { expect(mail.body.encoded).to match(/à l'étape contrat/) }
+    it { expect(mail.body.encoded).to match(/à l'étape Contrat/) }
   end
 end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -41,4 +41,24 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.body.encoded).to match(/à l'étape Validation dossier complet/) }
   end
+
+  describe "contract_feedback_waiting" do
+    subject(:mail) { described_class.with(administrator:, job_application:).contract_feedback_waiting }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.contract_feedback_waiting.subject",
+          service_name: administrator.organization.service_name
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/à l'étape contrat/) }
+  end
 end

--- a/spec/mailers/previews/notifications_preview.rb
+++ b/spec/mailers/previews/notifications_preview.rb
@@ -14,5 +14,11 @@ class NotificationsPreview < ActionMailer::Preview
     NotificationsMailer.with(administrator:, job_application:).contract_drafting
   end
 
+  def contract_feedback_waiting
+    job_application = JobApplication.find_by(state: :contract_feedback_waiting) || JobApplication.first
+    administrator = Administrator.hr_managers.first || Administrator.first
+    NotificationsMailer.with(administrator:, job_application:).contract_feedback_waiting
+  end
+
   def daily_summary = NotificationsMailer.daily_summary
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -264,6 +264,45 @@ RSpec.describe JobApplication do
         it { expect(NotificationsMailer).not_to have_received(:with) }
       end
     end
+
+    describe "#notify_hr_managers_contract_feedback_waiting" do
+      subject(:contract_feedback_waiting) { job_application.contract_feedback_waiting! }
+
+      let(:job_application) { create(:job_application, state: :contract_drafting) }
+
+      context "when the job application has at least one hr_manager" do
+        let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          create(:job_offer_actor, job_offer: job_application.job_offer, administrator:, role: :employer)
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_feedback_waiting: mailer_double
+          )
+          contract_feedback_waiting
+        end
+
+        it { expect(NotificationsMailer).to have_received(:with).with(administrator:, job_application:) }
+
+        it { expect(NotificationsMailer).to have_received(:contract_feedback_waiting) }
+      end
+
+      context "when the job application doesn't have any hr managers" do
+        let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_feedback_waiting: mailer_double
+          )
+          contract_feedback_waiting
+        end
+
+        it { expect(NotificationsMailer).not_to have_received(:with) }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
# Description

Quand une candidature passe à l'état `contract_feedback_waiting` ("contrat"), on envoie un email à tous les gestionnaires RH affectés à l'offre correspondante.

# Review app

https://erecrutement-cvd-staging-pr2045.osc-fr1.scalingo.io

# Links

Closes #1977 

# Screenshots

<img width="2266" height="1208" alt="CleanShot 2026-01-31 at 09 09 46@2x" src="https://github.com/user-attachments/assets/06485ae0-7950-4867-a719-aeb8a3120545" />

