### PR TITLE
Exclude rejected job applications from initial check on acceptance

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -193,6 +193,7 @@ class JobApplication < ApplicationRecord
   scope :finished, -> { where(state: FINISHED_STATES) }
   scope :not_finished, -> { where.not(state: FINISHED_STATES) }
   scope :between, ->(a, b) { where(created_at: b..a) }
+  scope :not_rejected, -> { where(rejected: false) }
   scope :with_user, -> { where.not(user: nil) }
 
   delegate :employer_recruiters, :hr_managers, :payroll_managers, to: :job_offer, prefix: true

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -307,7 +307,7 @@ class JobApplication < ApplicationRecord
   def cant_accept_remaining_initial_job_applications
     return if state.to_s != "accepted"
     return if state_was.to_s == "accepted"
-    return if job_offer.job_applications.where(state: "initial").where.not(id: id).empty?
+    return if job_offer.job_applications.not_rejected.where(state: "initial").where.not(id: id).empty?
 
     errors.add(:state, :cant_accept_remaining_initial_job_applications)
   end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
     user
   end
 
+  trait :rejected do
+    rejected { true }
+    rejection_reason
+  end
+
   trait :with_employer do
     employer
   end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe JobApplication do
   end
 
   describe "scopes" do
+    describe ".not_rejected" do
+      subject { described_class.not_rejected }
+
+      let(:matching) { create(:job_application, rejected: false) }
+      let(:unmatching) { create(:job_application, rejected: true, rejection_reason: create(:rejection_reason)) }
+
+      it { is_expected.to include(matching) }
+
+      it { is_expected.not_to include(unmatching) }
+    end
+
     describe ".with_category" do
       subject { described_class.with_category }
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe JobApplication do
       end
 
       context "when the job offer has initial but rejected job applications" do
-        before { create(:job_application, job_offer:, state: :initial, rejected: true, rejection_reason: create(:rejection_reason)) }
+        before { create(:job_application, :rejected, job_offer:, state: :initial) }
 
         it { is_expected.to be(true) }
       end
@@ -103,7 +103,7 @@ RSpec.describe JobApplication do
       subject { described_class.not_rejected }
 
       let(:matching) { create(:job_application, rejected: false) }
-      let(:unmatching) { create(:job_application, rejected: true, rejection_reason: create(:rejection_reason)) }
+      let(:unmatching) { create(:job_application, :rejected) }
 
       it { is_expected.to include(matching) }
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe JobApplication do
 
         it { expect { acceptance }.to raise_error(ActiveRecord::RecordInvalid) }
       end
+
+      context "when the job offer has initial but rejected job applications" do
+        before { create(:job_application, job_offer:, state: :initial, rejected: true, rejection_reason: create(:rejection_reason)) }
+
+        it { is_expected.to be(true) }
+      end
     end
 
     describe "#cant_skip_state" do


### PR DESCRIPTION
## Summary
- Add `not_rejected` scope to `JobApplication` to filter out rejected applications
- Use `not_rejected` in `cant_accept_remaining_initial_job_applications` so rejected initial applications no longer block acceptance
- Add `:rejected` trait to `job_application` factory for cleaner test setup

## Links
Closes #2073