### PR TITLE
Add rejected column

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -69,7 +69,8 @@ class Admin::JobOffersController < Admin::BaseController
   # GET /admin/job_offers/1/board
   # GET /admin/job_offers/1/board.json
   def board
-    @job_applications = @job_offer.job_applications.group_by(&:state)
+    @job_applications = @job_offer.job_applications.not_rejecteds.group_by(&:state)
+    @rejecteds = @job_offer.job_applications.rejecteds
     request.xhr? && render(layout: false)
   end
 

--- a/app/controllers/admin/rejections_controller.rb
+++ b/app/controllers/admin/rejections_controller.rb
@@ -1,13 +1,13 @@
 class Admin::RejectionsController < Admin::BaseController
   skip_load_and_authorize_resource
 
+  before_action :set_job_application
+
   def new
-    @job_application = JobApplication.find(params[:job_application_id])
     render layout: false if request.xhr?
   end
 
   def create
-    @job_application = JobApplication.find(params[:job_application_id])
     @job_application.reject!(rejection_reason:)
     respond_to do |format|
       format.html { redirect_to admin_job_application_path(@job_application), notice: t(".success") }
@@ -15,7 +15,17 @@ class Admin::RejectionsController < Admin::BaseController
     end
   end
 
+  def destroy
+    @job_application.unreject!
+    respond_to do |format|
+      format.html { redirect_to admin_job_application_path(@job_application), notice: t(".success") }
+      format.js
+    end
+  end
+
   private
+
+  def set_job_application = @job_application = JobApplication.find(params[:job_application_id])
 
   def rejection_reason = RejectionReason.find(rejection_params[:rejection_reason_id])
 

--- a/app/controllers/admin/rejections_controller.rb
+++ b/app/controllers/admin/rejections_controller.rb
@@ -1,10 +1,18 @@
 class Admin::RejectionsController < Admin::BaseController
   skip_load_and_authorize_resource
 
+  def new
+    @job_application = JobApplication.find(params[:job_application_id])
+    render layout: false if request.xhr?
+  end
+
   def create
     @job_application = JobApplication.find(params[:job_application_id])
     @job_application.reject!(rejection_reason:)
-    redirect_to admin_job_application_path(@job_application), notice: t(".success")
+    respond_to do |format|
+      format.html { redirect_to admin_job_application_path(@job_application), notice: t(".success") }
+      format.js
+    end
   end
 
   private

--- a/app/javascript/controllers/rejection_controller.js
+++ b/app/javascript/controllers/rejection_controller.js
@@ -1,9 +1,9 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["submit"]
+  static targets = ["submit"];
 
   reasonChanged(event) {
-    this.submitTarget.disabled = event.target.value.length === 0
+    this.submitTarget.disabled = event.target.value.length === 0;
   }
 }

--- a/app/javascript/js/board.js
+++ b/app/javascript/js/board.js
@@ -1,91 +1,125 @@
-import Sortable from 'sortablejs'
-import Rails from '@rails/ujs'
-import BSN from 'bootstrap.native/dist/bootstrap-native.js'
-import formAutoSubmit from './form-auto-submit'
-import dependentFields from './dependent-fields'
-import displaySnackbars from './display-snackbars'
-import emailTemplateSelectHandling from './email-template-select-handling'
+import Sortable from "sortablejs";
+import Rails from "@rails/ujs";
+import BSN from "bootstrap.native/dist/bootstrap-native.js";
+import formAutoSubmit from "./form-auto-submit";
+import dependentFields from "./dependent-fields";
+import displaySnackbars from "./display-snackbars";
+import emailTemplateSelectHandling from "./email-template-select-handling";
 
 export function boardRedraw() {
-  var url = window.location.href
-  var nodeBoard = document.querySelector('#board')
+  var url = window.location.href;
+  var nodeBoard = document.querySelector("#board");
   if (nodeBoard !== null) {
     Rails.ajax({
-      type: 'GET',
+      type: "GET",
       url: url,
-      dataType: 'html',
+      dataType: "html",
       success: (response) => {
-        nodeBoard.outerHTML = response.body.innerHTML
-        boardManagement()
+        nodeBoard.outerHTML = response.body.innerHTML;
+        boardManagement();
       },
       error: (response) => {
-        console.log('error boardManagement')
-        console.log(response)
-      }
-    })
+        console.log("error boardManagement");
+        console.log(response);
+      },
+    });
   }
 }
 
 export function boardManagement() {
-  var board = document.getElementById('board')
-  if (board !== null && board.getAttribute('data-draggable') !== null) {
-    ;[].forEach.call(board.querySelectorAll('.lists .list'), function(listNode) {
-      var state = listNode.getAttribute('data-state')
-      ;[].forEach.call(listNode.querySelectorAll('.cards'), function(cardListNode) {
-        Sortable.create(cardListNode, {
-          group: 'job-applications',
-          sort: false,
-          onAdd: (evt) => {
-            var item = evt.item
-            var oldState = item.getAttribute('data-state')
-            var to = evt.to
-            var newState = to.getAttribute('data-state')
+  var board = document.getElementById("board");
+  if (board !== null && board.getAttribute("data-draggable") !== null) {
+    [].forEach.call(
+      board.querySelectorAll(".lists .list"),
+      function (listNode) {
+        var state = listNode.getAttribute("data-state");
+        [].forEach.call(
+          listNode.querySelectorAll(".cards"),
+          function (cardListNode) {
+            Sortable.create(cardListNode, {
+              group: "job-applications",
+              sort: false,
+              onAdd: (evt) => {
+                var item = evt.item;
+                var oldState = item.getAttribute("data-state");
+                var to = evt.to;
+                var newState = to.getAttribute("data-state");
 
-            if (newState === 'rejected') {
-              var rejectionUrl = item.getAttribute('data-rejection-url')
-              Rails.ajax({
-                type: 'GET',
-                url: rejectionUrl,
-                dataType: 'html',
-                success: (response) => {
-                  var modal = document.getElementById('remoteContentModal')
-                  var modalBody = modal.querySelector('.modal-body')
-                  modalBody.innerHTML = response.body ? response.body.innerHTML : response.documentElement.innerHTML
-                  var form = modalBody.querySelector('form')
-                  if (form) {
-                    form.setAttribute('data-remote', 'true')
+                if (newState === "rejected") {
+                  var rejectionUrl = item.getAttribute("data-rejection-url");
+                  Rails.ajax({
+                    type: "GET",
+                    url: rejectionUrl,
+                    dataType: "html",
+                    success: (response) => {
+                      var modal = document.getElementById("remoteContentModal");
+                      var modalBody = modal.querySelector(".modal-body");
+                      modalBody.innerHTML = response.body
+                        ? response.body.innerHTML
+                        : response.documentElement.innerHTML;
+                      var form = modalBody.querySelector("form");
+                      if (form) {
+                        form.setAttribute("data-remote", "true");
+                      }
+                      new BSN.Modal(modal).show();
+                      modal.addEventListener(
+                        "hidden.bs.modal",
+                        function onHidden() {
+                          modal.removeEventListener(
+                            "hidden.bs.modal",
+                            onHidden,
+                          );
+                          boardRedraw();
+                        },
+                      );
+                    },
+                    error: (response) => {
+                      console.log("error loading rejection form");
+                      console.log(response);
+                      boardRedraw();
+                    },
+                  });
+                } else if (item.getAttribute("data-rejected") === "true") {
+                  if (newState === "initial") {
+                    var rejectionUrl = item.getAttribute("data-rejection-url");
+                    var destroyUrl = rejectionUrl.replace("/new", "");
+                    Rails.ajax({
+                      type: "DELETE",
+                      url: destroyUrl,
+                      dataType: "script",
+                    });
+                  } else {
+                    Snackbar.show({
+                      text: 'Vous devez d\'abord remettre la candidature en "Nouvelle candidature"',
+                      showAction: false,
+                    });
+                    boardRedraw();
                   }
-                  new BSN.Modal(modal).show()
-                  modal.addEventListener('hidden.bs.modal', function onHidden() {
-                    modal.removeEventListener('hidden.bs.modal', onHidden)
-                    boardRedraw()
-                  })
-                },
-                error: (response) => {
-                  console.log('error loading rejection form')
-                  console.log(response)
-                  boardRedraw()
-                }
-              })
-            } else {
-              var changeStateUrl = item.getAttribute('data-change-state-url')
-              var newChangeStateUrl = changeStateUrl.replace(`state=${oldState}`, `state=${newState}`)
+                } else {
+                  var changeStateUrl = item.getAttribute(
+                    "data-change-state-url",
+                  );
+                  var newChangeStateUrl = changeStateUrl.replace(
+                    `state=${oldState}`,
+                    `state=${newState}`,
+                  );
 
-              Rails.ajax({
-                type: 'PATCH',
-                url: newChangeStateUrl,
-                dataType: 'script',
-                success: (response) => {
-                },
-                error: (response) => {
-                  console.log('error boardManagement')
-                  console.log(response)
+                  Rails.ajax({
+                    type: "PATCH",
+                    url: newChangeStateUrl,
+                    dataType: "script",
+                    success: (response) => {},
+                    error: (response) => {
+                      console.log("error boardManagement");
+                      console.log(response);
+                    },
+                  });
                 }
-              })
-            }
-          }
-        })
-      })
-    })
+              },
+            });
+          },
+        );
+      },
+    );
   }
 }

--- a/app/javascript/js/board.js
+++ b/app/javascript/js/board.js
@@ -40,20 +40,49 @@ export function boardManagement() {
             var oldState = item.getAttribute('data-state')
             var to = evt.to
             var newState = to.getAttribute('data-state')
-            var changeStateUrl = item.getAttribute('data-change-state-url')
-            var newChangeStateUrl = changeStateUrl.replace(`state=${oldState}`, `state=${newState}`)
 
-            Rails.ajax({
-              type: 'PATCH',
-              url: newChangeStateUrl,
-              dataType: 'script',
-              success: (response) => {
-              },
-              error: (response) => {
-                console.log('error boardManagement')
-                console.log(response)
-              }
-            })
+            if (newState === 'rejected') {
+              var rejectionUrl = item.getAttribute('data-rejection-url')
+              Rails.ajax({
+                type: 'GET',
+                url: rejectionUrl,
+                dataType: 'html',
+                success: (response) => {
+                  var modal = document.getElementById('remoteContentModal')
+                  var modalBody = modal.querySelector('.modal-body')
+                  modalBody.innerHTML = response.body ? response.body.innerHTML : response.documentElement.innerHTML
+                  var form = modalBody.querySelector('form')
+                  if (form) {
+                    form.setAttribute('data-remote', 'true')
+                  }
+                  new BSN.Modal(modal).show()
+                  modal.addEventListener('hidden.bs.modal', function onHidden() {
+                    modal.removeEventListener('hidden.bs.modal', onHidden)
+                    boardRedraw()
+                  })
+                },
+                error: (response) => {
+                  console.log('error loading rejection form')
+                  console.log(response)
+                  boardRedraw()
+                }
+              })
+            } else {
+              var changeStateUrl = item.getAttribute('data-change-state-url')
+              var newChangeStateUrl = changeStateUrl.replace(`state=${oldState}`, `state=${newState}`)
+
+              Rails.ajax({
+                type: 'PATCH',
+                url: newChangeStateUrl,
+                dataType: 'script',
+                success: (response) => {
+                },
+                error: (response) => {
+                  console.log('error boardManagement')
+                  console.log(response)
+                }
+              })
+            }
           }
         })
       })

--- a/app/models/job_application/rejectable.rb
+++ b/app/models/job_application/rejectable.rb
@@ -5,7 +5,6 @@ module JobApplication::Rejectable
     belongs_to :rejection_reason, optional: true
 
     validate :missing_rejection_reason, if: -> { rejected && rejection_reason.blank? }
-    validate :immutable_state, if: -> { state_changed? && rejected }, on: :update
 
     before_save :cleanup_rejection_reason, unless: -> { rejected }
     after_update :notify_rejected, if: -> { saved_change_to_rejected? && rejected }
@@ -16,6 +15,8 @@ module JobApplication::Rejectable
 
   def reject!(rejection_reason:) = update!(rejected: true, rejection_reason:)
 
+  def unreject! = update!(state: :initial, rejected: false, rejection_reason: nil)
+
   private
 
   def missing_rejection_reason = errors.add(:rejection_reason, :blank)
@@ -23,6 +24,4 @@ module JobApplication::Rejectable
   def cleanup_rejection_reason = self.rejection_reason = nil
 
   def notify_rejected = ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
-
-  def immutable_state = errors.add(:state, :immutable_rejected)
 end

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -107,6 +107,7 @@ class JobOffer < ApplicationRecord
     initial: 0,
     phone_meeting: 2,
     to_be_met: 5,
+    financial_estimate: 6,
     accepted: 7,
     contract_drafting: 8,
     contract_feedback_waiting: 9,

--- a/app/views/admin/job_applications/_rejection_form.html.haml
+++ b/app/views/admin/job_applications/_rejection_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for job_application, url: admin_job_application_rejections_path(job_application), method: :post, html: { data: {flash: true, controller: "rejection"}} do |f|
+= simple_form_for job_application, url: admin_job_application_rejection_path(job_application), method: :post, html: { data: {flash: true, controller: "rejection"}} do |f|
   .form-inputs
     = f.input :rejection_reason_id, collection: RejectionReason.all, label: false, prompt: :translate, wrapper: :custom_multi_select_full_wide, disabled: job_application.rejected, input_html: { data: { action: "rejection#reasonChanged"} }
   - unless job_application.rejected

--- a/app/views/admin/job_offers/_job_application.html.haml
+++ b/app/views/admin/job_offers/_job_application.html.haml
@@ -1,6 +1,7 @@
 - job_offer = job_application.job_offer
 - change_state_url = url_for([:change_state, :admin, job_application, {state: job_application.state}])
-.card.job-application{id: dom_id(job_application), class: "job-application--state-#{job_application.state}", data: {state: job_application.state, change: {state: {url: change_state_url}}}}
+- rejection_url = new_admin_job_application_rejection_path(job_application)
+.card.job-application{id: dom_id(job_application), class: "job-application--state-#{job_application.state}", data: {state: job_application.state, change: {state: {url: change_state_url}}, rejection: {url: rejection_url}}}
   - if job_application.administrator_notifications_count > 0
     .notification= job_application.administrator_notifications_count
 

--- a/app/views/admin/job_offers/_job_application.html.haml
+++ b/app/views/admin/job_offers/_job_application.html.haml
@@ -1,7 +1,7 @@
 - job_offer = job_application.job_offer
 - change_state_url = url_for([:change_state, :admin, job_application, {state: job_application.state}])
 - rejection_url = new_admin_job_application_rejection_path(job_application)
-.card.job-application{id: dom_id(job_application), class: "job-application--state-#{job_application.state}", data: {state: job_application.state, change: {state: {url: change_state_url}}, rejection: {url: rejection_url}}}
+.card.job-application{id: dom_id(job_application), class: "job-application--state-#{job_application.state}", data: {state: job_application.state, rejected: job_application.rejected.to_s, change: {state: {url: change_state_url}}, rejection: {url: rejection_url}}}
   - if job_application.administrator_notifications_count > 0
     .notification= job_application.administrator_notifications_count
 

--- a/app/views/admin/job_offers/board.html.haml
+++ b/app/views/admin/job_offers/board.html.haml
@@ -9,6 +9,6 @@
       - concerned_job_applications = @job_applications[state_name]&.sort_by(&:preselection) || []
       = render partial: 'board_column', locals: { state_name: state_name, job_applications: concerned_job_applications}
 .modal.fade#remoteContentModal{tabindex: -1, role: :dialog, aria: {labelledby: :remoteContentModal, hidden: true}}
-  .modal-dialog.modal-lg{role: :document}
+  .modal-dialog{role: :document}
     .modal-content
       .modal-body.p-0

--- a/app/views/admin/job_offers/board.html.haml
+++ b/app/views/admin/job_offers/board.html.haml
@@ -3,6 +3,7 @@
 - draggable = can? :manage, @job_applications.values.flatten.first
 .board#board{data: {draggable: draggable}}
   .lists
+    = render partial: 'board_column', locals: { state_name: :rejected, job_applications: @rejecteds}
     - JobApplication.aasm.states.each do |state|
       - state_name = state.name.to_s
       - concerned_job_applications = @job_applications[state_name]&.sort_by(&:preselection) || []

--- a/app/views/admin/rejections/create.js.erb
+++ b/app/views/admin/rejections/create.js.erb
@@ -1,0 +1,3 @@
+new window.BSN.Modal('#remoteContentModal').hide()
+boardRedraw()
+Snackbar.show({showAction: false, text: '<%= j t(".success") %>'})

--- a/app/views/admin/rejections/destroy.js.erb
+++ b/app/views/admin/rejections/destroy.js.erb
@@ -1,0 +1,2 @@
+boardRedraw()
+Snackbar.show({showAction: false, text: '<%= j t(".success") %>'})

--- a/app/views/admin/rejections/new.html.haml
+++ b/app/views/admin/rejections/new.html.haml
@@ -2,7 +2,7 @@
   .card-header
     = t('.title')
   .card-body
-    = simple_form_for @job_application, url: admin_job_application_rejections_path(@job_application), method: :post, remote: true, html: { data: { controller: "rejection" } } do |f|
+    = simple_form_for @job_application, url: admin_job_application_rejection_path(@job_application), method: :post, remote: true, html: { data: { controller: "rejection" } } do |f|
       = f.input :rejection_reason_id, collection: RejectionReason.all, label: false, prompt: :translate, input_html: { data: { action: "rejection#reasonChanged"} }
       .form-actions
         = f.submit t('buttons.reject'), class: 'btn btn-primary btn-raised', disabled: true, data: { rejection_target: "submit" }

--- a/app/views/admin/rejections/new.html.haml
+++ b/app/views/admin/rejections/new.html.haml
@@ -1,0 +1,9 @@
+.card
+  .card-header
+    = t('.title')
+  .card-body
+    = simple_form_for @job_application, url: admin_job_application_rejections_path(@job_application), method: :post, remote: true, html: { data: { controller: "rejection" } } do |f|
+      = f.input :rejection_reason_id, collection: RejectionReason.all, label: false, prompt: :translate, input_html: { data: { action: "rejection#reasonChanged"} }
+      .form-actions
+        = f.submit t('buttons.reject'), class: 'btn btn-primary btn-raised', disabled: true, data: { rejection_target: "submit" }
+        %button.btn.btn-secondary.mr-2{type: 'button', data: {dismiss: 'modal'}}= t('buttons.cancel')

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,6 +362,8 @@ fr:
         title: "Refus ou désistement"
       create:
         success: "Candidature refusée ou désistée"
+      destroy:
+        success: "La candidature a été dé-refusée"
     job_offers:
       add_actor:
         admin_not_found_html: 'Ce mail n’a pas de compte existant, veuillez envoyer une demande de création de compte via le lien suivant : <a href="https://demarches-simplifiees.intradef.gouv.fr/commencer/demande-creation-compte-erecrutement">https://demarches-simplifiees.intradef.gouv.fr/commencer/demande-creation-compte-erecrutement</a>'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -358,6 +358,8 @@ fr:
       uncheck:
         success: "Fichier invalidé !"
     rejections:
+      new:
+        title: "Refus ou désistement"
       create:
         success: "Candidature refusée ou désistée"
     job_offers:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1223,7 +1223,7 @@ fr:
         state: "État"
         state/start: "N'a encore aucune candidature"
         state/initial: "Nouvelle candidature"
-        state/rejected: "Refusé·e"
+        state/rejected: "Refusée"
         state/phone_meeting: "Entretien téléphonique"
         state/phone_meeting_rejected: "Refusé·e après e. tél."
         state/to_be_met: "Entretien d'embauche"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1165,7 +1165,6 @@ fr:
               complete_files_before_draft_contract: "Tous les documents doivent être téléversés et validés avant la rédaction du contrat"
               required_files_missing: "Des documents obligatoires sont manquants ou non validés"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
-              immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
               cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
             cover_letter_content_type:
               invalid: "PDF uniquement, max 2Mo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
           post :uncheck
         end
       end
-      resources :rejections, only: %i[new create]
+      resource :rejection, only: %i[new create destroy]
       resources :messages, only: %i[create]
       resources :emails, only: %i[create] do
         member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
           post :uncheck
         end
       end
-      resources :rejections, only: %i[create]
+      resources :rejections, only: %i[new create]
       resources :messages, only: %i[create]
       resources :emails, only: %i[create] do
         member do

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -104,6 +104,18 @@ RSpec.describe JobApplication::Rejectable do
     end
   end
 
+  describe "#unreject!" do
+    subject(:unreject) { job_application.unreject! }
+
+    let(:job_application) { create(:job_application, state: :to_be_met, rejected: true, rejection_reason: create(:rejection_reason)) }
+
+    it { expect { unreject }.to change(job_application, :rejected).to(false) }
+
+    it { expect { unreject }.to change(job_application, :rejection_reason).to(nil) }
+
+    it { expect { unreject }.to change(job_application, :state).to("initial") }
+  end
+
   describe "#reject!" do
     subject(:reject) { job_application.reject!(rejection_reason:) }
 

--- a/spec/requests/admin/rejections_spec.rb
+++ b/spec/requests/admin/rejections_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin::Rejections" do
   before { sign_in administrator }
 
   describe "POST /admin/job_applications/:id/rejections" do
-    subject(:rejection) { post admin_job_application_rejections_path(job_application), params: }
+    subject(:rejection) { post admin_job_application_rejection_path(job_application), params: }
 
     let(:job_application) { create(:job_application) }
     let(:params) { {job_application: {rejection_reason_id: create(:rejection_reason).id}} }


### PR DESCRIPTION
# Description

On ajoute une colonne "Refusée" dans le board. Elle ne correspond pas à un état de candidature. Elle rassemble les candidatures refusées.

Lorsqu'une candidature est glissée dans cette colonne, une modale permet de choisir le motif de rejet. Celui-ci est obligatoire pour pouvoir valider le rejet de candidature.

Lorsqu'une candidature rejetée est glissée hors de la colonne : 
- si la colonne destination est "Nouvelle candidature", alors la candidature est dé-refusée
- sinon, un message d'erreur s'affiche et la candidature reste refusée

# Review app

https://erecrutement-cvd-staging-pr2068.osc-fr1.scalingo.io

# Links

Closes #2051

# Screenshots

<img width="1705" height="898" alt="CleanShot 2026-03-19 at 08 17 55" src="https://github.com/user-attachments/assets/2abd61e4-0d46-4156-adc2-ac8e6cdf8206" />

<img width="1707" height="639" alt="CleanShot 2026-03-19 at 08 18 27" src="https://github.com/user-attachments/assets/646215ee-71f2-4ed1-8aa6-d2f1e50a179e" />

<img width="1704" height="902" alt="CleanShot 2026-03-19 at 08 19 00" src="https://github.com/user-attachments/assets/306fc987-e2a6-4cec-bae4-8620cab0e33b" />


