### PR TITLE
Update JobApplicationFileType kinds and remove from_state

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,10 @@ require:
 AllCops:
   NewCops: enable
   Exclude:
-    - 'bin/{bundle,rails,rake,setup,spring,update}'
+    - "bin/{bundle,rails,rake,setup,spring,update}"
     - "db/**/*"
-    - 'node_modules/**/*'
-    - 'vendor/bundle/**/*'
+    - "node_modules/**/*"
+    - "vendor/bundle/**/*"
 
 RSpec/ExampleLength:
   Enabled: false
@@ -24,7 +24,7 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 
 RSpec/FilePath:
   Enabled: false

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::JobOffersController < Admin::BaseController
+  before_action :set_employers, only: %i[index archived featured]
   before_action :set_job_offers, only: %i[index archived featured]
   layout :choose_layout
 
@@ -192,8 +193,11 @@ class Admin::JobOffersController < Admin::BaseController
 
   private
 
-  def set_job_offers
+  def set_employers
     @employers = Employer.tree
+  end
+
+  def set_job_offers
     @job_offers_active = @job_offers.admin_index_active
     @job_offers_featured = @job_offers.admin_index_featured
     @job_offers_archived = @job_offers.admin_index_archived
@@ -206,7 +210,8 @@ class Admin::JobOffersController < Admin::BaseController
     end
     job_offers_nearly_filtered = @job_offers_unfiltered
     if params[:s].present?
-      job_offers_nearly_filtered = job_offers_nearly_filtered.search_full_text(params[:s])
+      job_offers_nearly_filtered = job_offers_nearly_filtered
+        .search_full_text(params[:s])
         .unscope(:order)
     end
     @q = job_offers_nearly_filtered.ransack(params[:q])

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -40,7 +40,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :description,
       :kind,
       :content,
-      :to_state,
       :required,
       :required_to_state,
       :notification,

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -41,7 +41,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :kind,
       :content,
       :required,
-      :required_to_state,
       :notification,
       visibility_rules_attributes: [:id, :by, :state, :_destroy]
     ]

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -3,9 +3,65 @@
 class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::InheritedResourcesController
   # rubocop:enable Layout/LineLength
 
+  def new
+    build_resource
+    build_visibility_rules
+  end
+
+  def edit
+    resource
+    build_visibility_rules
+  end
+
+  def create
+    build_resource
+    if resource.save
+      redirect_to collection_url, notice: t(".success")
+    else
+      build_visibility_rules
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    if resource.update(permitted_params)
+      redirect_to collection_url, notice: t(".success")
+    else
+      build_visibility_rules
+      render :edit, status: :unprocessable_content
+    end
+  end
+
   protected
 
   def permitted_fields
-    %i[name description kind content from_state to_state required required_from_state required_to_state notification]
+    [
+      :name,
+      :description,
+      :kind,
+      :content,
+      :from_state,
+      :to_state,
+      :required,
+      :required_from_state,
+      :required_to_state,
+      :notification,
+      visibility_rules_attributes: [:id, :by, :state, :_destroy]
+    ]
+  end
+
+  private
+
+  def build_visibility_rules
+    @visibility_rules_for_administrator = JobApplication.states.keys.map do |state|
+      find_or_initialize_by(by: :administrator, state:)
+    end
+    @visibility_rules_for_user = JobApplication.states.keys.map do |state|
+      find_or_initialize_by(by: :user, state:)
+    end
+  end
+
+  def find_or_initialize_by(by:, state:)
+    @job_application_file_type.visibility_rules.find_or_initialize_by(by:, state:)
   end
 end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -42,7 +42,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :content,
       :to_state,
       :required,
-      :required_from_state,
       :required_to_state,
       :notification,
       visibility_rules_attributes: [:id, :by, :state, :_destroy]

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -40,7 +40,6 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :description,
       :kind,
       :content,
-      :from_state,
       :to_state,
       :required,
       :required_from_state,

--- a/app/helpers/admin/job_applications_helper.rb
+++ b/app/helpers/admin/job_applications_helper.rb
@@ -67,9 +67,12 @@ module Admin::JobApplicationsHelper
   def job_application_resume_url(job_application)
     return unless job_application
 
-    target_state = JobApplication.states["initial"]
-    target_file_type = JobApplicationFileType.where(from_state: target_state, kind: :applicant_provided)
-    job_application_files = job_application.job_application_files.where(job_application_file_type: target_file_type).joins(:job_application_file_type).order("job_application_file_types.position")
+    target_file_type = JobApplicationFileType.visible_by_user(:initial)
+    job_application_files = job_application
+      .job_application_files
+      .where(job_application_file_type: target_file_type)
+      .joins(:job_application_file_type)
+      .order("job_application_file_types.position")
     job_application_file = job_application_files.limit(1).first
     if job_application_file&.document_content&.present?
       url_for([:admin, job_application, job_application_file, {format: :pdf}])

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -340,12 +340,18 @@ class JobApplication < ApplicationRecord
     errors.add(:state, :complete_files_before_draft_contract)
   end
 
-  def required_files_not_validated = errors.add(:state, :required_files_missing)
+  def required_files_not_validated = errors.add(:state, :required_files_missing, documents: required_files)
 
   def required_files_validated?
     required_types = JobApplicationFileType.required(state_was)
     validated_files = job_application_files.where(job_application_file_type: required_types).select(&:validated?)
     required_types.count == validated_files.count
+  end
+
+  def required_files
+    required_types = JobApplicationFileType.required(state_was)
+    validated_type_ids = job_application_files.where(job_application_file_type: required_types).select(&:validated?).map(&:job_application_file_type_id)
+    required_types.where.not(id: validated_type_ids).pluck(:name).join(", ")
   end
 
   def cant_be_accepted_twice = errors.add(:state, :cant_be_accepted_twice)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -238,34 +238,6 @@ class JobApplication < ApplicationRecord
     self.administrator_notifications_count = emails_administrator_unread_count + files_unread_count
   end
 
-  # Return two arrays
-  # First with JobApplicationFile already existing or that need to be fill
-  # Second with JobApplicationFileType where no instance exist in first array
-  def files_to_be_provided
-    result = {}
-    result[:must_be_provided_files] = []
-    result[:optional_file_types] = []
-
-    visible_file_type_ids = JobApplicationFileType.visible_by_user_up_to(state).reorder(nil).pluck(:id).to_set
-
-    JobApplicationFileType.all.find_each do |file_type|
-      existing_file = job_application_files.detect { |file|
-        file.job_application_file_type == file_type
-      }
-
-      if existing_file
-        result[:must_be_provided_files] << existing_file
-      elsif visible_file_type_ids.include?(file_type.id)
-        virgin = job_application_files.build(job_application_file_type: file_type)
-        result[:must_be_provided_files] << virgin
-      else
-        result[:optional_file_types] << file_type
-      end
-    end
-
-    result
-  end
-
   def send_confirmation_email
     job_offer_identifier = job_offer.identifier
     service_name = job_offer.organization.service_name

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -59,6 +59,12 @@ class JobApplication < ApplicationRecord
 
   before_validation :set_employer
   before_save :compute_notifications_counter
+  after_save :create_required_job_application_files,
+    if: -> {
+      saved_change_to_state? &&
+        state_previously_was.present? &&
+        JobApplication.states[state] > JobApplication.states[state_previously_was]
+    }
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze
@@ -324,6 +330,13 @@ class JobApplication < ApplicationRecord
     required_types = JobApplicationFileType.required(state_was)
     validated_type_ids = job_application_files.where(job_application_file_type: required_types).select(&:validated?).map(&:job_application_file_type_id)
     required_types.where.not(id: validated_type_ids).pluck(:name).join(", ")
+  end
+
+  def create_required_job_application_files
+    existing_type_ids = job_application_files.reload.pluck(:job_application_file_type_id)
+    JobApplicationFileType.required(state).where.not(id: existing_type_ids).find_each do |file_type|
+      job_application_files.create!(job_application_file_type: file_type, do_not_provide_immediately: true)
+    end
   end
 
   def cant_be_accepted_twice = errors.add(:state, :cant_be_accepted_twice)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -51,10 +51,9 @@ class JobApplication < ApplicationRecord
   validate :cant_accept_before_delay
   validate :cant_accept_remaining_initial_job_applications
   validate :cant_skip_mandatory_state, on: :update
-  validate :complete_files_before_draft_contract
-  validate :required_files_not_validated,
+  validate :requested_files_not_validated,
     if: -> { state_changed? && state_was.present? && JobApplication.states[state] > JobApplication.states[state_was] },
-    unless: -> { required_files_validated? }
+    unless: -> { requested_files_validated? }
   validate :cant_be_accepted_twice, if: -> { accepted? }, unless: -> { has_accepted_other_job_application? }
 
   before_validation :set_employer
@@ -307,29 +306,22 @@ class JobApplication < ApplicationRecord
 
   def mandatory_states = ORDERED_STATES.reject { |s| SKIPPABLE_STATES.include?(s) && s != state && s != state_was }
 
-  def complete_files_before_draft_contract
-    return if state.to_s != "contract_drafting"
+  def requested_files_not_validated = errors.add(:state, :requested_files_missing, documents: requested_files)
 
-    default_types = JobApplicationFileType.visible_by_user(:accepted).pluck(:id)
-    validated_types = job_application_files.where(is_validated: true).pluck(:job_application_file_type_id)
-
-    return if (default_types - validated_types).blank?
-
-    errors.add(:state, :complete_files_before_draft_contract)
+  def requested_files_validated?
+    mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
+    requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
+    types_to_validate = mandatory_type_ids & requested_type_ids
+    validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
+    types_to_validate.subset?(validated_type_ids)
   end
 
-  def required_files_not_validated = errors.add(:state, :required_files_missing, documents: required_files)
-
-  def required_files_validated?
-    required_types = JobApplicationFileType.required(state_was)
-    validated_files = job_application_files.where(job_application_file_type: required_types).select(&:validated?)
-    required_types.count == validated_files.count
-  end
-
-  def required_files
-    required_types = JobApplicationFileType.required(state_was)
-    validated_type_ids = job_application_files.where(job_application_file_type: required_types).select(&:validated?).map(&:job_application_file_type_id)
-    required_types.where.not(id: validated_type_ids).pluck(:name).join(", ")
+  def requested_files
+    mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
+    requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
+    validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
+    unvalidated_ids = (mandatory_type_ids & requested_type_ids) - validated_type_ids
+    JobApplicationFileType.where(id: unvalidated_ids).pluck(:name).join(", ")
   end
 
   def create_required_job_application_files

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -331,7 +331,7 @@ class JobApplication < ApplicationRecord
   def complete_files_before_draft_contract
     return if state.to_s != "contract_drafting"
 
-    default_types = JobApplicationFileType.for_applicant(:accepted).pluck(:id)
+    default_types = JobApplicationFileType.visible_by_user(:accepted).pluck(:id)
     validated_types = job_application_files.where(is_validated: true).pluck(:job_application_file_type_id)
 
     return if (default_types - validated_types).blank?

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -52,7 +52,9 @@ class JobApplication < ApplicationRecord
   validate :cant_accept_remaining_initial_job_applications
   validate :cant_skip_mandatory_state, on: :update
   validate :complete_files_before_draft_contract
-  validate :required_files_not_validated, if: -> { state_changed? }, unless: -> { required_files_validated? }
+  validate :required_files_not_validated,
+    if: -> { state_changed? && state_was.present? && JobApplication.states[state] > JobApplication.states[state_was] },
+    unless: -> { required_files_validated? }
   validate :cant_be_accepted_twice, if: -> { accepted? }, unless: -> { has_accepted_other_job_application? }
 
   before_validation :set_employer

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -246,17 +246,16 @@ class JobApplication < ApplicationRecord
     result[:must_be_provided_files] = []
     result[:optional_file_types] = []
 
+    visible_file_type_ids = JobApplicationFileType.visible_by_user_up_to(state).reorder(nil).pluck(:id).to_set
+
     JobApplicationFileType.all.find_each do |file_type|
       existing_file = job_application_files.detect { |file|
         file.job_application_file_type == file_type
       }
 
-      from_state_as_val = JobApplication.states[file_type.from_state]
-      current_state_as_val = JobApplication.states[state]
-
       if existing_file
         result[:must_be_provided_files] << existing_file
-      elsif current_state_as_val >= from_state_as_val
+      elsif visible_file_type_ids.include?(file_type.id)
         virgin = job_application_files.build(job_application_file_type: file_type)
         result[:must_be_provided_files] << virgin
       else

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -43,11 +43,13 @@ class JobApplicationFile < ApplicationRecord
     is_validated == 0
   end
 
-  def downloadable? = job_application_state < max_downloadable_state
+  def downloadable? = JobApplication.states[job_application_state] < max_downloadable_state
 
   private
 
-  def max_downloadable_state = job_application_file_type.required_to_state
+  def max_downloadable_state
+    job_application_file_type.visibility_rules.where(by: :administrator).maximum(:state)
+  end
 end
 
 # == Schema Information

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -4,7 +4,7 @@
 # The list of names/types is managed by the administrators of the platform.
 class JobApplicationFileType < ApplicationRecord
   # TODO: @sebastiencarceles remove these columns from DB after v2
-  self.ignored_columns += %i[from_state required_from_state to_state]
+  self.ignored_columns += %i[from_state required_from_state to_state required_to_state]
 
   acts_as_list
   default_scope -> { order(position: :asc) }
@@ -12,7 +12,6 @@ class JobApplicationFileType < ApplicationRecord
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
 
   validates :name, :kind, presence: true
-  validates :required_to_state, if: -> { required? }, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
 
@@ -23,8 +22,6 @@ class JobApplicationFileType < ApplicationRecord
     employer_provided: 12,
     check_only_admin_only: 40
   }
-
-  enum required_to_state: JobApplication.states, _prefix: true
 
   scope :visible_by_user, ->(state) {
     where(kind: :applicant_provided)

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -3,12 +3,15 @@
 # The name/type of file attached to a job application.
 # The list of names/types is managed by the administrators of the platform.
 class JobApplicationFileType < ApplicationRecord
+  # TODO: @sebastiencarceles remove these columns from DB after v2
+  self.ignored_columns += %i[from_state]
+
   acts_as_list
   default_scope -> { order(position: :asc) }
 
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
 
-  validates :name, :kind, :from_state, :to_state, presence: true
+  validates :name, :kind, :to_state, presence: true
   validates :required_from_state, :required_to_state, if: -> { required? }, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
@@ -21,7 +24,6 @@ class JobApplicationFileType < ApplicationRecord
     check_only_admin_only: 40
   }
 
-  enum from_state: JobApplication.states
   enum to_state: JobApplication.states, _prefix: true
   enum required_from_state: JobApplication.states, _prefix: true
   enum required_to_state: JobApplication.states, _prefix: true

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -4,14 +4,14 @@
 # The list of names/types is managed by the administrators of the platform.
 class JobApplicationFileType < ApplicationRecord
   # TODO: @sebastiencarceles remove these columns from DB after v2
-  self.ignored_columns += %i[from_state required_from_state]
+  self.ignored_columns += %i[from_state required_from_state to_state]
 
   acts_as_list
   default_scope -> { order(position: :asc) }
 
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
 
-  validates :name, :kind, :to_state, presence: true
+  validates :name, :kind, presence: true
   validates :required_to_state, if: -> { required? }, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
@@ -24,7 +24,6 @@ class JobApplicationFileType < ApplicationRecord
     check_only_admin_only: 40
   }
 
-  enum to_state: JobApplication.states, _prefix: true
   enum required_to_state: JobApplication.states, _prefix: true
 
   scope :visible_by_user, ->(state) {

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -53,6 +53,25 @@ class JobApplicationFileType < ApplicationRecord
       .distinct
   }
 
+  scope :mandatory, ->(state) {
+    state_value = JobApplication.states[state]
+
+    where(
+      required: true,
+      id: VisibilityRule.where(by: :administrator)
+        .where("state <= ?", state_value)
+        .select(:job_application_file_type_id)
+    ).or(
+      where(
+        required: false,
+        id: VisibilityRule.where(by: :administrator)
+          .group(:job_application_file_type_id)
+          .having("MAX(state) < ?", state_value)
+          .select(:job_application_file_type_id)
+      )
+    )
+  }
+
   has_many :job_application_files, dependent: :nullify
   has_many :visibility_rules, dependent: :destroy
   accepts_nested_attributes_for :visibility_rules, allow_destroy: true

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -20,6 +20,7 @@ class JobApplicationFileType < ApplicationRecord
   # Enums
   enum kind: {
     applicant_provided: 10,
+    employment_authority_provided: 13,
     manager_provided: 11,
     employer_provided: 12,
     check_only_admin_only: 40

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -6,18 +6,13 @@ class JobApplicationFileType < ApplicationRecord
   acts_as_list
   default_scope -> { order(position: :asc) }
 
-  #####################################
-  # File uploads
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
-
-  #####################################
-  # Validations
 
   validates :name, :kind, :from_state, :to_state, presence: true
   validates :required_from_state, :required_to_state, if: -> { required? }, presence: true
+  validate :must_have_administrator_visibility_rule
+  validate :must_have_user_visibility_rule
 
-  #####################################
-  # Enums
   enum kind: {
     applicant_provided: 10,
     employment_authority_provided: 13,
@@ -44,9 +39,20 @@ class JobApplicationFileType < ApplicationRecord
       .where("required_to_state > ?", JobApplication.states[state])
   }
 
-  #####################################
-  # Relations
   has_many :job_application_files, dependent: :nullify
+  has_many :visibility_rules, dependent: :destroy
+
+  private
+
+  def must_have_administrator_visibility_rule
+    errors.add(:visibility_rules, :must_have_administrator) unless visibility_rules.any?(&:administrator?)
+  end
+
+  def must_have_user_visibility_rule
+    errors.add(:visibility_rules, :must_have_user) unless visibility_rules.any?(&:user?)
+  end
+
+  public
 
   def is_mandatory?(state)
     from_state_as_val = JobApplication.states[from_state]

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -4,7 +4,7 @@
 # The list of names/types is managed by the administrators of the platform.
 class JobApplicationFileType < ApplicationRecord
   # TODO: @sebastiencarceles remove these columns from DB after v2
-  self.ignored_columns += %i[from_state]
+  self.ignored_columns += %i[from_state required_from_state]
 
   acts_as_list
   default_scope -> { order(position: :asc) }
@@ -12,7 +12,7 @@ class JobApplicationFileType < ApplicationRecord
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
 
   validates :name, :kind, :to_state, presence: true
-  validates :required_from_state, :required_to_state, if: -> { required? }, presence: true
+  validates :required_to_state, if: -> { required? }, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
 
@@ -25,7 +25,6 @@ class JobApplicationFileType < ApplicationRecord
   }
 
   enum to_state: JobApplication.states, _prefix: true
-  enum required_from_state: JobApplication.states, _prefix: true
   enum required_to_state: JobApplication.states, _prefix: true
 
   scope :visible_by_user, ->(state) {

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -37,6 +37,13 @@ class JobApplicationFileType < ApplicationRecord
       .distinct
   }
 
+  scope :visible_by_administrator, ->(state) {
+    joins(:visibility_rules)
+      .where(visibility_rules: {by: :administrator})
+      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .distinct
+  }
+
   scope :required, ->(state) {
     where(
       id: VisibilityRule.where(by: :administrator)

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -45,12 +45,12 @@ class JobApplicationFileType < ApplicationRecord
   }
 
   scope :required, ->(state) {
-    where(
-      id: VisibilityRule.where(by: :administrator)
-        .group(:job_application_file_type_id)
-        .having("MAX(state) <= ?", JobApplication.states[state])
-        .select(:job_application_file_type_id)
-    )
+    where(required: true)
+      .joins(:visibility_rules)
+      .where(visibility_rules: {by: :administrator})
+      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .reorder(nil)
+      .distinct
   }
 
   has_many :job_application_files, dependent: :nullify

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -41,15 +41,18 @@ class JobApplicationFileType < ApplicationRecord
 
   has_many :job_application_files, dependent: :nullify
   has_many :visibility_rules, dependent: :destroy
+  accepts_nested_attributes_for :visibility_rules, allow_destroy: true
 
   private
 
   def must_have_administrator_visibility_rule
-    errors.add(:visibility_rules, :must_have_administrator) unless visibility_rules.any?(&:administrator?)
+    rules = visibility_rules.reject(&:marked_for_destruction?)
+    errors.add(:visibility_rules, :must_have_administrator) unless rules.any?(&:administrator?)
   end
 
   def must_have_user_visibility_rule
-    errors.add(:visibility_rules, :must_have_user) unless visibility_rules.any?(&:user?)
+    rules = visibility_rules.reject(&:marked_for_destruction?)
+    errors.add(:visibility_rules, :must_have_user) unless rules.any?(&:user?)
   end
 
   public

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -26,17 +26,27 @@ class JobApplicationFileType < ApplicationRecord
   enum required_from_state: JobApplication.states, _prefix: true
   enum required_to_state: JobApplication.states, _prefix: true
 
-  scope :for_states_around, ->(state) {
+  scope :visible_by_user, ->(state) {
     where(kind: :applicant_provided)
-      .where("from_state <= ?", JobApplication.states[state])
-      .where("to_state > ?", JobApplication.states[state])
+      .joins(:visibility_rules)
+      .where(visibility_rules: {by: :user, state:})
   }
 
-  scope :for_applicant, ->(state) { where(kind: :applicant_provided, from_state: JobApplication.states[state]) }
+  scope :visible_by_user_up_to, ->(state) {
+    where(kind: :applicant_provided)
+      .joins(:visibility_rules)
+      .where(visibility_rules: {by: :user})
+      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .distinct
+  }
+
   scope :required, ->(state) {
-    where(required: true)
-      .where("required_from_state <= ?", JobApplication.states[state])
-      .where("required_to_state > ?", JobApplication.states[state])
+    where(
+      id: VisibilityRule.where(by: :administrator)
+        .group(:job_application_file_type_id)
+        .having("MAX(state) <= ?", JobApplication.states[state])
+        .select(:job_application_file_type_id)
+    )
   }
 
   has_many :job_application_files, dependent: :nullify
@@ -53,15 +63,6 @@ class JobApplicationFileType < ApplicationRecord
   def must_have_user_visibility_rule
     rules = visibility_rules.reject(&:marked_for_destruction?)
     errors.add(:visibility_rules, :must_have_user) unless rules.any?(&:user?)
-  end
-
-  public
-
-  def is_mandatory?(state)
-    from_state_as_val = JobApplication.states[from_state]
-    current_state_as_val = JobApplication.states[state]
-
-    current_state_as_val >= from_state_as_val
   end
 end
 

--- a/app/models/visibility_rule.rb
+++ b/app/models/visibility_rule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class VisibilityRule < ApplicationRecord
+  belongs_to :job_application_file_type
+
+  enum by: {administrator: "administrator", user: "user"}
+  enum state: JobApplication.states
+
+  validates :by, presence: true
+  validates :state, presence: true
+end
+
+# == Schema Information
+#
+# Table name: visibility_rules
+#
+#  id                           :uuid             not null, primary key
+#  by                           :string           default("administrator"), not null
+#  state                        :integer          default("initial"), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  job_application_file_type_id :uuid             not null
+#
+# Indexes
+#
+#  index_visibility_rules_on_job_application_file_type_id  (job_application_file_type_id)
+#
+# Foreign Keys
+#
+#  fk_rails_2da155b95c  (job_application_file_type_id => job_application_file_types.id)
+#

--- a/app/views/account/job_application_files/index.html.haml
+++ b/app/views/account/job_application_files/index.html.haml
@@ -1,6 +1,5 @@
 - job_application_files = @job_application.job_application_files.to_a
-- job_application_file_types = JobApplicationFileType.for_states_around(@job_application.state)
-- job_application_file_types.each do |job_application_file_type|
+- JobApplicationFileType.visible_by_user(@job_application.state).each do |job_application_file_type|
   - job_application_file = job_application_files.detect { |x| x.job_application_file_type == job_application_file_type }
   - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)
   = render partial: 'file_name_upload', locals: {job_application_file: job_application_file, job_application: @job_application}

--- a/app/views/admin/inherited_resources/_element.html.haml
+++ b/app/views/admin/inherited_resources/_element.html.haml
@@ -8,8 +8,6 @@
       = element.code
   - if resource_class == JobApplicationFileType
     %td
-      = JobApplication.human_attribute_name("state/#{element.from_state}")
-    %td
       = JobApplication.human_attribute_name("state/#{element.to_state}")
     %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")

--- a/app/views/admin/inherited_resources/_element.html.haml
+++ b/app/views/admin/inherited_resources/_element.html.haml
@@ -8,8 +8,6 @@
       = element.code
   - if resource_class == JobApplicationFileType
     %td
-      = JobApplication.human_attribute_name("state/#{element.to_state}")
-    %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
   - if resource_class.reflect_on_association(:job_offers)
     %td.text-center

--- a/app/views/admin/inherited_resources/index.html.haml
+++ b/app/views/admin/inherited_resources/index.html.haml
@@ -15,7 +15,6 @@
         - else
           %th= resource_class.human_attribute_name(:name)
           - if resource_class == JobApplicationFileType
-            %th= resource_class.human_attribute_name(:to_state)
             %th= resource_class.human_attribute_name(:kind)
           - if resource_class == Employer
             %th= resource_class.human_attribute_name(:code)

--- a/app/views/admin/inherited_resources/index.html.haml
+++ b/app/views/admin/inherited_resources/index.html.haml
@@ -15,7 +15,6 @@
         - else
           %th= resource_class.human_attribute_name(:name)
           - if resource_class == JobApplicationFileType
-            %th= resource_class.human_attribute_name(:from_state)
             %th= resource_class.human_attribute_name(:to_state)
             %th= resource_class.human_attribute_name(:kind)
           - if resource_class == Employer

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -1,5 +1,4 @@
-- target_state = JobApplication.states["initial"]
-- target_file_type = JobApplicationFileType.where(from_state: target_state, kind: :applicant_provided)
+- target_file_type = JobApplicationFileType.visible_by_user(:initial)
 - job_application_files = job_application.job_application_files.where(job_application_file_type: target_file_type).joins(:job_application_file_type).order('job_application_file_types.position')
 - job_application_files = job_application_files.limit(1) if defined?(only_first) && only_first
 

--- a/app/views/admin/job_applications/files.html.haml
+++ b/app/views/admin/job_applications/files.html.haml
@@ -1,6 +1,5 @@
-- result = @job_application.files_to_be_provided
-- must_be_provided_files = result[:must_be_provided_files]
-- optional_file_types = result[:optional_file_types]
+- requested_files = @job_application.job_application_files
+- other_file_types = JobApplicationFileType.visible_by_administrator(@job_application.state).where.not(id: requested_files.select(:job_application_file_type_id))
 
 .card.job-application-files
   .card-header.with-subheader.bg-white.font-weight-bold.text-secondary
@@ -9,15 +8,15 @@
   .card-subheader.bg-card-bg.font-weight-bold.text-muted
     = t('.subtitle_1')
   .card-body.bg-white.files-list
-    - if must_be_provided_files.any?
-      = render partial: "/admin/job_application_files/job_application_file", collection: must_be_provided_files
+    - if requested_files.any?
+      = render partial: "/admin/job_application_files/job_application_file", collection: requested_files
     - else
       %em= t('.none_atm')
   .card-subheader.bg-card-bg.font-weight-bold.text-muted
     = t('.subtitle_2')
   .card-body.bg-white.files-list
     %small.text-italic.d-block.mb-3= t('.note')
-    - if optional_file_types.any?
-      = render partial: "/admin/job_application_files/optional_job_application_file_type", collection: optional_file_types, as: :job_application_file_type, locals: {job_application: @job_application}
+    - if other_file_types.any?
+      = render partial: "/admin/job_application_files/optional_job_application_file_type", collection: other_file_types, as: :job_application_file_type, locals: {job_application: @job_application}
     - else
       %em= t('.none')

--- a/app/views/admin/settings/inherited_resources/_element.html.haml
+++ b/app/views/admin/settings/inherited_resources/_element.html.haml
@@ -21,8 +21,6 @@
     %td
       = element.name
     %td
-      = JobApplication.human_attribute_name("state/#{element.from_state}")
-    %td
       = JobApplication.human_attribute_name("state/#{element.to_state}")
     %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")

--- a/app/views/admin/settings/inherited_resources/_element.html.haml
+++ b/app/views/admin/settings/inherited_resources/_element.html.haml
@@ -21,8 +21,6 @@
     %td
       = element.name
     %td
-      = JobApplication.human_attribute_name("state/#{element.to_state}")
-    %td
       = JobApplicationFileType.human_attribute_name("kind/#{element.kind}")
     %td
       = element.required? ? t('.affirmative') : t('.negative')

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -12,7 +12,6 @@
           = f.input :kind, collection: kinds, prompt: true
           = f.input :content
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
-          = f.input :from_state, collection: states, prompt: true
           = f.input :to_state, collection: states, prompt: true
           = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
           = f.input :required_from_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -12,7 +12,6 @@
           = f.input :kind, collection: kinds, prompt: true
           = f.input :content
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
-          = f.input :to_state, collection: states, prompt: true
           = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
           = f.input :required_to_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           - if f.object.errors[:visibility_rules].present?

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -17,7 +17,28 @@
           = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
           = f.input :required_from_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           = f.input :required_to_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
+          - if f.object.errors[:visibility_rules].present?
+            .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence
+          .form-group
+            %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_administrator")
+            - @visibility_rules_for_administrator.each do |vr|
+              = f.fields_for :visibility_rules, vr do |vrf|
+                = vrf.hidden_field :by
+                = vrf.hidden_field :state
+                .form-check
+                  = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
+                  %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
+          .form-group
+            %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_user")
+            - @visibility_rules_for_user.each do |vr|
+              = f.fields_for :visibility_rules, vr do |vrf|
+                = vrf.hidden_field :by
+                = vrf.hidden_field :state
+                .form-check
+                  = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
+                  %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
           = f.input :notification
+
         - elsif resource.is_a?(Cmg)
           = f.input :email
         - elsif resource.is_a?(EmailTemplate)

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -6,34 +6,7 @@
       = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
       .form-inputs
         - if resource.is_a?(JobApplicationFileType)
-          = f.input :name
-          = f.input :description
-          - kinds = JobApplicationFileType.kinds.map {|k, v| [ JobApplicationFileType.human_attribute_name("kind/#{k}"), k] }
-          = f.input :kind, collection: kinds, prompt: true
-          = f.input :content
-          = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
-          - if f.object.errors[:visibility_rules].present?
-            .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence
-          .form-group
-            %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_administrator")
-            - @visibility_rules_for_administrator.each do |vr|
-              = f.fields_for :visibility_rules, vr do |vrf|
-                = vrf.hidden_field :by
-                = vrf.hidden_field :state
-                .form-check
-                  = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
-                  %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
-          .form-group
-            %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_user")
-            - @visibility_rules_for_user.each do |vr|
-              = f.fields_for :visibility_rules, vr do |vrf|
-                = vrf.hidden_field :by
-                = vrf.hidden_field :state
-                .form-check
-                  = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
-                  %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
-          = f.input :notification
-
+          = render "admin/settings/job_application_file_types/form_fields", f: f
         - elsif resource.is_a?(Cmg)
           = f.input :email
         - elsif resource.is_a?(EmailTemplate)

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -11,9 +11,7 @@
           - kinds = JobApplicationFileType.kinds.map {|k, v| [ JobApplicationFileType.human_attribute_name("kind/#{k}"), k] }
           = f.input :kind, collection: kinds, prompt: true
           = f.input :content
-          - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
           = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
-          = f.input :required_to_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           - if f.object.errors[:visibility_rules].present?
             .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence
           .form-group

--- a/app/views/admin/settings/inherited_resources/_form.html.haml
+++ b/app/views/admin/settings/inherited_resources/_form.html.haml
@@ -14,7 +14,6 @@
           - states = JobApplication.states.map {|k, v| [ JobApplication.human_attribute_name("state/#{k}"), k] }
           = f.input :to_state, collection: states, prompt: true
           = f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
-          = f.input :required_from_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           = f.input :required_to_state, required: true, collection: states, prompt: true, wrapper_html: { data: { toggle_visibility_target: "toggleable" } }
           - if f.object.errors[:visibility_rules].present?
             .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence

--- a/app/views/admin/settings/inherited_resources/_table.html.haml
+++ b/app/views/admin/settings/inherited_resources/_table.html.haml
@@ -11,7 +11,6 @@
       - else
         %th= resource_class.human_attribute_name(:name)
         - if resource_class == JobApplicationFileType
-          %th= resource_class.human_attribute_name(:to_state)
           %th= resource_class.human_attribute_name(:kind)
           %th= resource_class.human_attribute_name(:required)
         - if resource_class == Employer

--- a/app/views/admin/settings/inherited_resources/_table.html.haml
+++ b/app/views/admin/settings/inherited_resources/_table.html.haml
@@ -11,7 +11,6 @@
       - else
         %th= resource_class.human_attribute_name(:name)
         - if resource_class == JobApplicationFileType
-          %th= resource_class.human_attribute_name(:from_state)
           %th= resource_class.human_attribute_name(:to_state)
           %th= resource_class.human_attribute_name(:kind)
           %th= resource_class.human_attribute_name(:required)

--- a/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
+++ b/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
@@ -3,7 +3,8 @@
 - kinds = JobApplicationFileType.kinds.map {|k, v| [ JobApplicationFileType.human_attribute_name("kind/#{k}"), k] }
 = f.input :kind, collection: kinds, prompt: true
 = f.input :content
-= f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
+- required_options = [[JobApplicationFileType.human_attribute_name("required/true"), true], [JobApplicationFileType.human_attribute_name("required/false"), false]]
+= f.input :required, as: :select, collection: required_options, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
 - if f.object.errors[:visibility_rules].present?
   .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence
 .form-group

--- a/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
+++ b/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
@@ -1,0 +1,27 @@
+= f.input :name
+= f.input :description
+- kinds = JobApplicationFileType.kinds.map {|k, v| [ JobApplicationFileType.human_attribute_name("kind/#{k}"), k] }
+= f.input :kind, collection: kinds, prompt: true
+= f.input :content
+= f.input :required, as: :radio_buttons, input_html: { data: { action: "toggle-visibility#toggle" } }, wrapper_html: { data: { toggle_visibility_target: "radioWrapper" } }
+- if f.object.errors[:visibility_rules].present?
+  .alert.alert-danger= f.object.errors[:visibility_rules].to_sentence
+.form-group
+  %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_administrator")
+  - @visibility_rules_for_administrator.each do |vr|
+    = f.fields_for :visibility_rules, vr do |vrf|
+      = vrf.hidden_field :by
+      = vrf.hidden_field :state
+      .form-check
+        = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
+        %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
+.form-group
+  %label= t("activerecord.attributes.job_application_file_type.visibility_rules_for_user")
+  - @visibility_rules_for_user.each do |vr|
+    = f.fields_for :visibility_rules, vr do |vrf|
+      = vrf.hidden_field :by
+      = vrf.hidden_field :state
+      .form-check
+        = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
+        %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
+= f.input :notification

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -46,8 +46,7 @@
               = link_to profile_form.object.resume_file_name, account_profiles_resume_path, target: '_blank'
 
     - job_application_files = @job_application.job_application_files.to_a
-    - current_state = JobApplication.states[@job_application.state]
-    - JobApplicationFileType.where("from_state <= ?", current_state).where(kind: :applicant_provided).each do |job_application_file_type, index|
+    - JobApplicationFileType.visible_by_user_up_to(@job_application.state).each do |job_application_file_type, index|
       - job_application_file = job_application_files.detect{|x| x.job_application_file_type == job_application_file_type}
       - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)
       = f.simple_fields_for :job_application_files, job_application_file, input_html: {placeholder: false, required: true} do |file_form|

--- a/app/views/job_applications/_form.html.haml
+++ b/app/views/job_applications/_form.html.haml
@@ -47,11 +47,7 @@
 
     - job_application_files = @job_application.job_application_files.to_a
     - current_state = JobApplication.states[@job_application.state]
-    - if @job_offer.spontaneous
-      - job_application_file_types = JobApplicationFileType.where(spontaneous: true)
-    - else
-      - job_application_file_types = JobApplicationFileType.where("from_state <= ?", current_state).where(kind: :applicant_provided).all
-    - job_application_file_types.each do |job_application_file_type, index|
+    - JobApplicationFileType.where("from_state <= ?", current_state).where(kind: :applicant_provided).each do |job_application_file_type, index|
       - job_application_file = job_application_files.detect{|x| x.job_application_file_type == job_application_file_type}
       - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)
       = f.simple_fields_for :job_application_files, job_application_file, input_html: {placeholder: false, required: true} do |file_form|

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1174,8 +1174,7 @@ fr:
             state:
               cant_accept_before_delay: "Un délai de 30 jours après la publication de l'offre sur CSP doit être respecté avant d'accepter une candidature"
               cant_accept_remaining_initial_job_applications: "Toutes les nouvelles candidatures doivent être traitées avant d'accepter une candidature"
-              complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
-              required_files_missing: "Des documents obligatoires sont manquants ou non validés : %{documents}"
+              requested_files_missing: "Des documents obligatoires sont manquants ou non validés : %{documents}"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
             cover_letter_content_type:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1264,7 +1264,6 @@ fr:
       job_application_file_type:
         visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
         visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
-        from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"
         required_from_state: "Obligatoire à partir de l'état"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1175,7 +1175,7 @@ fr:
               cant_accept_before_delay: "Un délai de 30 jours après la publication de l'offre sur CSP doit être respecté avant d'accepter une candidature"
               cant_accept_remaining_initial_job_applications: "Toutes les nouvelles candidatures doivent être traitées avant d'accepter une candidature"
               complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
-              required_files_missing: "Des documents obligatoires sont manquants ou non validés"
+              required_files_missing: "Des documents obligatoires sont manquants ou non validés : %{documents}"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
             cover_letter_content_type:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1185,6 +1185,11 @@ fr:
             photo:
               file_size_is_less_than_or_equal_to: "Est trop volumineuse (ne doit pas dépasser %{count})"
               allowed_file_content_types: "au mauvais format (seuls les formats JPG et PNG sont acceptés)"
+        job_application_file_type:
+          attributes:
+            visibility_rules:
+              must_have_administrator: "doit contenir au moins une règle pour le back office"
+              must_have_user: "doit contenir au moins une règle pour le front office"
         job_application_file:
           attributes:
             content:
@@ -1257,6 +1262,8 @@ fr:
         state/end_user_state_7: "Contrat reçu"
         state/end_user_state_8: "Affectée"
       job_application_file_type:
+        visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
+        visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
         from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1265,6 +1265,8 @@ fr:
         visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
         visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
         required: "Obligatoire"
+        required/true: "Par défaut pour tous les candidats"
+        required/false: "Uniquement si l'un des acteurs notifiés dans l'offre en fait la demande dans l'onglet « Documents »"
         kind: "Type"
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1266,6 +1266,7 @@ fr:
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"
         kind/employer_provided: "Fourni par l'employeur"
+        kind/employment_authority_provided: "Fourni par l'autorité d'emploi"
         kind/check_only_admin_only: "Fichier géré hors outil"
       job_offer:
         title: "Intitulé du poste"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1266,7 +1266,6 @@ fr:
         visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
         to_state: "État de fin"
         required: "Obligatoire"
-        required_from_state: "Obligatoire à partir de l'état"
         required_to_state: "Plus obligatoire à partir de l'état"
         kind: "Type"
         kind/applicant_provided: "Fourni par le candidat"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1261,8 +1261,8 @@ fr:
         state/end_user_state_7: "Contrat reçu"
         state/end_user_state_8: "Affectée"
       job_application_file_type:
-        visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
-        visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
+        visibility_rules_for_administrator: "États où le fichier sera accessible et visible en back office"
+        visibility_rules_for_user: "États où le fichier sera accessible et visible en front office"
         required: "Obligatoire"
         required/true: "Par défaut pour tous les candidats"
         required/false: "Uniquement si l'un des acteurs notifiés dans l'offre en fait la demande dans l'onglet « Documents »"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1264,7 +1264,6 @@ fr:
       job_application_file_type:
         visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
         visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
-        to_state: "État de fin"
         required: "Obligatoire"
         required_to_state: "Plus obligatoire à partir de l'état"
         kind: "Type"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1265,7 +1265,6 @@ fr:
         visibility_rules_for_administrator: "Étapes où le fichier sera accessible et visible en back office"
         visibility_rules_for_user: "Étapes où le fichier sera accessible et visible en front office"
         required: "Obligatoire"
-        required_to_state: "Plus obligatoire à partir de l'état"
         kind: "Type"
         kind/applicant_provided: "Fourni par le candidat"
         kind/manager_provided: "Fourni par le gestionnaire"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -99,7 +99,6 @@ fr:
       job_application_file_type:
         kind: "Type"
         content: "Fichier"
-        from_state: "État de début"
         to_state: "État de fin"
         required: "Obligatoire"
         required_from_state: "Obligatoire à partir de l'état"
@@ -248,7 +247,6 @@ fr:
         cover_letter: "Format PDF, max. 2Mo"
         website_url: "LinkedIn, Viadeo, portfolio, etc."
       job_application_file_type:
-        from_state: "État à partir duquel le fichier sera visible"
         to_state: "État à partir duquel le fichier ne sera plus visible"
         required_from_state: "Si le fichier n’est pas inséré, vous ne pourrez pas faire passer le candidat à l'étape suivante"
         required_to_state: "Le fichier ne sera plus visible"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -101,7 +101,6 @@ fr:
         content: "Fichier"
         to_state: "État de fin"
         required: "Obligatoire"
-        required_from_state: "Obligatoire à partir de l'état"
         required_to_state: "Plus obligatoire à partir de l'état"
       job_offer:
         title: "Intitulé du poste"
@@ -248,7 +247,6 @@ fr:
         website_url: "LinkedIn, Viadeo, portfolio, etc."
       job_application_file_type:
         to_state: "État à partir duquel le fichier ne sera plus visible"
-        required_from_state: "Si le fichier n’est pas inséré, vous ne pourrez pas faire passer le candidat à l'étape suivante"
         required_to_state: "Le fichier ne sera plus visible"
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -100,7 +100,6 @@ fr:
         kind: "Type"
         content: "Fichier"
         required: "Obligatoire"
-        required_to_state: "Plus obligatoire à partir de l'état"
       job_offer:
         title: "Intitulé du poste"
         professional_category: "Catégorie professionnelle"
@@ -244,8 +243,6 @@ fr:
         resume: "Format PDF, max. 2Mo"
         cover_letter: "Format PDF, max. 2Mo"
         website_url: "LinkedIn, Viadeo, portfolio, etc."
-      job_application_file_type:
-        required_to_state: "Le fichier ne sera plus visible"
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"
         days_before_publishing: "Indiquez un nombre de jours ouvrés. Laissez à 0 ou vide pour supprimer complètement le délai avant publication"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -99,7 +99,6 @@ fr:
       job_application_file_type:
         kind: "Type"
         content: "Fichier"
-        to_state: "État de fin"
         required: "Obligatoire"
         required_to_state: "Plus obligatoire à partir de l'état"
       job_offer:
@@ -246,7 +245,6 @@ fr:
         cover_letter: "Format PDF, max. 2Mo"
         website_url: "LinkedIn, Viadeo, portfolio, etc."
       job_application_file_type:
-        to_state: "État à partir duquel le fichier ne sera plus visible"
         required_to_state: "Le fichier ne sera plus visible"
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"

--- a/db/migrate/20260321000000_create_visibility_rules.rb
+++ b/db/migrate/20260321000000_create_visibility_rules.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateVisibilityRules < ActiveRecord::Migration[7.1]
+  def change
+    create_table :visibility_rules, id: :uuid do |t|
+      t.references :job_application_file_type, null: false, foreign_key: true, type: :uuid
+      t.string :by, null: false, default: "administrator"
+      t.integer :state, null: false, default: 0 # initial
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_26_084435) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -835,6 +835,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_26_084435) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  create_table "visibility_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "job_application_file_type_id", null: false
+    t.string "by", default: "administrator", null: false
+    t.integer "state", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_application_file_type_id"], name: "index_visibility_rules_on_job_application_file_type_id"
+  end
+
   create_table "zip_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -899,4 +908,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_26_084435) do
   add_foreign_key "salary_ranges", "experience_levels"
   add_foreign_key "salary_ranges", "professional_categories"
   add_foreign_key "salary_ranges", "sectors"
+  add_foreign_key "visibility_rules", "job_application_file_types"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -366,92 +366,75 @@ AvailabilityRange.create!(name: "Disponible sous 1 mois")
 AvailabilityRange.create!(name: "Disponible sous 2 mois")
 AvailabilityRange.create!(name: "Disponible sous 3 mois ou plus")
 
-cover_letter = JobApplicationFileType.create!(
-  name: "Lettre de Motivation",
-  kind: :applicant_provided,
-  from_state: :initial,
-  to_state: :accepted
+all_states = JobApplication.states.keys.map(&:to_sym)
+
+job_application_file_type_with_visibility_rules = ->(attrs, from_state, to_state) {
+  jaft = JobApplicationFileType.new(attrs)
+  from_idx = all_states.index(from_state)
+  to_idx = all_states.index(to_state)
+  all_states[from_idx...to_idx].each do |s|
+    jaft.visibility_rules.build(by: :administrator, state: s)
+    jaft.visibility_rules.build(by: :user, state: s)
+  end
+  jaft.save!
+  jaft
+}
+
+cover_letter = job_application_file_type_with_visibility_rules.call(
+  {name: "Lettre de Motivation", kind: :applicant_provided, from_state: :initial, to_state: :accepted},
+  :initial, :accepted
 )
-JobApplicationFileType.create!(
-  name: "Copie des diplômes",
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_received
+job_application_file_type_with_visibility_rules.call(
+  {name: "Copie des diplômes", kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  :accepted, :contract_received
 )
-JobApplicationFileType.create!(
-  name: "Justificatif de domicile de moins de 6 mois",
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_received
+job_application_file_type_with_visibility_rules.call(
+  {name: "Justificatif de domicile de moins de 6 mois", kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  :accepted, :contract_received
 )
-JobApplicationFileType.create!(
-  name: "Carte d'identité",
-  description: "Carte nationale d’identité recto/verso ou passeport",
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :affected
+job_application_file_type_with_visibility_rules.call(
+  {name: "Carte d’identité", description: "Carte nationale d’identité recto/verso ou passeport", kind: :applicant_provided, from_state: :accepted, to_state: :affected},
+  :accepted, :affected
 )
 description = "Attestation de carte vitale ou copie de carte vitale " \
   "(mentionnant le n° INSEE)"
-JobApplicationFileType.create!(
-  name: "Carte Vitale",
-  description: description,
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_received
+job_application_file_type_with_visibility_rules.call(
+  {name: "Carte Vitale", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  :accepted, :contract_received
 )
 description = "Certificat médical d’aptitude fourni par le médecin de l’établissement" \
   " ou à défaut par un médecin agréé"
-JobApplicationFileType.create!(
-  name: "Certificat Médical",
-  description: description,
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_received
+job_application_file_type_with_visibility_rules.call(
+  {name: "Certificat Médical", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  :accepted, :contract_received
 )
 description = "RIB original au format BIC/IBAN comportant le logo de la banque au nom du " \
   " signataire du contrat (les RIB sur compte épargne ne sont pas acceptés)"
-JobApplicationFileType.create!(
-  name: "Relevé d'identité bancaire",
-  description: description,
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :affected
+job_application_file_type_with_visibility_rules.call(
+  {name: "Relevé d’identité bancaire", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :affected},
+  :accepted, :affected
 )
-name = "Copie d'un titre de transport (si vous postulez en Île-de-france)"
-JobApplicationFileType.create!(
-  name: name,
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_feedback_waiting
+job_application_file_type_with_visibility_rules.call(
+  {name: "Copie d’un titre de transport (si vous postulez en Île-de-france)", kind: :applicant_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  :accepted, :contract_feedback_waiting
 )
 description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant au moment " \
   "de la date d’effet du recrutement"
-JobApplicationFileType.create!(
-  name: "Fiche de poste",
-  description: description,
-  kind: :manager_provided,
-  from_state: :accepted,
-  to_state: :contract_feedback_waiting
+job_application_file_type_with_visibility_rules.call(
+  {name: "Fiche de poste", description: description, kind: :manager_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  :accepted, :contract_feedback_waiting
 )
-JobApplicationFileType.create!(
-  name: "FICE transmis à officier sécurité",
-  kind: :check_only_admin_only,
-  from_state: :accepted,
-  to_state: :affected
+job_application_file_type_with_visibility_rules.call(
+  {name: "FICE transmis à officier sécurité", kind: :check_only_admin_only, from_state: :accepted, to_state: :affected},
+  :accepted, :affected
 )
-JobApplicationFileType.create!(
-  name: "Demande de B2",
-  kind: :check_only_admin_only,
-  from_state: :accepted,
-  to_state: :affected
+job_application_file_type_with_visibility_rules.call(
+  {name: "Demande de B2", kind: :check_only_admin_only, from_state: :accepted, to_state: :affected},
+  :accepted, :affected
 )
-JobApplicationFileType.create!(
-  name: "Copie du livret de famille",
-  description: "Seulement si marié",
-  kind: :applicant_provided,
-  from_state: :accepted,
-  to_state: :contract_feedback_waiting
+job_application_file_type_with_visibility_rules.call(
+  {name: "Copie du livret de famille", description: "Seulement si marié", kind: :applicant_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  :accepted, :contract_feedback_waiting
 )
 
 job_offer = JobOffer.new { |j|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -381,59 +381,59 @@ job_application_file_type_with_visibility_rules = ->(attrs, from_state, to_state
 }
 
 cover_letter = job_application_file_type_with_visibility_rules.call(
-  {name: "Lettre de Motivation", kind: :applicant_provided, to_state: :accepted},
+  {name: "Lettre de Motivation", kind: :applicant_provided},
   :initial, :accepted
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie des diplômes", kind: :applicant_provided, to_state: :contract_received},
+  {name: "Copie des diplômes", kind: :applicant_provided},
   :accepted, :contract_received
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Justificatif de domicile de moins de 6 mois", kind: :applicant_provided, to_state: :contract_received},
+  {name: "Justificatif de domicile de moins de 6 mois", kind: :applicant_provided},
   :accepted, :contract_received
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Carte d’identité", description: "Carte nationale d’identité recto/verso ou passeport", kind: :applicant_provided, to_state: :affected},
+  {name: "Carte d’identité", description: "Carte nationale d’identité recto/verso ou passeport", kind: :applicant_provided},
   :accepted, :affected
 )
 description = "Attestation de carte vitale ou copie de carte vitale " \
   "(mentionnant le n° INSEE)"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Carte Vitale", description: description, kind: :applicant_provided, to_state: :contract_received},
+  {name: "Carte Vitale", description: description, kind: :applicant_provided},
   :accepted, :contract_received
 )
 description = "Certificat médical d’aptitude fourni par le médecin de l’établissement" \
   " ou à défaut par un médecin agréé"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Certificat Médical", description: description, kind: :applicant_provided, to_state: :contract_received},
+  {name: "Certificat Médical", description: description, kind: :applicant_provided},
   :accepted, :contract_received
 )
 description = "RIB original au format BIC/IBAN comportant le logo de la banque au nom du " \
   " signataire du contrat (les RIB sur compte épargne ne sont pas acceptés)"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Relevé d’identité bancaire", description: description, kind: :applicant_provided, to_state: :affected},
+  {name: "Relevé d’identité bancaire", description: description, kind: :applicant_provided},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie d’un titre de transport (si vous postulez en Île-de-france)", kind: :applicant_provided, to_state: :contract_feedback_waiting},
+  {name: "Copie d’un titre de transport (si vous postulez en Île-de-france)", kind: :applicant_provided},
   :accepted, :contract_feedback_waiting
 )
 description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant au moment " \
   "de la date d’effet du recrutement"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Fiche de poste", description: description, kind: :manager_provided, to_state: :contract_feedback_waiting},
+  {name: "Fiche de poste", description: description, kind: :manager_provided},
   :accepted, :contract_feedback_waiting
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "FICE transmis à officier sécurité", kind: :check_only_admin_only, to_state: :affected},
+  {name: "FICE transmis à officier sécurité", kind: :check_only_admin_only},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Demande de B2", kind: :check_only_admin_only, to_state: :affected},
+  {name: "Demande de B2", kind: :check_only_admin_only},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie du livret de famille", description: "Seulement si marié", kind: :applicant_provided, to_state: :contract_feedback_waiting},
+  {name: "Copie du livret de famille", description: "Seulement si marié", kind: :applicant_provided},
   :accepted, :contract_feedback_waiting
 )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -381,59 +381,59 @@ job_application_file_type_with_visibility_rules = ->(attrs, from_state, to_state
 }
 
 cover_letter = job_application_file_type_with_visibility_rules.call(
-  {name: "Lettre de Motivation", kind: :applicant_provided, from_state: :initial, to_state: :accepted},
+  {name: "Lettre de Motivation", kind: :applicant_provided, to_state: :accepted},
   :initial, :accepted
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie des diplômes", kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  {name: "Copie des diplômes", kind: :applicant_provided, to_state: :contract_received},
   :accepted, :contract_received
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Justificatif de domicile de moins de 6 mois", kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  {name: "Justificatif de domicile de moins de 6 mois", kind: :applicant_provided, to_state: :contract_received},
   :accepted, :contract_received
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Carte d’identité", description: "Carte nationale d’identité recto/verso ou passeport", kind: :applicant_provided, from_state: :accepted, to_state: :affected},
+  {name: "Carte d’identité", description: "Carte nationale d’identité recto/verso ou passeport", kind: :applicant_provided, to_state: :affected},
   :accepted, :affected
 )
 description = "Attestation de carte vitale ou copie de carte vitale " \
   "(mentionnant le n° INSEE)"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Carte Vitale", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  {name: "Carte Vitale", description: description, kind: :applicant_provided, to_state: :contract_received},
   :accepted, :contract_received
 )
 description = "Certificat médical d’aptitude fourni par le médecin de l’établissement" \
   " ou à défaut par un médecin agréé"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Certificat Médical", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :contract_received},
+  {name: "Certificat Médical", description: description, kind: :applicant_provided, to_state: :contract_received},
   :accepted, :contract_received
 )
 description = "RIB original au format BIC/IBAN comportant le logo de la banque au nom du " \
   " signataire du contrat (les RIB sur compte épargne ne sont pas acceptés)"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Relevé d’identité bancaire", description: description, kind: :applicant_provided, from_state: :accepted, to_state: :affected},
+  {name: "Relevé d’identité bancaire", description: description, kind: :applicant_provided, to_state: :affected},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie d’un titre de transport (si vous postulez en Île-de-france)", kind: :applicant_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  {name: "Copie d’un titre de transport (si vous postulez en Île-de-france)", kind: :applicant_provided, to_state: :contract_feedback_waiting},
   :accepted, :contract_feedback_waiting
 )
 description = "Fiche de poste comportant le code poste ALLIANCE actif et vacant au moment " \
   "de la date d’effet du recrutement"
 job_application_file_type_with_visibility_rules.call(
-  {name: "Fiche de poste", description: description, kind: :manager_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  {name: "Fiche de poste", description: description, kind: :manager_provided, to_state: :contract_feedback_waiting},
   :accepted, :contract_feedback_waiting
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "FICE transmis à officier sécurité", kind: :check_only_admin_only, from_state: :accepted, to_state: :affected},
+  {name: "FICE transmis à officier sécurité", kind: :check_only_admin_only, to_state: :affected},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Demande de B2", kind: :check_only_admin_only, from_state: :accepted, to_state: :affected},
+  {name: "Demande de B2", kind: :check_only_admin_only, to_state: :affected},
   :accepted, :affected
 )
 job_application_file_type_with_visibility_rules.call(
-  {name: "Copie du livret de famille", description: "Seulement si marié", kind: :applicant_provided, from_state: :accepted, to_state: :contract_feedback_waiting},
+  {name: "Copie du livret de famille", description: "Seulement si marié", kind: :applicant_provided, to_state: :contract_feedback_waiting},
   :accepted, :contract_feedback_waiting
 )
 

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :job_application_file_type do
     name { "CV" }
-    to_state { :phone_meeting }
     kind { :applicant_provided }
 
     after(:build) do |jaft|

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :job_application_file_type do
     name { "CV" }
-    from_state { :initial }
     to_state { :phone_meeting }
     kind { :applicant_provided }
 

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -6,6 +6,11 @@ FactoryBot.define do
     from_state { :initial }
     to_state { :phone_meeting }
     kind { :applicant_provided }
+
+    after(:build) do |jaft|
+      jaft.visibility_rules.build(by: :administrator, state: :initial)
+      jaft.visibility_rules.build(by: :user, state: :initial)
+    end
   end
 end
 

--- a/spec/factories/visibility_rules.rb
+++ b/spec/factories/visibility_rules.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :visibility_rule do
+    job_application_file_type
+    by { :administrator }
+    state { :initial }
+  end
+end
+
+# == Schema Information
+#
+# Table name: visibility_rules
+#
+#  id                           :uuid             not null, primary key
+#  by                           :string           default("administrator"), not null
+#  state                        :integer          default("initial"), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  job_application_file_type_id :uuid             not null
+#
+# Indexes
+#
+#  index_visibility_rules_on_job_application_file_type_id  (job_application_file_type_id)
+#
+# Foreign Keys
+#
+#  fk_rails_2da155b95c  (job_application_file_type_id => job_application_file_types.id)
+#

--- a/spec/helpers/admin/job_applications_helper_spec.rb
+++ b/spec/helpers/admin/job_applications_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::JobApplicationsHelper do
+  describe "#job_application_resume_url" do
+    subject(:resume_url) { helper.job_application_resume_url(job_application) }
+
+    context "when job_application is nil" do
+      let(:job_application) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when job_application has a file with visible_by_user file type" do
+      let(:job_application) { create(:job_application) }
+      let(:job_application_file_type) { create(:job_application_file_type) }
+
+      before { create(:job_application_file, job_application:, job_application_file_type:) }
+
+      it { is_expected.to be_present }
+    end
+
+    context "when job_application has no matching file" do
+      let(:job_application) { create(:job_application) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when job_application has a file but file type is not visible by user at initial state" do
+      let(:job_application) { create(:job_application) }
+      let(:job_application_file_type) { create(:job_application_file_type, kind: :employer_provided) }
+
+      before { create(:job_application_file, job_application:, job_application_file_type:) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -10,18 +10,24 @@ RSpec.describe JobApplicationFile do
 
     let(:job_application_file) { build(:job_application_file, job_application:, job_application_file_type:) }
     let(:job_application) { build(:job_application, state: current_state) }
-    let(:job_application_file_type) { build(:job_application_file_type, required_to_state: max_downloadable_state) }
+    let(:job_application_file_type) { create(:job_application_file_type) }
 
-    context "when the current state is before the max downloadable state" do
+    context "when the current state is before the max administrator visibility rule" do
       let(:current_state) { :initial }
-      let(:max_downloadable_state) { :phone_meeting }
+
+      before { job_application_file_type.visibility_rules.create!(by: :administrator, state: :phone_meeting) }
 
       it { is_expected.to be(true) }
     end
 
-    context "when the current state is afterr the max downloadable state" do
+    context "when the current state equals the max administrator visibility rule" do
+      let(:current_state) { :initial }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the current state is after the max administrator visibility rule" do
       let(:current_state) { :phone_meeting }
-      let(:max_downloadable_state) { :phone_meeting }
 
       it { is_expected.to be(false) }
     end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -37,32 +37,78 @@ RSpec.describe JobApplicationFileType do
   end
 
   describe "scopes" do
-    describe "#for_states_around" do
-      subject { described_class.for_states_around(:accepted) }
+    describe "#visible_by_user" do
+      subject { described_class.visible_by_user(:phone_meeting) }
 
-      let!(:jaft_around) { create(:job_application_file_type, from_state: :to_be_met, to_state: :contract_drafting) }
-      let!(:jaft_not_around) { create(:job_application_file_type, from_state: :contract_drafting, to_state: :affected) }
+      let!(:jaft_visible) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :phone_meeting)
+        end
+      end
+      let!(:jaft_not_visible) { create(:job_application_file_type) }
+      let!(:jaft_admin_only) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
+      end
 
-      it { is_expected.to match([jaft_around]) }
-      it { is_expected.not_to include(jaft_not_around) }
+      it { is_expected.to include(jaft_visible) }
+      it { is_expected.not_to include(jaft_not_visible) }
+      it { is_expected.not_to include(jaft_admin_only) }
+    end
+
+    describe "#visible_by_user_up_to" do
+      subject { described_class.visible_by_user_up_to(:to_be_met) }
+
+      let!(:jaft_before) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :phone_meeting)
+        end
+      end
+      let!(:jaft_exact) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+        end
+      end
+      let!(:jaft_after) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :user).destroy_all
+          jaft.visibility_rules.create!(by: :user, state: :financial_estimate)
+        end
+      end
+
+      let!(:jaft_admin_only_before) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :user).destroy_all
+          jaft.visibility_rules.create!(by: :user, state: :financial_estimate)
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
+      end
+
+      it { is_expected.to include(jaft_before) }
+      it { is_expected.to include(jaft_exact) }
+      it { is_expected.not_to include(jaft_after) }
+      it { is_expected.not_to include(jaft_admin_only_before) }
     end
 
     describe "#required" do
       subject { described_class.required(:to_be_met) }
 
       let!(:jaft_required) do
-        create(:job_application_file_type, required: true, required_from_state: :phone_meeting, required_to_state: :accepted)
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
       end
-      let!(:jaft_not_around) do
-        create(:job_application_file_type, required: true, required_from_state: :contract_drafting, required_to_state: :affected)
-      end
-      let!(:jaft_not_required) do
-        create(:job_application_file_type, required: false, required_from_state: :phone_meeting, required_to_state: :accepted)
+      let!(:jaft_last_state_after) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
+        end
       end
 
-      it { is_expected.to match([jaft_required]) }
-      it { is_expected.not_to include(jaft_not_around) }
-      it { is_expected.not_to include(jaft_not_required) }
+      it { is_expected.to include(jaft_required) }
+      it { is_expected.not_to include(jaft_last_state_after) }
     end
   end
 end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -111,20 +111,36 @@ RSpec.describe JobApplicationFileType do
       subject { described_class.required(:to_be_met) }
 
       let!(:jaft_required) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, required: true).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
         end
       end
       let!(:jaft_last_state_after) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, required: true).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
+        end
+      end
+      let!(:jaft_not_required) do
+        create(:job_application_file_type, required: false).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
+      end
+
+      let!(:jaft_with_rules_before_and_after) do
+        create(:job_application_file_type, required: true).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :initial)
           jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
         end
       end
 
       it { is_expected.to include(jaft_required) }
+      it { is_expected.to include(jaft_with_rules_before_and_after) }
       it { is_expected.not_to include(jaft_last_state_after) }
+      it { is_expected.not_to include(jaft_not_required) }
     end
   end
 end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -16,6 +16,24 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.to validate_presence_of(:required_from_state) }
       it { is_expected.to validate_presence_of(:required_to_state) }
     end
+
+    context "without an administrator visibility rule" do
+      subject(:jaft) { build(:job_application_file_type) }
+
+      before { jaft.visibility_rules.target.reject!(&:administrator?) }
+
+      it { is_expected.not_to be_valid }
+      it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
+    end
+
+    context "without a user visibility rule" do
+      subject(:jaft) { build(:job_application_file_type) }
+
+      before { jaft.visibility_rules.target.reject!(&:user?) }
+
+      it { is_expected.not_to be_valid }
+      it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
+    end
   end
 
   describe "scopes" do

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe JobApplicationFileType do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
 
-    it { is_expected.to validate_presence_of(:from_state) }
-
     it { is_expected.to validate_presence_of(:to_state) }
 
     context "when required" do

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe JobApplicationFileType do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
 
-    context "when required" do
-      subject { build(:job_application_file_type, required: true) }
-
-      it { is_expected.to validate_presence_of(:required_to_state) }
-    end
-
     context "without an administrator visibility rule" do
       subject(:jaft) { build(:job_application_file_type) }
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -80,6 +80,33 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(jaft_admin_only_before) }
     end
 
+    describe "#visible_by_administrator" do
+      subject { described_class.visible_by_administrator(:to_be_met) }
+
+      let!(:jaft_before) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
+      end
+      let!(:jaft_exact) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
+      end
+      let!(:jaft_after) do
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
+        end
+      end
+
+      it { is_expected.to include(jaft_before) }
+      it { is_expected.to include(jaft_exact) }
+      it { is_expected.not_to include(jaft_after) }
+    end
+
     describe "#required" do
       subject { described_class.required(:to_be_met) }
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -142,6 +142,47 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(jaft_last_state_after) }
       it { is_expected.not_to include(jaft_not_required) }
     end
+
+    describe "#mandatory" do
+      subject { described_class.mandatory(:financial_estimate) }
+
+      let!(:jaft_required_visible_before) do
+        create(:job_application_file_type, required: true).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
+      end
+      let!(:jaft_required_visible_after) do
+        create(:job_application_file_type, required: true).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :accepted)
+        end
+      end
+      let!(:jaft_non_required_past_visibility) do
+        create(:job_application_file_type, required: false).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
+      end
+      let!(:jaft_non_required_still_visible) do
+        create(:job_application_file_type, required: false).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :financial_estimate)
+        end
+      end
+      let!(:jaft_non_required_visible_after) do
+        create(:job_application_file_type, required: false).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :accepted)
+        end
+      end
+
+      it { is_expected.to include(jaft_required_visible_before) }
+      it { is_expected.not_to include(jaft_required_visible_after) }
+      it { is_expected.to include(jaft_non_required_past_visibility) }
+      it { is_expected.not_to include(jaft_non_required_still_visible) }
+      it { is_expected.not_to include(jaft_non_required_visible_after) }
+    end
   end
 end
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe JobApplicationFileType do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
 
-    it { is_expected.to validate_presence_of(:to_state) }
-
     context "when required" do
       subject { build(:job_application_file_type, required: true) }
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe JobApplicationFileType do
     context "when required" do
       subject { build(:job_application_file_type, required: true) }
 
-      it { is_expected.to validate_presence_of(:required_from_state) }
       it { is_expected.to validate_presence_of(:required_to_state) }
     end
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -105,44 +105,6 @@ RSpec.describe JobApplication do
     end
   end
 
-  describe "files_to_be_provided" do
-    before do
-      create(:job_application_file_type, name: "CV", kind: :applicant_provided)
-      create(:job_application_file_type, name: "LM", kind: :applicant_provided)
-      create(:job_application_file_type, name: "FILE", kind: :applicant_provided) do |jaft|
-        jaft.visibility_rules.destroy_all
-        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
-        jaft.visibility_rules.create!(by: :user, state: :to_be_met)
-      end
-    end
-
-    let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
-
-    it "computes files to be provided" do
-      result = job_application.files_to_be_provided
-      must_be_provided_files = result[:must_be_provided_files]
-      optional_file_types = result[:optional_file_types]
-
-      expect(must_be_provided_files.size).to eq(2)
-      expect(optional_file_types.size).to eq(1)
-
-      JobApplicationFileType.required(:phone_meeting).each do |jaft|
-        file = job_application.job_application_files.find_by(job_application_file_type: jaft) ||
-          create(:job_application_file, job_application:, job_application_file_type: jaft)
-        file.check!
-      end
-      job_application.reload
-      job_application.to_be_met!
-
-      result = job_application.files_to_be_provided
-      must_be_provided_files = result[:must_be_provided_files]
-      optional_file_types = result[:optional_file_types]
-
-      expect(must_be_provided_files.size).to eq(3)
-      expect(optional_file_types.size).to eq(0)
-    end
-  end
-
   describe "cant_accept_before_delay" do
     subject(:acceptance) { job_application.accepted! }
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -122,9 +122,12 @@ RSpec.describe JobApplication do
       expect(must_be_provided_files.size).to eq(2)
       expect(optional_file_types.size).to eq(1)
 
-      job_application.job_application_files.each do |file|
-        file.content = fixture_file_upload("document.pdf", "application/pdf")
+      JobApplicationFileType.required(:phone_meeting).each do |jaft|
+        file = job_application.job_application_files.find_by(job_application_file_type: jaft) ||
+          create(:job_application_file, job_application:, job_application_file_type: jaft)
+        file.check!
       end
+      job_application.reload
       job_application.to_be_met!
 
       result = job_application.files_to_be_provided
@@ -204,11 +207,18 @@ RSpec.describe JobApplication do
 
       let!(:job_application) { create(:job_application, state: :phone_meeting) }
       let!(:job_application_file_type) do
-        create(:job_application_file_type, required: true, required_from_state: :phone_meeting, required_to_state: :accepted)
+        create(:job_application_file_type).tap do |jaft|
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
       end
 
       context "when required files are present and validated" do
-        before { create(:job_application_file, job_application:, job_application_file_type:).check! }
+        before do
+          JobApplicationFileType.required(:phone_meeting).each do |jaft|
+            create(:job_application_file, job_application:, job_application_file_type: jaft).check!
+          end
+          job_application.reload
+        end
 
         it { is_expected.to be(true) }
       end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe JobApplication do
     end
 
     context "when state moves forward" do
+      before do
+        JobApplicationFileType.mandatory(:phone_meeting).find_each do |jaft|
+          file = job_application.job_application_files.find_by(job_application_file_type: jaft) ||
+            create(:job_application_file, job_application:, job_application_file_type: jaft)
+          file.check!
+        end
+        job_application.reload
+      end
+
       it "creates job application files for newly required file types" do
         expect { job_application.to_be_met! }.to change { job_application.job_application_files.count }.by(1)
         expect(job_application.job_application_files.map(&:job_application_file_type)).to include(required_file_type)
@@ -129,7 +138,10 @@ RSpec.describe JobApplication do
     end
 
     context "when the file type is already requested" do
-      before { create(:job_application_file, job_application:, job_application_file_type: required_file_type) }
+      before do
+        create(:job_application_file, job_application:, job_application_file_type: required_file_type)
+        job_application.job_application_files.reload.each(&:check!)
+      end
 
       it "does not create a duplicate" do
         expect { job_application.to_be_met! }.not_to change { job_application.job_application_files.count }
@@ -154,97 +166,6 @@ RSpec.describe JobApplication do
       before { job_offer.update(csp_date: 31.days.before) }
 
       it { is_expected.to be(true) }
-    end
-  end
-
-  describe "complete_files_before_draft_contract" do
-    let(:job_application) { create(:job_application, state: :accepted) }
-    let!(:jaft_1) do
-      create(:job_application_file_type, name: "File 1", kind: :applicant_provided) do |jaft|
-        jaft.visibility_rules.destroy_all
-        jaft.visibility_rules.create!(by: :administrator, state: :accepted)
-        jaft.visibility_rules.create!(by: :user, state: :accepted)
-      end
-    end
-    let!(:jaft_2) do
-      create(:job_application_file_type, name: "File 2", kind: :applicant_provided) do |jaft|
-        jaft.visibility_rules.destroy_all
-        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
-        jaft.visibility_rules.create!(by: :user, state: :to_be_met)
-      end
-    end
-
-    context "when no files are filled" do
-      it "cant pass to contract_drafting" do
-        expect { job_application.contract_drafting! }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when files are fill but not validated" do
-      before do
-        create(:job_application_file, job_application: job_application, job_application_file_type: jaft_1)
-        create(:job_application_file, job_application: job_application, job_application_file_type: jaft_2)
-      end
-
-      it "cant pass to contract_drafting" do
-        expect { job_application.contract_drafting! }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when files are fill and validated" do
-      before do
-        create(
-          :job_application_file,
-          job_application: job_application, job_application_file_type: jaft_1, is_validated: true
-        )
-        create(
-          :job_application_file,
-          job_application: job_application, job_application_file_type: jaft_2, is_validated: true
-        )
-      end
-
-      it "can pass to contract_drafting" do
-        expect(job_application.contract_drafting!).to be(true)
-      end
-    end
-
-    describe "required_files_are_validated" do
-      subject(:chante_state) { job_application.to_be_met! }
-
-      let!(:job_application) { create(:job_application, state: initial_state) }
-      let(:initial_state) { :phone_meeting }
-      let!(:job_application_file_type) do
-        create(:job_application_file_type, required: true).tap do |jaft|
-          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
-        end
-      end
-
-      context "when required files are present and validated" do
-        before do
-          JobApplicationFileType.required(:phone_meeting).each do |jaft|
-            create(:job_application_file, job_application:, job_application_file_type: jaft).check!
-          end
-          job_application.reload
-        end
-
-        it { is_expected.to be(true) }
-      end
-
-      context "when required files are present but not validated" do
-        before { create(:job_application_file, job_application:, job_application_file_type:).uncheck! }
-
-        it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
-      end
-
-      context "when required files are missing" do
-        it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
-      end
-
-      context "when state moves downward" do
-        let(:initial_state) { :financial_estimate }
-
-        it { is_expected.to be(true) }
-      end
     end
   end
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -105,6 +105,38 @@ RSpec.describe JobApplication do
     end
   end
 
+  describe "#create_required_job_application_files" do
+    let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
+    let!(:required_file_type) do
+      create(:job_application_file_type, required: true).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+      end
+    end
+    let!(:not_yet_required_file_type) do
+      create(:job_application_file_type, required: true).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
+      end
+    end
+
+    context "when state moves forward" do
+      it "creates job application files for newly required file types" do
+        expect { job_application.to_be_met! }.to change { job_application.job_application_files.count }.by(1)
+        expect(job_application.job_application_files.map(&:job_application_file_type)).to include(required_file_type)
+        expect(job_application.job_application_files.map(&:job_application_file_type)).not_to include(not_yet_required_file_type)
+      end
+    end
+
+    context "when the file type is already requested" do
+      before { create(:job_application_file, job_application:, job_application_file_type: required_file_type) }
+
+      it "does not create a duplicate" do
+        expect { job_application.to_be_met! }.not_to change { job_application.job_application_files.count }
+      end
+    end
+  end
+
   describe "cant_accept_before_delay" do
     subject(:acceptance) { job_application.accepted! }
 
@@ -182,7 +214,7 @@ RSpec.describe JobApplication do
       let!(:job_application) { create(:job_application, state: initial_state) }
       let(:initial_state) { :phone_meeting }
       let!(:job_application_file_type) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, required: true).tap do |jaft|
           jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
         end
       end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -205,7 +205,8 @@ RSpec.describe JobApplication do
     describe "required_files_are_validated" do
       subject(:chante_state) { job_application.to_be_met! }
 
-      let!(:job_application) { create(:job_application, state: :phone_meeting) }
+      let!(:job_application) { create(:job_application, state: initial_state) }
+      let(:initial_state) { :phone_meeting }
       let!(:job_application_file_type) do
         create(:job_application_file_type).tap do |jaft|
           jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
@@ -231,6 +232,12 @@ RSpec.describe JobApplication do
 
       context "when required files are missing" do
         it { expect { chante_state }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
+
+      context "when state moves downward" do
+        let(:initial_state) { :financial_estimate }
+
+        it { is_expected.to be(true) }
       end
     end
   end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -107,9 +107,13 @@ RSpec.describe JobApplication do
 
   describe "files_to_be_provided" do
     before do
-      create(:job_application_file_type, name: "CV", from_state: :initial, kind: :applicant_provided)
-      create(:job_application_file_type, name: "LM", from_state: :initial, kind: :applicant_provided)
-      create(:job_application_file_type, name: "FILE", from_state: :to_be_met, kind: :applicant_provided)
+      create(:job_application_file_type, name: "CV", kind: :applicant_provided)
+      create(:job_application_file_type, name: "LM", kind: :applicant_provided)
+      create(:job_application_file_type, name: "FILE", kind: :applicant_provided) do |jaft|
+        jaft.visibility_rules.destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+      end
     end
 
     let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
@@ -162,10 +166,18 @@ RSpec.describe JobApplication do
   describe "complete_files_before_draft_contract" do
     let(:job_application) { create(:job_application, state: :accepted) }
     let!(:jaft_1) do
-      create(:job_application_file_type, name: "File 1", from_state: :accepted, kind: :applicant_provided)
+      create(:job_application_file_type, name: "File 1", kind: :applicant_provided) do |jaft|
+        jaft.visibility_rules.destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :accepted)
+        jaft.visibility_rules.create!(by: :user, state: :accepted)
+      end
     end
     let!(:jaft_2) do
-      create(:job_application_file_type, name: "File 2", from_state: :to_be_met, kind: :applicant_provided)
+      create(:job_application_file_type, name: "File 2", kind: :applicant_provided) do |jaft|
+        jaft.visibility_rules.destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+      end
     end
 
     context "when no files are filled" do

--- a/spec/models/visibility_rule_spec.rb
+++ b/spec/models/visibility_rule_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VisibilityRule do
+  describe "associations" do
+    it { is_expected.to belong_to(:job_application_file_type) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:by) }
+    it { is_expected.to validate_presence_of(:state) }
+
+    it "only allows administrator or user for by" do
+      expect(described_class.bies.keys).to match_array(%w[administrator user])
+    end
+
+    it "uses the same states as JobApplication" do
+      expect(described_class.states).to eq(JobApplication.states.transform_keys(&:to_s))
+    end
+  end
+
+  describe "defaults" do
+    subject(:rule) { described_class.new }
+
+    it { expect(rule.by).to eq("administrator") }
+    it { expect(rule.state).to eq("initial") }
+  end
+end
+
+# == Schema Information
+#
+# Table name: visibility_rules
+#
+#  id                           :uuid             not null, primary key
+#  by                           :string           default("administrator"), not null
+#  state                        :integer          default("initial"), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  job_application_file_type_id :uuid             not null
+#
+# Indexes
+#
+#  index_visibility_rules_on_job_application_file_type_id  (job_application_file_type_id)
+#
+# Foreign Keys
+#
+#  fk_rails_2da155b95c  (job_application_file_type_id => job_application_file_types.id)
+#

--- a/spec/requests/admin/settings/job_application_file_types_spec.rb
+++ b/spec/requests/admin/settings/job_application_file_types_spec.rb
@@ -3,6 +3,149 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Settings::JobApplicationFileTypes" do
+  let(:create_attributes) do
+    {
+      visibility_rules_attributes: [
+        {by: "administrator", state: :initial, _destroy: "0"},
+        {by: "user", state: :initial, _destroy: "0"}
+      ]
+    }
+  end
+
+  before { sign_in create(:administrator) }
+
   it_behaves_like "an admin setting", :job_application_file_type, :name, "a new name"
   it_behaves_like "a movable admin setting", :job_application_file_type
+
+  describe "GET /admin/parametres/job_application_file_types/new" do
+    subject(:new_request) { get new_admin_settings_job_application_file_type_path }
+
+    before { new_request }
+
+    it "renders the form" do
+      expect(response).to render_template(:new)
+      expect(assigns(:visibility_rules_for_administrator).length).to eq(JobApplication.states.count)
+      expect(assigns(:visibility_rules_for_user).length).to eq(JobApplication.states.count)
+      expect(assigns(:visibility_rules_for_administrator)).to all(be_administrator)
+      expect(assigns(:visibility_rules_for_user)).to all(be_user)
+    end
+  end
+
+  describe "GET /admin/parametres/job_application_file_types/:id/edit" do
+    subject(:edit_request) { get edit_admin_settings_job_application_file_type_path(job_application_file_type) }
+
+    let(:job_application_file_type) { create(:job_application_file_type) }
+
+    it "renders the form" do
+      edit_request
+      expect(response).to render_template(:edit)
+      expect(assigns(:visibility_rules_for_administrator).length).to eq(JobApplication.states.count)
+      expect(assigns(:visibility_rules_for_user).length).to eq(JobApplication.states.count)
+    end
+
+    context "when the file type already has visibility rules" do
+      before do
+        create(:visibility_rule, job_application_file_type: job_application_file_type, by: :administrator, state: :initial)
+        create(:visibility_rule, job_application_file_type: job_application_file_type, by: :user, state: :accepted)
+        edit_request
+      end
+
+      it "shows existing administrator rules as persisted (checked)" do
+        initial_rule = assigns(:visibility_rules_for_administrator).find { |r| r.state == "initial" }
+        expect(initial_rule).to be_persisted
+      end
+
+      it "shows missing administrator states as new records (unchecked)" do
+        phone_meeting_rule = assigns(:visibility_rules_for_administrator).find { |r| r.state == "phone_meeting" }
+        expect(phone_meeting_rule).to be_new_record
+      end
+
+      it "shows existing user rules as persisted (checked)" do
+        accepted_rule = assigns(:visibility_rules_for_user).find { |r| r.state == "accepted" }
+        expect(accepted_rule).to be_persisted
+      end
+
+      it "shows missing user states as new records (unchecked)" do
+        phone_meeting_rule = assigns(:visibility_rules_for_user).find { |r| r.state == "phone_meeting" }
+        expect(phone_meeting_rule).to be_new_record
+      end
+    end
+  end
+
+  describe "POST /admin/parametres/job_application_file_types" do
+    subject(:create_request) { post admin_settings_job_application_file_types_path, params: }
+
+    let(:params) do
+      {
+        job_application_file_type: attributes_for(:job_application_file_type).merge(
+          visibility_rules_attributes: [
+            {by: "administrator", state: :initial, _destroy: "0"},
+            {by: "user", state: :initial, _destroy: "0"}
+          ]
+        )
+      }
+    end
+
+    it "creates the visibility rules" do
+      expect { create_request }.to change(VisibilityRule, :count).by(2)
+      expect(response).to redirect_to(admin_settings_job_application_file_types_path)
+    end
+
+    context "when visibility rules are missing" do
+      let(:params) do
+        {job_application_file_type: attributes_for(:job_application_file_type)}
+      end
+
+      it "does not create the job application file type" do
+        expect { create_request }.not_to change(JobApplicationFileType, :count)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PATCH /admin/parametres/job_application_file_types/:id" do
+    let(:job_application_file_type) { create(:job_application_file_type) }
+
+    context "when adding a visibility rule" do
+      subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
+
+      let(:params) do
+        {
+          job_application_file_type: {
+            visibility_rules_attributes: [
+              {by: "administrator", state: :phone_meeting, _destroy: "0"}
+            ]
+          }
+        }
+      end
+
+      it "creates the new visibility rule" do
+        expect { update_request }.to change { job_application_file_type.reload.visibility_rules.count }.by(1)
+        expect(response).to redirect_to(admin_settings_job_application_file_types_path)
+      end
+    end
+
+    context "when destroying a visibility rule" do
+      subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
+
+      let!(:visibility_rule) {
+        create(:visibility_rule, job_application_file_type: job_application_file_type, by: :administrator, state: :phone_meeting)
+      }
+
+      let(:params) do
+        {
+          job_application_file_type: {
+            visibility_rules_attributes: [
+              {id: visibility_rule.id, by: "administrator", state: visibility_rule.state, _destroy: "1"}
+            ]
+          }
+        }
+      end
+
+      it "destroys the visibility rule" do
+        expect { update_request }.to change { job_application_file_type.reload.visibility_rules.count }.by(-1)
+        expect(response).to redirect_to(admin_settings_job_application_file_types_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

On adresse dans cette PR les demandes de #2057 et #2058.

## Suppressions

On supprime : 
- candidature spontannée
- état de début
- état de fin
- obligatoire à partir de l'état
- obligatoire à plus obligatoire à partir de l'état

## Type de fichier
Ajout du type de fichier "Fourni par l'autorité d'emploi" :

<img width="1705" height="534" alt="CleanShot 2026-04-06 at 11 54 09" src="https://github.com/user-attachments/assets/fb0f0061-9fcc-45cd-8976-4c3de4f159d2" />

## États où le fichier sera accessible et visible

<img width="1705" height="1308" alt="CleanShot 2026-04-06 at 12 00 49" src="https://github.com/user-attachments/assets/d13680b6-2ba6-4f72-bdcf-450d6eb85b8c" />

## Statut obligatoire

Le champ `required` du type de fichier est devenu un select avec des libellés explicites (obligatoire par défaut vs. sur demande) :

<img width="1705" height="644" alt="CleanShot 2026-04-06 at 11 54 30" src="https://github.com/user-attachments/assets/afd53286-35d7-4701-8407-e573141a7cf8" />

## Simplification de la vue Documents
La vue Documents affiche directement les `job_application_files` existants et les autres types de fichiers visibles par l'admin à l'état courant : 

<img width="1707" height="1310" alt="CleanShot 2026-04-06 at 11 56 57" src="https://github.com/user-attachments/assets/4c5f29b3-06cb-47bb-ac56-c9729dcf7f96" />

## Création automatique des fichiers requis

Lorsque la candidature change d'état, on demande automatiquement les documents dont les types de fichiers sont "Obligatoires - par défaut pour tous les candidats".

Par exemple si "Justificatif de domicile de moins de 6 mois" est obligatoire par défaut pour tous les candidats, à partir de l'état "Entretien d'embauche" :

<img width="1705" height="1308" alt="CleanShot 2026-04-06 at 12 00 49" src="https://github.com/user-attachments/assets/b3937e35-bec1-4cba-b1d2-9c0d6cdb5967" />

Avant le changement d'état : 

<img width="1702" height="946" alt="CleanShot 2026-04-06 at 12 01 18" src="https://github.com/user-attachments/assets/be2ebc97-e01a-4132-b193-48182496f8ba" />

Après le changement d'état : 

<img width="1705" height="1068" alt="CleanShot 2026-04-06 at 12 01 33" src="https://github.com/user-attachments/assets/a7b281c1-568c-4d58-b432-e7e76fb30b0a" />

## Contrôle des documents obligatoires

Lors du passage d'un état à l'autre : 


1. un fichier dont le statut obligatoire est "par défaut pour tous les candidats" est immédiatement requis (c'est à dire présent et validé).
2. un fichier dont le statut obligatoire est "sur demande" est requis seulement si on est en train de dépasser son dernier état.

<img width="1700" height="1311" alt="CleanShot 2026-04-06 at 12 05 43" src="https://github.com/user-attachments/assets/69a96ab7-bddb-4070-a736-3fa1e687541e" />

# Review app

https://erecrutement-cvd-staging-pr2067.osc-fr1.scalingo.io

# Links

Closes #2057
Closes #2058
