### PR TITLE
Notify payroll managers when job app state becomes contract reveived

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -39,6 +39,17 @@ class NotificationsMailer < ApplicationMailer
     mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
   end
 
+  def contract_received
+    @administrator = params[:administrator]
+    @job_application = params[:job_application]
+    @job_offer = @job_application.job_offer
+    @service_name = @administrator.organization.service_name
+    @employer_recruiters = @job_application.job_offer_employer_recruiters
+    @hr_managers = @job_application.job_offer_hr_managers
+
+    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+  end
+
   def daily_summary(administrator, data, service_name)
     @data = data
     subject = t(".subject", service_name: service_name)

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -84,6 +84,7 @@ class Administrator < ApplicationRecord
   scope :inactive, -> { where.not(deleted_at: nil) }
   scope :employer_recruiters, -> { where("roles & ? != 0", 1 << ROLES[:employer_recruiter]) }
   scope :hr_managers, -> { where("roles & ? != 0", 1 << ROLES[:hr_manager]) }
+  scope :payroll_managers, -> { where("roles & ? != 0", 1 << ROLES[:payroll_manager]) }
 
   enummer roles: ROLES
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -59,6 +59,7 @@ class JobApplication < ApplicationRecord
   after_update :notify_applicant_new_state, if: -> { new_state_requires_applicant_notification? }
   after_update :notify_hr_managers_contract_drafting, if: -> { saved_change_to_state? && contract_drafting? }
   after_update :notify_hr_managers_contract_feedback_waiting, if: -> { saved_change_to_state? && contract_feedback_waiting? }
+  after_update :notify_payroll_managers_contract_received, if: -> { saved_change_to_state? && contract_received? }
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze
@@ -197,7 +198,7 @@ class JobApplication < ApplicationRecord
   scope :between, ->(a, b) { where(created_at: b..a) }
   scope :with_user, -> { where.not(user: nil) }
 
-  delegate :employer_recruiters, :hr_managers, to: :job_offer, prefix: true
+  delegate :employer_recruiters, :hr_managers, :payroll_managers, to: :job_offer, prefix: true
 
   def set_employer
     self.employer_id ||= job_offer.employer_id
@@ -377,6 +378,16 @@ class JobApplication < ApplicationRecord
 
   def notify_hr_manager_contract_feedback_waiting(administrator)
     NotificationsMailer.with(administrator:, job_application: self).contract_feedback_waiting.deliver_later
+  end
+
+  def notify_payroll_managers_contract_received
+    job_offer_payroll_managers.each do |administrator|
+      notify_payroll_manager_contract_received(administrator)
+    end
+  end
+
+  def notify_payroll_manager_contract_received(administrator)
+    NotificationsMailer.with(administrator:, job_application: self).contract_received.deliver_later
   end
 
   class << self

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -57,6 +57,7 @@ class JobOffer < ApplicationRecord
   has_many :administrators, through: :job_offer_actors
   has_many :employer_recruiters, -> { merge(Administrator.employer_recruiters) }, through: :job_offer_actors, source: :administrator
   has_many :hr_managers, -> { merge(Administrator.hr_managers) }, through: :job_offer_actors, source: :administrator
+  has_many :payroll_managers, -> { merge(Administrator.payroll_managers) }, through: :job_offer_actors, source: :administrator
 
   accepts_nested_attributes_for :job_offer_actors
 

--- a/app/views/notifications_mailer/contract_feedback_waiting.html.erb
+++ b/app/views/notifications_mailer/contract_feedback_waiting.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
+  Vous êtes notifié comme « Gestionnaire RH » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
 </p>
 
 <p>

--- a/app/views/notifications_mailer/contract_received.html.erb
+++ b/app/views/notifications_mailer/contract_received.html.erb
@@ -1,0 +1,53 @@
+<p>
+  Bonjour <%= @administrator.full_name %>,
+</p>
+
+<p>
+  Vous êtes notifié comme « Gestionnaire Paie » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+</p>
+
+<p>
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape dossier de paie.
+</p>
+
+<% if @employer_recruiters.any? || @hr_managers.any? %>
+  <p>
+    Pour information, les personnes liées à cette offre sont :
+  </p>
+
+  <% if @employer_recruiters.any? %>
+    <p>
+      Employeur(s) :
+    </p>
+
+    <ul>
+      <% @employer_recruiters.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @hr_managers.any? %>
+    <p>
+      Gestionnaire(s) :
+    </p>
+
+    <ul>
+      <% @hr_managers.each do |administrator| %>
+        <li><%= administrator.full_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
+<p>
+  Pour y accéder et procéder à une action, cliquez sur le lien suivant : <%= link_to(@job_offer.title, [:admin, @job_offer]) %>
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/notifications_mailer/contract_received.html.erb
+++ b/app/views/notifications_mailer/contract_received.html.erb
@@ -3,11 +3,11 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire Paie » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+  Vous êtes notifié comme « Gestionnaire Paie » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
 </p>
 
 <p>
-  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape dossier de paie.
+  Le/la candidat(e) <%= @job_application.user.full_name %> est passé(e) à l'étape Dossier de paie.
 </p>
 
 <% if @employer_recruiters.any? || @hr_managers.any? %>

--- a/app/views/notifications_mailer/contract_received.html.erb
+++ b/app/views/notifications_mailer/contract_received.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Gestionnaire Paie » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
+  Vous êtes notifié comme « Gestionnaire Paie » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
 </p>
 
 <p>

--- a/app/views/notifications_mailer/new_email.html.erb
+++ b/app/views/notifications_mailer/new_email.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, @job_offer %>.
+  Vous êtes notifié comme « Employeur » sur la plateforme E-recrutement sur l’offre <%= link_to @job_offer.title, [:admin, @job_offer] %>.
 </p>
 
 <p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -187,6 +187,8 @@ fr:
       subject: "[%{service_name}] Notification « Gestionnaire » - Validation dossier complet"
     contract_feedback_waiting:
       subject: "[%{service_name}] Notification « Gestionnaire » - Contrat"
+    contract_received:
+      subject: "[%{service_name}] Notification « Gestionnaire » - Dossier de paie"
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"
       generic_title: "Candidatures %{state}"

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -62,26 +62,6 @@ RSpec.describe NotificationsMailer do
     it { expect(mail.body.encoded).to match(/à l'étape Contrat/) }
   end
 
-  describe "contract_feedback_waiting" do
-    subject(:mail) { described_class.with(administrator:, job_application:).contract_feedback_waiting }
-
-    let(:administrator) { create(:administrator) }
-    let(:job_application) { create(:job_application) }
-
-    it {
-      expect(mail.subject).to eq(
-        I18n.t(
-          "notifications_mailer.contract_feedback_waiting.subject",
-          service_name: administrator.organization.service_name
-        )
-      )
-    }
-
-    it { expect(mail.to).to match([administrator.email]) }
-
-    it { expect(mail.body.encoded).to match(/à l'étape contrat/) }
-  end
-
   describe "contract_received" do
     subject(:mail) { described_class.with(administrator:, job_application:).contract_received }
 

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -61,4 +61,24 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.body.encoded).to match(/à l'étape Contrat/) }
   end
+
+  describe "contract_feedback_waiting" do
+    subject(:mail) { described_class.with(administrator:, job_application:).contract_feedback_waiting }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.contract_feedback_waiting.subject",
+          service_name: administrator.organization.service_name
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/à l'étape contrat/) }
+  end
 end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -81,4 +81,24 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.body.encoded).to match(/à l'étape contrat/) }
   end
+
+  describe "contract_received" do
+    subject(:mail) { described_class.with(administrator:, job_application:).contract_received }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.contract_received.subject",
+          service_name: administrator.organization.service_name
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/à l'étape dossier de paie/) }
+  end
 end

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -99,6 +99,6 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.to).to match([administrator.email]) }
 
-    it { expect(mail.body.encoded).to match(/à l'étape dossier de paie/) }
+    it { expect(mail.body.encoded).to match(/à l'étape Dossier de paie/) }
   end
 end

--- a/spec/mailers/previews/notifications_preview.rb
+++ b/spec/mailers/previews/notifications_preview.rb
@@ -20,5 +20,11 @@ class NotificationsPreview < ActionMailer::Preview
     NotificationsMailer.with(administrator:, job_application:).contract_feedback_waiting
   end
 
+  def contract_received
+    job_application = JobApplication.find_by(state: :contract_received) || JobApplication.first
+    administrator = Administrator.hr_managers.first || Administrator.first
+    NotificationsMailer.with(administrator:, job_application:).contract_received
+  end
+
   def daily_summary = NotificationsMailer.daily_summary
 end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe Administrator do
 
       it { is_expected.not_to include(unmatching) }
     end
+
+    describe "#payroll_managers" do
+      subject(:payroll_managers) { described_class.payroll_managers }
+
+      let!(:matching) { create(:administrator, roles: [:functional_administrator, :payroll_manager]) }
+      let!(:unmatching) { create(:administrator, roles: [:employer_recruiter, :hr_manager]) }
+
+      it { is_expected.to match([matching]) }
+
+      it { is_expected.not_to include(unmatching) }
+    end
   end
 
   describe "before_validation callbacks" do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -303,6 +303,45 @@ RSpec.describe JobApplication do
         it { expect(NotificationsMailer).not_to have_received(:with) }
       end
     end
+
+    describe "#notify_payroll_managers_contract_received" do
+      subject(:contract_received) { job_application.contract_received! }
+
+      let(:job_application) { create(:job_application, state: :contract_feedback_waiting) }
+
+      context "when the job application has at least one payroll_manager" do
+        let(:administrator) { create(:administrator, roles: [:payroll_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          create(:job_offer_actor, job_offer: job_application.job_offer, administrator:, role: :employer)
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_received: mailer_double
+          )
+          contract_received
+        end
+
+        it { expect(NotificationsMailer).to have_received(:with).with(administrator:, job_application:) }
+
+        it { expect(NotificationsMailer).to have_received(:contract_received) }
+      end
+
+      context "when the job application doesn't have any payroll managers" do
+        let(:administrator) { create(:administrator, roles: [:payroll_manager]) }
+        let(:mailer_double) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+        before do
+          allow(NotificationsMailer).to receive_messages(
+            with: NotificationsMailer,
+            contract_received: mailer_double
+          )
+          contract_received
+        end
+
+        it { expect(NotificationsMailer).not_to have_received(:with) }
+      end
+    end
   end
 end
 

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe JobOffer do
     it { is_expected.to have_many(:employer_recruiters).through(:job_offer_actors) }
 
     it { is_expected.to have_many(:hr_managers).through(:job_offer_actors) }
+
+    it { is_expected.to have_many(:payroll_managers).through(:job_offer_actors) }
   end
 
   describe "delegations" do


### PR DESCRIPTION
# Description

Quand une candidature passe à l'état `contract_received` ("dossier de paie"), on envoie un email à tous les gestionnaires paie affectés à l'offre correspondante.

# Review app

https://erecrutement-cvd-staging-pr2046.osc-fr1.scalingo.io

# Links

Closes #1984

# Screenshots

<img width="2978" height="1256" alt="CleanShot 2026-02-02 at 08 29 16@2x" src="https://github.com/user-attachments/assets/84395366-d61e-42ae-8cb1-c542db7f5f76" />

