### PR TITLE
Add instant notification for file uploads

### DIFF
--- a/app/controllers/account/job_application_files_controller.rb
+++ b/app/controllers/account/job_application_files_controller.rb
@@ -29,8 +29,7 @@ class Account::JobApplicationFilesController < Account::BaseController
     file_type = @job_application_file.job_application_file_type
 
     respond_to do |format|
-      if @job_application_file.save
-        @job_application.compute_notifications_counter!
+      if @job_application_file.record_by_user
         format.turbo_stream do
           str = turbo_stream.replace(file_type,
             partial: "file_name_upload",
@@ -54,18 +53,13 @@ class Account::JobApplicationFilesController < Account::BaseController
     file_type = @job_application_file.job_application_file_type
 
     respond_to do |format|
-      if @job_application_file.update(job_application_file_params.merge(is_validated: 0))
-        @job_application.compute_notifications_counter!
-        format.turbo_stream do
-          render turbo_stream: turbo_stream_update_response(file_type)
-        end
+      @job_application_file.assign_attributes(job_application_file_params.merge(is_validated: 0))
+      if @job_application_file.record_by_user
         format.html { redirect_to redirect_back_location, notice: t(".success") }
       else
-        format.turbo_stream do
-          render turbo_stream: turbo_stream_update_response(file_type)
-        end
         format.html { redirect_to redirect_back_location, notice: t(".error") }
       end
+      format.turbo_stream { render turbo_stream: turbo_stream_update_response(file_type) }
     end
   end
 

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -42,6 +42,11 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :content,
       :required,
       :notification,
+      :notify_user,
+      :notify_employer_recruiter,
+      :notify_employment_authority,
+      :notify_hr_manager,
+      :notify_payroll_manager,
       visibility_rules_attributes: [:id, :by, :state, :_destroy]
     ]
   end

--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -82,6 +82,15 @@ class ApplicantNotificationsMailer < ApplicationMailer
     )
   end
 
+  def notify_new_documents
+    @user = params[:user]
+    @job_offer = params[:job_offer]
+    @document_names = params[:document_names]
+    @service_name = @job_offer.organization.service_name
+
+    mail to: @user.email, subject: t(".subject")
+  end
+
   def notify_rejected
     @user = params[:user]
     @job_offer = params[:job_offer]

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -62,6 +62,15 @@ class NotificationsMailer < ApplicationMailer
     mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
   end
 
+  def new_document
+    @administrator = params[:administrator]
+    @job_application = params[:job_application]
+    @job_offer = @job_application.job_offer
+    @service_name = @administrator.organization.service_name
+
+    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+  end
+
   def daily_summary(administrator, data, service_name)
     @data = data
     subject = t(".subject", service_name: service_name)

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -84,6 +84,7 @@ class Administrator < ApplicationRecord
   scope :inactive, -> { where.not(deleted_at: nil) }
   scope :employer_recruiters, -> { where("roles & ? != 0", 1 << ROLES[:employer_recruiter]) }
   scope :hr_managers, -> { where("roles & ? != 0", 1 << ROLES[:hr_manager]) }
+  scope :employment_authorities, -> { where("roles & ? != 0", 1 << ROLES[:employment_authority]) }
   scope :payroll_managers, -> { where("roles & ? != 0", 1 << ROLES[:payroll_manager]) }
 
   enummer roles: ROLES

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -64,6 +64,7 @@ class JobApplication < ApplicationRecord
         state_previously_was.present? &&
         JobApplication.states[state] > JobApplication.states[state_previously_was]
     }
+  after_save :notify_user_new_documents, if: -> { saved_change_to_state? } # Keep it after create_required_job_application_files
 
   FINISHED_STATES = %w[affected].freeze
   PROCESSING_STATES = %w[initial phone_meeting to_be_met financial_estimate].freeze

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -203,7 +203,7 @@ class JobApplication < ApplicationRecord
   scope :not_rejected, -> { where(rejected: false) }
   scope :with_user, -> { where.not(user: nil) }
 
-  delegate :employer_recruiters, :hr_managers, :payroll_managers, to: :job_offer, prefix: true
+  delegate :employer_recruiters, :employment_authorities, :hr_managers, :payroll_managers, to: :job_offer, prefix: true
 
   def set_employer
     self.employer_id ||= job_offer.employer_id

--- a/app/models/job_application/notifiable.rb
+++ b/app/models/job_application/notifiable.rb
@@ -45,4 +45,10 @@ module JobApplication::Notifiable
   def notify_admin_new_state(administrator, state)
     NotificationsMailer.with(administrator:, job_application: self).send(state).deliver_later
   end
+
+  def notify_user_new_documents
+    if (document_names = JobApplicationFileType.notifiable_by_user_at(state).pluck(:name)).any?
+      ApplicantNotificationsMailer.with(user:, job_offer:, document_names:).notify_new_documents.deliver_later
+    end
+  end
 end

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -23,6 +23,15 @@ class JobApplicationFile < ApplicationRecord
     end
   end
 
+  def record_by_user
+    if save
+      job_application.compute_notifications_counter!
+      true
+    else
+      false
+    end
+  end
+
   def check!
     update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
   end

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -26,6 +26,7 @@ class JobApplicationFile < ApplicationRecord
   def record_by_user
     if save
       job_application.compute_notifications_counter!
+      notify_administrators
       true
     else
       false
@@ -58,6 +59,18 @@ class JobApplicationFile < ApplicationRecord
 
   def max_downloadable_state
     job_application_file_type.visibility_rules.where(by: :administrator).maximum(:state)
+  end
+
+  def notify_administrators
+    file_type = job_application_file_type
+    admins_to_notify = []
+    admins_to_notify.concat(job_application.job_offer_employer_recruiters) if file_type.notify_employer_recruiter
+    admins_to_notify.concat(job_application.job_offer_employment_authorities) if file_type.notify_employment_authority
+    admins_to_notify.concat(job_application.job_offer_hr_managers) if file_type.notify_hr_manager
+    admins_to_notify.concat(job_application.job_offer_payroll_managers) if file_type.notify_payroll_manager
+    admins_to_notify.uniq.each do |administrator|
+      NotificationsMailer.with(administrator:, job_application:).new_document.deliver_later
+    end
   end
 end
 

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -93,18 +93,19 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                  :uuid             not null, primary key
-#  content_file_name   :string
-#  description         :string
-#  from_state          :integer
-#  kind                :integer
-#  name                :string
-#  notification        :boolean          default(TRUE)
-#  position            :integer
-#  required            :boolean          default(FALSE), not null
-#  required_from_state :integer          default(0)
-#  required_to_state   :integer          default(11)
-#  to_state            :integer          default("affected")
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
+#  id                          :uuid             not null, primary key
+#  content_file_name           :string
+#  description                 :string
+#  kind                        :integer
+#  name                        :string
+#  notification                :boolean          default(TRUE)
+#  notify_employer_recruiter   :boolean          default(FALSE), not null
+#  notify_employment_authority :boolean          default(FALSE), not null
+#  notify_hr_manager           :boolean          default(FALSE), not null
+#  notify_payroll_manager      :boolean          default(FALSE), not null
+#  notify_user                 :boolean          default(FALSE), not null
+#  position                    :integer
+#  required                    :boolean          default(FALSE), not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -37,6 +37,14 @@ class JobApplicationFileType < ApplicationRecord
       .distinct
   }
 
+  scope :notifiable_by_user_at, ->(state) {
+    where(notify_user: true)
+      .joins(:visibility_rules)
+      .where(visibility_rules: {by: :user, state:})
+      .reorder(nil)
+      .distinct
+  }
+
   scope :visible_by_administrator, ->(state) {
     joins(:visibility_rules)
       .where(visibility_rules: {by: :administrator})

--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -56,6 +56,7 @@ class JobOffer < ApplicationRecord
   has_many :job_offer_actors, inverse_of: :job_offer, dependent: :destroy
   has_many :administrators, through: :job_offer_actors
   has_many :employer_recruiters, -> { merge(Administrator.employer_recruiters) }, through: :job_offer_actors, source: :administrator
+  has_many :employment_authorities, -> { merge(Administrator.employment_authorities) }, through: :job_offer_actors, source: :administrator
   has_many :hr_managers, -> { merge(Administrator.hr_managers) }, through: :job_offer_actors, source: :administrator
   has_many :payroll_managers, -> { merge(Administrator.payroll_managers) }, through: :job_offer_actors, source: :administrator
 

--- a/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
+++ b/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
@@ -25,7 +25,6 @@
       .form-check
         = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
         %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
-= f.input :notification
 %fieldset.form-group
   %label= t("activerecord.attributes.job_application_file_type.notification_recipients")
   .form-check
@@ -43,3 +42,4 @@
   .form-check
     = f.check_box :notify_payroll_manager, class: "form-check-input"
     %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_payroll_manager")
+= f.input :notification

--- a/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
+++ b/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
@@ -26,3 +26,20 @@
         = vrf.check_box :_destroy, { class: "form-check-input", checked: vr.persisted? }, "0", "1"
         %label.form-check-label= JobApplication.human_attribute_name("state/#{vr.state}")
 = f.input :notification
+%fieldset.form-group
+  %label= t("activerecord.attributes.job_application_file_type.notification_recipients")
+  .form-check
+    = f.check_box :notify_user, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_user")
+  .form-check
+    = f.check_box :notify_employer_recruiter, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_employer_recruiter")
+  .form-check
+    = f.check_box :notify_employment_authority, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_employment_authority")
+  .form-check
+    = f.check_box :notify_hr_manager, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_hr_manager")
+  .form-check
+    = f.check_box :notify_payroll_manager, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_payroll_manager")

--- a/app/views/applicant_notifications_mailer/notify_new_documents.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_new_documents.html.erb
@@ -1,0 +1,26 @@
+<p>
+  Bonjour <%= @user.full_name %>,
+</p>
+
+<p>
+  Vous avez de nouveaux documents à consulter :
+</p>
+
+<ul>
+  <% @document_names.each do |name| %>
+    <li><%= name %></li>
+  <% end %>
+</ul>
+
+<p>
+  Pour y accéder et procéder à une action, cliquez sur le lien suivant :
+  <a href="<%= account_job_applications_url %>">Mes candidatures</a>.
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/notifications_mailer/new_document.html.erb
+++ b/app/views/notifications_mailer/new_document.html.erb
@@ -1,0 +1,17 @@
+<p>
+  Bonjour <%= @administrator.full_name %>,
+</p>
+
+<p>
+  Vous avez un nouveau document à consulter.
+<br>
+  Pour y accéder et procéder à une action, cliquez sur le lien suivant : <%= link_to @job_offer.title, [:admin, @job_offer] %>.
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1272,6 +1272,12 @@ fr:
         kind/employer_provided: "Fourni par l'employeur"
         kind/employment_authority_provided: "Fourni par l'autorité d'emploi"
         kind/check_only_admin_only: "Fichier géré hors outil"
+        notification_recipients: "Notifications (sélection des destinataires)"
+        notify_user: "Candidat"
+        notify_employer_recruiter: "Employeur recruteur"
+        notify_employment_authority: "Autorité d'emploi"
+        notify_hr_manager: "Gestionnaire RH"
+        notify_payroll_manager: "Gestionnaire GA / Paie"
       job_offer:
         title: "Intitulé du poste"
         job_applications_count: "Nombre de candidatures: %{count}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -178,6 +178,8 @@ fr:
       subject: "Nouvelle offre"
     notify_new_state:
       subject: "Votre candidature à l'offre %{job_offer_identifier} sur %{service_name}"
+    notify_new_documents:
+      subject: "Nouveaux documents à consulter"
     notify_rejected:
       subject: "Votre candidature a été refusée"
   notifications_mailer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -191,6 +191,8 @@ fr:
       subject: "[%{service_name}] Notification « Gestionnaire » - Dossier de paie"
     affected:
       subject: "[%{service_name}] Notification « Gestionnaire » - Prise de poste"
+    new_document:
+      subject: "[%{service_name}] Nouveau document à consulter"
     daily_summary:
       subject: "[%{service_name}] Rapport journalier"
       generic_title: "Candidatures %{state}"

--- a/db/migrate/20260407063610_add_notification_recipients_to_job_application_file_types.rb
+++ b/db/migrate/20260407063610_add_notification_recipients_to_job_application_file_types.rb
@@ -1,0 +1,9 @@
+class AddNotificationRecipientsToJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :job_application_file_types, :notify_user, :boolean, default: false, null: false
+    add_column :job_application_file_types, :notify_employer_recruiter, :boolean, default: false, null: false
+    add_column :job_application_file_types, :notify_employment_authority, :boolean, default: false, null: false
+    add_column :job_application_file_types, :notify_hr_manager, :boolean, default: false, null: false
+    add_column :job_application_file_types, :notify_payroll_manager, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_21_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_07_063610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -380,6 +380,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_21_000000) do
     t.boolean "required", default: false, null: false
     t.integer "required_from_state", default: 0
     t.integer "required_to_state", default: 11
+    t.boolean "notify_user", default: false, null: false
+    t.boolean "notify_employer_recruiter", default: false, null: false
+    t.boolean "notify_employment_authority", default: false, null: false
+    t.boolean "notify_hr_manager", default: false, null: false
+    t.boolean "notify_payroll_manager", default: false, null: false
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -16,18 +16,19 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                  :uuid             not null, primary key
-#  content_file_name   :string
-#  description         :string
-#  from_state          :integer
-#  kind                :integer
-#  name                :string
-#  notification        :boolean          default(TRUE)
-#  position            :integer
-#  required            :boolean          default(FALSE), not null
-#  required_from_state :integer          default(0)
-#  required_to_state   :integer          default(11)
-#  to_state            :integer          default("affected")
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
+#  id                          :uuid             not null, primary key
+#  content_file_name           :string
+#  description                 :string
+#  kind                        :integer
+#  name                        :string
+#  notification                :boolean          default(TRUE)
+#  notify_employer_recruiter   :boolean          default(FALSE), not null
+#  notify_employment_authority :boolean          default(FALSE), not null
+#  notify_hr_manager           :boolean          default(FALSE), not null
+#  notify_payroll_manager      :boolean          default(FALSE), not null
+#  notify_user                 :boolean          default(FALSE), not null
+#  position                    :integer
+#  required                    :boolean          default(FALSE), not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
 #

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -56,6 +56,25 @@ RSpec.describe ApplicantNotificationsMailer do
     it { expect(notify_new_state.body.encoded).to match(/Votre candidature est passée à l'étape/) }
   end
 
+  describe "notify_new_documents" do
+    subject(:mail) { described_class.with(user:, job_offer:, document_names:).notify_new_documents }
+
+    let(:job_application) { build_stubbed(:job_application) }
+    let(:user) { job_application.user }
+    let(:job_offer) { job_application.job_offer }
+    let(:document_names) { ["CV", "Lettre de motivation"] }
+
+    it { expect(mail.subject).to eq("Nouveaux documents à consulter") }
+
+    it { expect(mail.to).to match([user.email]) }
+
+    it { expect(mail.body.encoded).to match(/nouveaux documents à consulter/) }
+
+    it { expect(mail.body.encoded).to match(/CV/) }
+
+    it { expect(mail.body.encoded).to match(/Lettre de motivation/) }
+  end
+
   describe "notify_rejected" do
     subject(:notify_rejected) { described_class.with(user:, job_offer:).notify_rejected }
 

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -101,4 +101,24 @@ RSpec.describe NotificationsMailer do
 
     it { expect(mail.body.encoded).to match(/à l'étape Prise de poste/) }
   end
+
+  describe "new_document" do
+    subject(:mail) { described_class.with(administrator:, job_application:).new_document }
+
+    let(:administrator) { create(:administrator) }
+    let(:job_application) { create(:job_application) }
+
+    it {
+      expect(mail.subject).to eq(
+        I18n.t(
+          "notifications_mailer.new_document.subject",
+          service_name: administrator.organization.service_name
+        )
+      )
+    }
+
+    it { expect(mail.to).to match([administrator.email]) }
+
+    it { expect(mail.body.encoded).to match(/nouveau document à consulter/) }
+  end
 end

--- a/spec/mailers/previews/applicant_notifications_preview.rb
+++ b/spec/mailers/previews/applicant_notifications_preview.rb
@@ -15,6 +15,14 @@ class ApplicantNotificationsPreview < ActionMailer::Preview
     ).notify_new_state
   end
 
+  def notify_new_documents
+    ApplicantNotificationsMailer.with(
+      user: User.first,
+      job_offer: JobOffer.first,
+      document_names: ["CV", "Lettre de motivation", "Justificatif de domicile"]
+    ).notify_new_documents
+  end
+
   def notify_rejected
     ApplicantNotificationsMailer.with(
       user: User.first,

--- a/spec/mailers/previews/notifications_preview.rb
+++ b/spec/mailers/previews/notifications_preview.rb
@@ -32,5 +32,11 @@ class NotificationsPreview < ActionMailer::Preview
     NotificationsMailer.with(administrator:, job_application:).affected
   end
 
+  def new_document
+    job_application = JobApplication.first
+    administrator = Administrator.hr_managers.first || Administrator.first
+    NotificationsMailer.with(administrator:, job_application:).new_document
+  end
+
   def daily_summary = NotificationsMailer.daily_summary
 end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe Administrator do
       it { is_expected.not_to include(unmatching) }
     end
 
+    describe "#employment_authorities" do
+      subject(:employment_authorities) { described_class.employment_authorities }
+
+      let!(:matching) { create(:administrator, roles: [:functional_administrator, :employment_authority]) }
+      let!(:unmatching) { create(:administrator, roles: [:employer_recruiter, :hr_manager]) }
+
+      it { is_expected.to match([matching]) }
+
+      it { is_expected.not_to include(unmatching) }
+    end
+
     describe "#hr_managers" do
       subject(:hr_managers) { described_class.hr_managers }
 

--- a/spec/models/job_application/notifiable_spec.rb
+++ b/spec/models/job_application/notifiable_spec.rb
@@ -179,4 +179,24 @@ RSpec.describe JobApplication::Notifiable do
       end
     end
   end
+
+  describe "#notify_user_new_documents" do
+    subject(:change_state) { job_application.to_be_met! }
+
+    let(:job_application) { create(:job_application, state: :phone_meeting) }
+
+    context "when there are notifiable file types at the new state" do
+      before do
+        create(:job_application_file_type, notify_user: true).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+        end
+      end
+
+      it { expect { change_state }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_new_documents) }
+    end
+
+    context "when there are no notifiable file types at the new state" do
+      it { expect { change_state }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_new_documents) }
+    end
+  end
 end

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -5,6 +5,27 @@ RSpec.describe JobApplicationFile do
     it { is_expected.to delegate_method(:state).to(:job_application).with_prefix(true) }
   end
 
+  describe "#record_by_user" do
+    subject(:record_by_user) { job_application_file.record_by_user }
+
+    let(:job_application_file) { build(:job_application_file, job_application:) }
+    let(:job_application) { create(:job_application) }
+
+    context "when the file is valid" do
+      it { is_expected.to be(true) }
+
+      it { expect { record_by_user }.to change { job_application.job_application_files.count }.by(1) }
+    end
+
+    context "when the file is invalid" do
+      before { job_application_file.content = nil }
+
+      it { is_expected.to be(false) }
+
+      it { expect { record_by_user }.not_to change { job_application.job_application_files.count } }
+    end
+  end
+
   describe "#downloadable?" do
     subject(:downloadable) { job_application_file.downloadable? }
 

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe JobApplicationFile do
       it { is_expected.to be(true) }
 
       it { expect { record_by_user }.to change { job_application.job_application_files.count }.by(1) }
+
+      context "when the file type has notification recipients" do
+        let(:job_application_file_type) { create(:job_application_file_type, notify_hr_manager: true) }
+        let(:job_application_file) { build(:job_application_file, job_application:, job_application_file_type:) }
+        let!(:hr_manager) { create(:administrator, roles: [:hr_manager]) }
+
+        before { create(:job_offer_actor, job_offer: job_application.job_offer, administrator: hr_manager) }
+
+        it { expect { record_by_user }.to have_enqueued_mail(NotificationsMailer, :new_document) }
+      end
+
+      context "when the file type has no notification recipients" do
+        it { expect { record_by_user }.not_to have_enqueued_mail(NotificationsMailer, :new_document) }
+      end
     end
 
     context "when the file is invalid" do

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -190,18 +190,19 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                  :uuid             not null, primary key
-#  content_file_name   :string
-#  description         :string
-#  from_state          :integer
-#  kind                :integer
-#  name                :string
-#  notification        :boolean          default(TRUE)
-#  position            :integer
-#  required            :boolean          default(FALSE), not null
-#  required_from_state :integer          default(0)
-#  required_to_state   :integer          default(11)
-#  to_state            :integer          default("affected")
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
+#  id                          :uuid             not null, primary key
+#  content_file_name           :string
+#  description                 :string
+#  kind                        :integer
+#  name                        :string
+#  notification                :boolean          default(TRUE)
+#  notify_employer_recruiter   :boolean          default(FALSE), not null
+#  notify_employment_authority :boolean          default(FALSE), not null
+#  notify_hr_manager           :boolean          default(FALSE), not null
+#  notify_payroll_manager      :boolean          default(FALSE), not null
+#  notify_user                 :boolean          default(FALSE), not null
+#  position                    :integer
+#  required                    :boolean          default(FALSE), not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
 #

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -80,6 +80,31 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(jaft_admin_only_before) }
     end
 
+    describe "#notifiable_by_user_at" do
+      subject { described_class.notifiable_by_user_at(:to_be_met) }
+
+      let!(:jaft_matching) do
+        create(:job_application_file_type, notify_user: true).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+        end
+      end
+      let!(:jaft_wrong_state) do
+        create(:job_application_file_type, notify_user: true).tap do |jaft|
+          jaft.visibility_rules.where(by: :user).destroy_all
+          jaft.visibility_rules.create!(by: :user, state: :phone_meeting)
+        end
+      end
+      let!(:jaft_not_notifiable) do
+        create(:job_application_file_type, notify_user: false).tap do |jaft|
+          jaft.visibility_rules.create!(by: :user, state: :to_be_met)
+        end
+      end
+
+      it { is_expected.to include(jaft_matching) }
+      it { is_expected.not_to include(jaft_wrong_state) }
+      it { is_expected.not_to include(jaft_not_notifiable) }
+    end
+
     describe "#visible_by_administrator" do
       subject { described_class.visible_by_administrator(:to_be_met) }
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe JobApplication do
   describe "delegations" do
     it { is_expected.to delegate_method(:employer_recruiters).to(:job_offer).with_prefix(true) }
 
+    it { is_expected.to delegate_method(:employment_authorities).to(:job_offer).with_prefix(true) }
+
     it { is_expected.to delegate_method(:hr_managers).to(:job_offer).with_prefix(true) }
+
+    it { is_expected.to delegate_method(:payroll_managers).to(:job_offer).with_prefix(true) }
   end
 
   describe "validations" do

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe JobOffer do
 
     it { is_expected.to have_many(:employer_recruiters).through(:job_offer_actors) }
 
+    it { is_expected.to have_many(:employment_authorities).through(:job_offer_actors) }
+
     it { is_expected.to have_many(:hr_managers).through(:job_offer_actors) }
 
     it { is_expected.to have_many(:payroll_managers).through(:job_offer_actors) }

--- a/spec/requests/admin/settings/job_application_file_types_spec.rb
+++ b/spec/requests/admin/settings/job_application_file_types_spec.rb
@@ -125,6 +125,32 @@ RSpec.describe "Admin::Settings::JobApplicationFileTypes" do
       end
     end
 
+    context "when updating notification recipients" do
+      subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
+
+      let(:params) do
+        {
+          job_application_file_type: {
+            notify_user: true,
+            notify_employer_recruiter: true,
+            notify_employment_authority: false,
+            notify_hr_manager: true,
+            notify_payroll_manager: false
+          }
+        }
+      end
+
+      it "updates the notification recipients" do
+        update_request
+        job_application_file_type.reload
+        expect(job_application_file_type.notify_user).to be(true)
+        expect(job_application_file_type.notify_employer_recruiter).to be(true)
+        expect(job_application_file_type.notify_employment_authority).to be(false)
+        expect(job_application_file_type.notify_hr_manager).to be(true)
+        expect(job_application_file_type.notify_payroll_manager).to be(false)
+      end
+    end
+
     context "when destroying a visibility rule" do
       subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
 


### PR DESCRIPTION
# Description

Cette PR ajoute un système notifications par email lors du dépôt ou de la demande de documents :  



- Notification email aux administrateurs quand un candidat dépose un document, configurable par type de fichier
- Notification email au candidat quand un changement d'état rend de nouveaux documents visibles

### Test plan
- [ ] Vérifier l'envoi d'email aux administrateurs lors du dépôt d'un document par le candidat
- [ ] Vérifier l'envoi d'email au candidat lors d'un changement d'état avec nouveaux documents

# Review app

https://erecrutement-cvd-staging-pr2075.osc-fr1.scalingo.io

# Links

Closes #2059
Closes #2050 

# Screenshots

<img width="1693" height="1311" alt="CleanShot 2026-04-11 at 12 09 00" src="https://github.com/user-attachments/assets/67324133-b2e6-44ad-b3da-5d879f4555aa" />

<img width="855" height="461" alt="CleanShot 2026-04-11 at 12 10 50" src="https://github.com/user-attachments/assets/d889d7e7-0f4e-40e4-bd3e-770532ac6257" />




<img width="917" height="522" alt="CleanShot 2026-04-11 at 12 10 19" src="https://github.com/user-attachments/assets/4101d102-8aba-42b2-806b-77f9f522df87" />


