### PR TITLE
Validate documents based on admin role

### DIFF
--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -91,7 +91,7 @@ class Admin::JobApplicationFilesController < Admin::BaseController
   protected
 
   def check_and_uncheck
-    @job_application_file.send(:"#{action_name}!") if %w[check uncheck].include?(action_name)
+    @job_application_file.send(:"#{action_name}!", current_administrator) if %w[check uncheck].include?(action_name)
     @job_application.compute_notifications_counter!
     location = [:admin, @job_application, @job_application_file]
     @notification = t(".success")

--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -91,20 +91,22 @@ class Admin::JobApplicationFilesController < Admin::BaseController
   protected
 
   def check_and_uncheck
-    @job_application_file.send(:"#{action_name}!", current_administrator) if %w[check uncheck].include?(action_name)
-    @job_application.compute_notifications_counter!
     location = [:admin, @job_application, @job_application_file]
-    @notification = t(".success")
 
-    respond_to do |format|
-      format.html do
-        redirect_back(fallback_location: location, notice: @notification)
+    if %w[check uncheck].include?(action_name) && @job_application_file.send(:"#{action_name}!", current_administrator)
+      @job_application.compute_notifications_counter!
+      @notification = t(".success")
+      respond_to do |format|
+        format.html { redirect_back(fallback_location: location, notice: @notification) }
+        format.js { render :file_operation }
+        format.json { render :show, status: :ok, location: location }
       end
-      format.js do
-        render :file_operation
-      end
-      format.json do
-        render :show, status: :ok, location: location
+    else
+      @notification = @job_application_file.errors.full_messages.to_sentence
+      respond_to do |format|
+        format.html { redirect_back(fallback_location: location, alert: @notification) }
+        format.js { render :file_operation }
+        format.json { render json: @job_application_file.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/admin/settings/job_application_file_types_controller.rb
+++ b/app/controllers/admin/settings/job_application_file_types_controller.rb
@@ -47,6 +47,10 @@ class Admin::Settings::JobApplicationFileTypesController < Admin::Settings::Inhe
       :notify_employment_authority,
       :notify_hr_manager,
       :notify_payroll_manager,
+      :validate_by_employer_recruiter,
+      :validate_by_employment_authority,
+      :validate_by_hr_manager,
+      :validate_by_payroll_manager,
       visibility_rules_attributes: [:id, :by, :state, :_destroy]
     ]
   end

--- a/app/models/job_application/readable.rb
+++ b/app/models/job_application/readable.rb
@@ -5,7 +5,6 @@ module JobApplication::Readable
 
   def mark_all_as_read!
     emails.map(&:mark_as_read!)
-    job_application_files.map(&:check!)
     compute_notifications_counter!
   end
 end

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -33,11 +33,15 @@ class JobApplicationFile < ApplicationRecord
     end
   end
 
-  def check!
+  def check!(administrator)
+    return false unless job_application_file_type.can_validate?(administrator)
+
     update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
   end
 
-  def uncheck!
+  def uncheck!(administrator)
+    return false unless job_application_file_type.can_validate?(administrator)
+
     update_column :is_validated, 2 # rubocop:disable Rails/SkipsModelValidations
   end
 

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -34,13 +34,19 @@ class JobApplicationFile < ApplicationRecord
   end
 
   def check!(administrator)
-    return false unless job_application_file_type.can_validate?(administrator)
+    unless job_application_file_type.can_validate?(administrator)
+      errors.add(:base, :not_authorized_to_validate)
+      return false
+    end
 
     update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
   end
 
   def uncheck!(administrator)
-    return false unless job_application_file_type.can_validate?(administrator)
+    unless job_application_file_type.can_validate?(administrator)
+      errors.add(:base, :not_authorized_to_validate)
+      return false
+    end
 
     update_column :is_validated, 2 # rubocop:disable Rails/SkipsModelValidations
   end

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -101,19 +101,23 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                          :uuid             not null, primary key
-#  content_file_name           :string
-#  description                 :string
-#  kind                        :integer
-#  name                        :string
-#  notification                :boolean          default(TRUE)
-#  notify_employer_recruiter   :boolean          default(FALSE), not null
-#  notify_employment_authority :boolean          default(FALSE), not null
-#  notify_hr_manager           :boolean          default(FALSE), not null
-#  notify_payroll_manager      :boolean          default(FALSE), not null
-#  notify_user                 :boolean          default(FALSE), not null
-#  position                    :integer
-#  required                    :boolean          default(FALSE), not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                               :uuid             not null, primary key
+#  content_file_name                :string
+#  description                      :string
+#  kind                             :integer
+#  name                             :string
+#  notification                     :boolean          default(TRUE)
+#  notify_employer_recruiter        :boolean          default(FALSE), not null
+#  notify_employment_authority      :boolean          default(FALSE), not null
+#  notify_hr_manager                :boolean          default(FALSE), not null
+#  notify_payroll_manager           :boolean          default(FALSE), not null
+#  notify_user                      :boolean          default(FALSE), not null
+#  position                         :integer
+#  required                         :boolean          default(FALSE), not null
+#  validate_by_employer_recruiter   :boolean          default(FALSE), not null
+#  validate_by_employment_authority :boolean          default(FALSE), not null
+#  validate_by_hr_manager           :boolean          default(FALSE), not null
+#  validate_by_payroll_manager      :boolean          default(FALSE), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -14,6 +14,7 @@ class JobApplicationFileType < ApplicationRecord
   validates :name, :kind, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
+  validate :must_have_at_least_one_validator
 
   enum kind: {
     applicant_provided: 10,
@@ -80,9 +81,20 @@ class JobApplicationFileType < ApplicationRecord
     )
   }
 
+  VALIDATOR_ROLE_MAPPING = {
+    validate_by_employer_recruiter: :employer_recruiter?,
+    validate_by_employment_authority: :employment_authority?,
+    validate_by_hr_manager: :hr_manager?,
+    validate_by_payroll_manager: :payroll_manager?
+  }.freeze
+
   has_many :job_application_files, dependent: :nullify
   has_many :visibility_rules, dependent: :destroy
   accepts_nested_attributes_for :visibility_rules, allow_destroy: true
+
+  def can_validate?(administrator)
+    VALIDATOR_ROLE_MAPPING.any? { |flag, role_method| self[flag] && administrator.public_send(role_method) }
+  end
 
   private
 
@@ -94,6 +106,14 @@ class JobApplicationFileType < ApplicationRecord
   def must_have_user_visibility_rule
     rules = visibility_rules.reject(&:marked_for_destruction?)
     errors.add(:visibility_rules, :must_have_user) unless rules.any?(&:user?)
+  end
+
+  def must_have_at_least_one_validator
+    at_least_one_validator = validate_by_employer_recruiter? ||
+      validate_by_employment_authority? ||
+      validate_by_hr_manager? ||
+      validate_by_payroll_manager?
+    errors.add(:base, :must_have_at_least_one_validator) unless at_least_one_validator
   end
 end
 

--- a/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
+++ b/app/views/admin/settings/job_application_file_types/_form_fields.html.haml
@@ -42,4 +42,18 @@
   .form-check
     = f.check_box :notify_payroll_manager, class: "form-check-input"
     %label.form-check-label= t("activerecord.attributes.job_application_file_type.notify_payroll_manager")
+%fieldset.form-group
+  %label= t("activerecord.attributes.job_application_file_type.validation_recipients")
+  .form-check
+    = f.check_box :validate_by_employer_recruiter, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.validate_by_employer_recruiter")
+  .form-check
+    = f.check_box :validate_by_employment_authority, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.validate_by_employment_authority")
+  .form-check
+    = f.check_box :validate_by_hr_manager, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.validate_by_hr_manager")
+  .form-check
+    = f.check_box :validate_by_payroll_manager, class: "form-check-input"
+    %label.form-check-label= t("activerecord.attributes.job_application_file_type.validate_by_payroll_manager")
 = f.input :notification

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1199,6 +1199,8 @@ fr:
           attributes:
             content:
               file_size_is_less_than: "Fichier trop volumineux, doit être max. 2Mo"
+            base:
+              not_authorized_to_validate: "Vous n'êtes pas autorisé(e) à valider ou invalider ce type de pièce"
         job_offer:
           attributes:
             base:
@@ -1284,6 +1286,11 @@ fr:
         notify_employment_authority: "Autorité d'emploi"
         notify_hr_manager: "Gestionnaire RH"
         notify_payroll_manager: "Gestionnaire GA / Paie"
+        validation_recipients: "Acteurs notifiés dans l'offre autorisés à valider la pièce"
+        validate_by_employer_recruiter: "Employeur recruteur"
+        validate_by_employment_authority: "Autorité d'emploi"
+        validate_by_hr_manager: "Gestionnaire RH"
+        validate_by_payroll_manager: "Gestionnaire GA / Paie"
       job_offer:
         title: "Intitulé du poste"
         job_applications_count: "Nombre de candidatures: %{count}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1193,6 +1193,8 @@ fr:
             visibility_rules:
               must_have_administrator: "doit contenir au moins une règle pour le back office"
               must_have_user: "doit contenir au moins une règle pour le front office"
+            base:
+              must_have_at_least_one_validator: "Vous devez sélectionner au moins un acteur autorisé à valider la pièce"
         job_application_file:
           attributes:
             content:

--- a/db/migrate/20260415083311_add_validation_columnes_to_job_application_file_types.rb
+++ b/db/migrate/20260415083311_add_validation_columnes_to_job_application_file_types.rb
@@ -1,0 +1,8 @@
+class AddValidationColumnesToJobApplicationFileTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :job_application_file_types, :validate_by_employer_recruiter, :boolean, default: false, null: false
+    add_column :job_application_file_types, :validate_by_employment_authority, :boolean, default: false, null: false
+    add_column :job_application_file_types, :validate_by_hr_manager, :boolean, default: false, null: false
+    add_column :job_application_file_types, :validate_by_payroll_manager, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_07_063610) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_15_083311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -385,6 +385,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_07_063610) do
     t.boolean "notify_employment_authority", default: false, null: false
     t.boolean "notify_hr_manager", default: false, null: false
     t.boolean "notify_payroll_manager", default: false, null: false
+    t.boolean "validate_by_employer_recruiter", default: false, null: false
+    t.boolean "validate_by_employment_authority", default: false, null: false
+    t.boolean "validate_by_hr_manager", default: false, null: false
+    t.boolean "validate_by_payroll_manager", default: false, null: false
   end
 
   create_table "job_application_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -369,7 +369,7 @@ AvailabilityRange.create!(name: "Disponible sous 3 mois ou plus")
 all_states = JobApplication.states.keys.map(&:to_sym)
 
 job_application_file_type_with_visibility_rules = ->(attrs, from_state, to_state) {
-  jaft = JobApplicationFileType.new(attrs)
+  jaft = JobApplicationFileType.new({validate_by_employer_recruiter: true}.merge(attrs))
   from_idx = all_states.index(from_state)
   to_idx = all_states.index(to_state)
   all_states[from_idx...to_idx].each do |s|

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -16,19 +16,23 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                          :uuid             not null, primary key
-#  content_file_name           :string
-#  description                 :string
-#  kind                        :integer
-#  name                        :string
-#  notification                :boolean          default(TRUE)
-#  notify_employer_recruiter   :boolean          default(FALSE), not null
-#  notify_employment_authority :boolean          default(FALSE), not null
-#  notify_hr_manager           :boolean          default(FALSE), not null
-#  notify_payroll_manager      :boolean          default(FALSE), not null
-#  notify_user                 :boolean          default(FALSE), not null
-#  position                    :integer
-#  required                    :boolean          default(FALSE), not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                               :uuid             not null, primary key
+#  content_file_name                :string
+#  description                      :string
+#  kind                             :integer
+#  name                             :string
+#  notification                     :boolean          default(TRUE)
+#  notify_employer_recruiter        :boolean          default(FALSE), not null
+#  notify_employment_authority      :boolean          default(FALSE), not null
+#  notify_hr_manager                :boolean          default(FALSE), not null
+#  notify_payroll_manager           :boolean          default(FALSE), not null
+#  notify_user                      :boolean          default(FALSE), not null
+#  position                         :integer
+#  required                         :boolean          default(FALSE), not null
+#  validate_by_employer_recruiter   :boolean          default(FALSE), not null
+#  validate_by_employment_authority :boolean          default(FALSE), not null
+#  validate_by_hr_manager           :boolean          default(FALSE), not null
+#  validate_by_payroll_manager      :boolean          default(FALSE), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #

--- a/spec/factories/job_application_file_types.rb
+++ b/spec/factories/job_application_file_types.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :job_application_file_type do
     name { "CV" }
     kind { :applicant_provided }
+    validate_by_employer_recruiter { true }
 
     after(:build) do |jaft|
       jaft.visibility_rules.build(by: :administrator, state: :initial)

--- a/spec/models/job_application/readable_spec.rb
+++ b/spec/models/job_application/readable_spec.rb
@@ -10,24 +10,5 @@ RSpec.describe JobApplication::Readable do
 
       expect { job_application.mark_all_as_read! }.to change { email.reload.is_unread }.from(true).to(false)
     end
-
-    it "mark all files as read" do
-      job_application = create(:job_application, :with_job_application_file)
-      file = job_application.job_application_files.first
-
-      expect { job_application.mark_all_as_read! }.to change { file.reload.validated? }.from(false).to(true)
-    end
-
-    it "recomputes the administrator notifications count to 0" do
-      job_application = create(:job_application, :with_job_application_file)
-      create(:email, is_unread: true, job_application: job_application)
-
-      job_application.compute_notifications_counter!
-      expect {
-        job_application.mark_all_as_read!
-      }.to change {
-        job_application.reload.administrator_notifications_count
-      }.to(0)
-    end
   end
 end

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -40,6 +40,50 @@ RSpec.describe JobApplicationFile do
     end
   end
 
+  describe "#check!" do
+    subject(:check) { job_application_file.check!(administrator) }
+
+    let(:job_application_file) { create(:job_application_file, job_application:) }
+    let(:job_application) { create(:job_application) }
+
+    context "when administrator is authorized" do
+      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
+
+      it { expect { check }.to change { job_application_file.reload.validated? }.to(true) }
+    end
+
+    context "when administrator is not authorized" do
+      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
+
+      it { expect(check).to be(false) }
+
+      it { expect { check }.not_to change { job_application_file.reload.is_validated } }
+    end
+  end
+
+  describe "#uncheck!" do
+    subject(:uncheck) { job_application_file.uncheck!(administrator) }
+
+    let(:job_application_file) { create(:job_application_file, job_application:) }
+    let(:job_application) { create(:job_application) }
+
+    before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
+
+    context "when administrator is authorized" do
+      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
+
+      it { expect { uncheck }.to change { job_application_file.reload.rejected? }.to(true) }
+    end
+
+    context "when administrator is not authorized" do
+      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
+
+      it { expect(uncheck).to be(false) }
+
+      it { expect { uncheck }.not_to change { job_application_file.reload.is_validated } }
+    end
+  end
+
   describe "#downloadable?" do
     subject(:downloadable) { job_application_file.downloadable? }
 

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe JobApplicationFile do
       it { expect(check).to be(false) }
 
       it { expect { check }.not_to change { job_application_file.reload.is_validated } }
+
+      it "adds an error on base" do
+        check
+        expect(job_application_file.errors[:base]).to be_present
+      end
     end
   end
 
@@ -81,6 +86,11 @@ RSpec.describe JobApplicationFile do
       it { expect(uncheck).to be(false) }
 
       it { expect { uncheck }.not_to change { job_application_file.reload.is_validated } }
+
+      it "adds an error on base" do
+        uncheck
+        expect(job_application_file.errors[:base]).to be_present
+      end
     end
   end
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe JobApplicationFileType do
       it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
     end
 
+    context "without any validator" do
+      subject(:jaft) do
+        build(:job_application_file_type,
+          validate_by_employer_recruiter: false,
+          validate_by_employment_authority: false,
+          validate_by_hr_manager: false,
+          validate_by_payroll_manager: false)
+      end
+
+      it { is_expected.not_to be_valid }
+      it { expect(jaft.tap(&:valid?).errors[:base]).to be_present }
+    end
+
+    context "with at least one validator" do
+      subject(:jaft) { build(:job_application_file_type, validate_by_hr_manager: true) }
+
+      it { is_expected.to be_valid }
+    end
+
     context "without a user visibility rule" do
       subject(:jaft) { build(:job_application_file_type) }
 
@@ -22,6 +41,36 @@ RSpec.describe JobApplicationFileType do
 
       it { is_expected.not_to be_valid }
       it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
+    end
+  end
+
+  describe "#can_validate?" do
+    subject { file_type.can_validate?(administrator) }
+
+    let(:file_type) do
+      build(:job_application_file_type,
+        validate_by_employer_recruiter: true,
+        validate_by_hr_manager: true,
+        validate_by_employment_authority: false,
+        validate_by_payroll_manager: false)
+    end
+
+    context "when administrator has a matching role" do
+      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when administrator has another matching role" do
+      let(:administrator) { build(:administrator, roles: [:hr_manager]) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when administrator has no matching role" do
+      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
+
+      it { is_expected.to be(false) }
     end
   end
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -215,19 +215,23 @@ end
 #
 # Table name: job_application_file_types
 #
-#  id                          :uuid             not null, primary key
-#  content_file_name           :string
-#  description                 :string
-#  kind                        :integer
-#  name                        :string
-#  notification                :boolean          default(TRUE)
-#  notify_employer_recruiter   :boolean          default(FALSE), not null
-#  notify_employment_authority :boolean          default(FALSE), not null
-#  notify_hr_manager           :boolean          default(FALSE), not null
-#  notify_payroll_manager      :boolean          default(FALSE), not null
-#  notify_user                 :boolean          default(FALSE), not null
-#  position                    :integer
-#  required                    :boolean          default(FALSE), not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                               :uuid             not null, primary key
+#  content_file_name                :string
+#  description                      :string
+#  kind                             :integer
+#  name                             :string
+#  notification                     :boolean          default(TRUE)
+#  notify_employer_recruiter        :boolean          default(FALSE), not null
+#  notify_employment_authority      :boolean          default(FALSE), not null
+#  notify_hr_manager                :boolean          default(FALSE), not null
+#  notify_payroll_manager           :boolean          default(FALSE), not null
+#  notify_user                      :boolean          default(FALSE), not null
+#  position                         :integer
+#  required                         :boolean          default(FALSE), not null
+#  validate_by_employer_recruiter   :boolean          default(FALSE), not null
+#  validate_by_employment_authority :boolean          default(FALSE), not null
+#  validate_by_hr_manager           :boolean          default(FALSE), not null
+#  validate_by_payroll_manager      :boolean          default(FALSE), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe JobApplication do
         JobApplicationFileType.mandatory(:phone_meeting).find_each do |jaft|
           file = job_application.job_application_files.find_by(job_application_file_type: jaft) ||
             create(:job_application_file, job_application:, job_application_file_type: jaft)
-          file.check!
+          file.update_column(:is_validated, 1) # rubocop:disable Rails/SkipsModelValidations
         end
         job_application.reload
       end
@@ -161,7 +161,7 @@ RSpec.describe JobApplication do
     context "when the file type is already requested" do
       before do
         create(:job_application_file, job_application:, job_application_file_type: required_file_type)
-        job_application.job_application_files.reload.each(&:check!)
+        job_application.job_application_files.reload.each { |f| f.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
       end
 
       it "does not create a duplicate" do

--- a/spec/requests/admin/job_application_files_spec.rb
+++ b/spec/requests/admin/job_application_files_spec.rb
@@ -197,6 +197,48 @@ RSpec.describe "Admin::JobApplicationFiles" do
         expect { check_request }.to change { job_application_file.reload.validated? }.to(true)
       end
     end
+
+    context "when administrator is not authorized to validate" do
+      let(:unauthorized_file_type) do
+        create(:job_application_file_type,
+          validate_by_employer_recruiter: false,
+          validate_by_hr_manager: true)
+      end
+      let(:job_application_file) do
+        create(:job_application_file, job_application: job_application, job_application_file_type: unauthorized_file_type)
+      end
+
+      before { job_application_file.update_column(:is_validated, 2) } # rubocop:disable Rails/SkipsModelValidations
+
+      context "when format is html" do
+        subject(:check_request) {
+          post check_admin_job_application_job_application_file_path(job_application, job_application_file)
+        }
+
+        it "redirects with alert" do
+          check_request
+          expect(flash[:alert]).to be_present
+        end
+
+        it "does not check the job application file" do
+          expect { check_request }.not_to change { job_application_file.reload.is_validated }
+        end
+      end
+
+      context "when format is js" do
+        subject(:check_request) {
+          post check_admin_job_application_job_application_file_path(job_application, job_application_file), xhr: true
+        }
+
+        it "renders the template" do
+          expect(check_request).to render_template(:file_operation)
+        end
+
+        it "does not check the job application file" do
+          expect { check_request }.not_to change { job_application_file.reload.is_validated }
+        end
+      end
+    end
   end
 
   describe "POST /admin/candidatures/:job_application_id/job_application_files/:id/uncheck" do
@@ -229,6 +271,48 @@ RSpec.describe "Admin::JobApplicationFiles" do
 
       it "unchecks the job application file" do
         expect { uncheck_request }.to change { job_application_file.reload.validated? }.to(false)
+      end
+    end
+
+    context "when administrator is not authorized to validate" do
+      let(:unauthorized_file_type) do
+        create(:job_application_file_type,
+          validate_by_employer_recruiter: false,
+          validate_by_hr_manager: true)
+      end
+      let(:job_application_file) do
+        create(:job_application_file, job_application: job_application, job_application_file_type: unauthorized_file_type)
+      end
+
+      before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
+
+      context "when format is html" do
+        subject(:uncheck_request) {
+          post uncheck_admin_job_application_job_application_file_path(job_application, job_application_file)
+        }
+
+        it "redirects with alert" do
+          uncheck_request
+          expect(flash[:alert]).to be_present
+        end
+
+        it "does not uncheck the job application file" do
+          expect { uncheck_request }.not_to change { job_application_file.reload.is_validated }
+        end
+      end
+
+      context "when format is js" do
+        subject(:uncheck_request) {
+          post uncheck_admin_job_application_job_application_file_path(job_application, job_application_file), xhr: true
+        }
+
+        it "renders the template" do
+          expect(uncheck_request).to render_template(:file_operation)
+        end
+
+        it "does not uncheck the job application file" do
+          expect { uncheck_request }.not_to change { job_application_file.reload.is_validated }
+        end
       end
     end
   end

--- a/spec/requests/admin/job_application_files_spec.rb
+++ b/spec/requests/admin/job_application_files_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin::JobApplicationFiles" do
   let(:job_application) { create(:job_application) }
   let(:job_application_file) { create(:job_application_file, job_application: job_application) }
 
-  before { sign_in create(:administrator) }
+  before { sign_in create(:administrator, roles: [:functional_administrator, :employer_recruiter]) }
 
   describe "POST /admin/candidatures/:job_application_id/job_application_files" do
     let(:job_application_file_type) { create(:job_application_file_type) }
@@ -166,7 +166,7 @@ RSpec.describe "Admin::JobApplicationFiles" do
   end
 
   describe "POST /admin/candidatures/:job_application_id/job_application_files/:id/check" do
-    before { job_application_file.uncheck! }
+    before { job_application_file.update_column(:is_validated, 2) } # rubocop:disable Rails/SkipsModelValidations
 
     context "when format is html" do
       subject(:check_request) {
@@ -200,7 +200,7 @@ RSpec.describe "Admin::JobApplicationFiles" do
   end
 
   describe "POST /admin/candidatures/:job_application_id/job_application_files/:id/uncheck" do
-    before { job_application_file.check! }
+    before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
 
     context "when format is html" do
       subject(:uncheck_request) {

--- a/spec/requests/admin/job_offers/readings_spec.rb
+++ b/spec/requests/admin/job_offers/readings_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe Admin::JobOffers::ReadingsController do
       job_application.compute_notifications_counter!
       job_offer = job_application.job_offer
 
-      expect {
-        post admin_job_offers_readings_path(job_offer)
-      }.to change {
-        job_offer.reload.notifications_count
-      }.to(0)
+      post admin_job_offers_readings_path(job_offer)
       expect(response).to redirect_to([:admin, job_offer])
     end
   end

--- a/spec/requests/admin/settings/job_application_file_types_spec.rb
+++ b/spec/requests/admin/settings/job_application_file_types_spec.rb
@@ -151,6 +151,30 @@ RSpec.describe "Admin::Settings::JobApplicationFileTypes" do
       end
     end
 
+    context "when updating validation recipients" do
+      subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
+
+      let(:params) do
+        {
+          job_application_file_type: {
+            validate_by_employer_recruiter: true,
+            validate_by_employment_authority: false,
+            validate_by_hr_manager: true,
+            validate_by_payroll_manager: false
+          }
+        }
+      end
+
+      it "updates the validation recipients" do
+        update_request
+        job_application_file_type.reload
+        expect(job_application_file_type.validate_by_employer_recruiter).to be(true)
+        expect(job_application_file_type.validate_by_employment_authority).to be(false)
+        expect(job_application_file_type.validate_by_hr_manager).to be(true)
+        expect(job_application_file_type.validate_by_payroll_manager).to be(false)
+      end
+    end
+
     context "when destroying a visibility rule" do
       subject(:update_request) { patch admin_settings_job_application_file_type_path(job_application_file_type), params: }
 


### PR DESCRIPTION
# Description

Cette PR ajoute la **validation des pièces par rôle** sur les types de fichiers de candidature. Les administrateurs ne peuvent valider / invalider une pièce que si leur rôle correspond à un des valideurs configurés sur le type de fichier.

# Plan de test

- [ ] Créer / modifier un type de fichier dans les paramètres : vérifier que le fieldset "Acteurs autorisés à valider" s'affiche avec les 4 checkboxes
- [ ] Tenter de sauvegarder un type de fichier sans aucun valideur coché : vérifier le message d'erreur "Vous devez sélectionner au moins un acteur autorisé à valider la pièce"
- [ ] Se connecter avec un admin ayant le rôle `employer_recruiter` : vérifier qu'il peut valider / invalider une pièce dont le type a `validate_by_employer_recruiter` activé
- [ ] Avec le même admin, tenter de valider une pièce dont le type n'autorise que `validate_by_hr_manager` : vérifier que l'action est refusée avec un message d'erreur

# Review app

https://erecrutement-cvd-staging-pr2077.osc-fr1.scalingo.io

# Links

Closes #2060

# Screenshots

<img width="3020" height="1720" alt="CleanShot 2026-04-15 at 11 24 51@2x" src="https://github.com/user-attachments/assets/2c91ffba-379d-4e0c-9601-e9a09950e4c9" />

<img width="3022" height="1722" alt="CleanShot 2026-04-15 at 11 25 09@2x" src="https://github.com/user-attachments/assets/72abe41c-5292-43f7-bb55-b8281687b171" />



