### PR TITLE
Update applicant email wordings

### DIFF
--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -75,7 +75,11 @@ class ApplicantNotificationsMailer < ApplicationMailer
     @state = JobApplication.human_attribute_name("state/#{params[:state]}")
     @service_name = @job_offer.organization.service_name
 
-    mail to: @user.email, subject: t(".subject")
+    mail to: @user.email, subject: t(
+      ".subject",
+      job_offer_identifier: @job_offer.identifier,
+      service_name: @job_offer.organization.service_name
+    )
   end
 
   def notify_rejected

--- a/app/views/applicant_notifications_mailer/notify_new_state.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_new_state.html.erb
@@ -9,8 +9,8 @@
 
 <p>
   Votre candidature est passée à l'étape
-  <%= @state %> !
-  Vous avez probablement de nouvelles actions à effectuer.
+  <%= @state %>.
+  Merci de bien vouloir consulter votre candidature pour vérifier si une action est requise de votre part.
 </p>
 
 <p>

--- a/app/views/applicant_notifications_mailer/notify_rejected.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_rejected.html.erb
@@ -12,7 +12,7 @@
 </p>
 
 <p>
-  Nous vous invitons à rester à l'écoute des offres que nous serons amenées à proposer dans les prochains mois sur notre site
+  Nous vous invitons consulter régulièrement les offres proposées sur notre site
   <%= link_to @service_name, ENV.fetch('DEFAULT_HOST') %>.
 </p>
 

--- a/app/views/applicant_notifications_mailer/notify_rejected.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_rejected.html.erb
@@ -12,7 +12,7 @@
 </p>
 
 <p>
-  Nous vous invitons consulter régulièrement les offres proposées sur notre site
+  Nous vous invitons à consulter régulièrement les offres proposées sur notre site
   <%= link_to @service_name, ENV.fetch('DEFAULT_HOST') %>.
 </p>
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -177,7 +177,7 @@ fr:
     send_job_offer:
       subject: "Nouvelle offre"
     notify_new_state:
-      subject: "Votre candidature : nouvelle étape"
+      subject: "Votre candidature à l'offre %{job_offer_identifier} sur %{service_name}"
     notify_rejected:
       subject: "Votre candidature a été refusée"
   notifications_mailer:

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ApplicantNotificationsMailer do
     let(:job_offer) { job_application.job_offer }
     let(:state) { "phone_meeting" }
 
-    it { expect(notify_new_state.subject).to eq("Votre candidature : nouvelle étape") }
+    it { expect(notify_new_state.subject).to include("Votre candidature") }
 
     it { expect(notify_new_state.body.encoded).to match(/Votre candidature est passée à l'étape/) }
   end


### PR DESCRIPTION
# Description

On met à jour les wordings des emails de notification du candidat : 

1/ Le candidat est passé à l’étape suivante 

<img width="1109" height="457" alt="CleanShot 2026-02-28 at 09 19 45" src="https://github.com/user-attachments/assets/aa1e99b6-c315-485a-aa6f-232165b58710" />


2/ Le candidat est passé à l’état refus/désistement

<img width="864" height="515" alt="CleanShot 2026-02-28 at 09 19 28" src="https://github.com/user-attachments/assets/01a3c413-c1fa-4c8e-8465-c080967704e7" />


# Review app

https://erecrutement-cvd-staging-pr2066.osc-fr1.scalingo.io

# Links

Closes #1933