### PR TITLE
Allow functional administrators to always validate files

### DIFF
--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -76,7 +76,6 @@ class Admin::JobApplicationFilesController < Admin::BaseController
 
   def check
     if @job_application_file.mark_as_valid!(current_administrator)
-      @job_application.compute_notifications_counter!
       @notification = t(".success")
       respond_to do |format|
         format.html { redirect_back_or_to location, notice: @notification }
@@ -95,7 +94,6 @@ class Admin::JobApplicationFilesController < Admin::BaseController
 
   def uncheck
     if @job_application_file.mark_as_invalid!(current_administrator)
-      @job_application.compute_notifications_counter!
       @notification = t(".success")
       respond_to do |format|
         format.html { redirect_back_or_to location, notice: @notification }

--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -25,10 +25,7 @@ class Admin::JobApplicationFilesController < Admin::BaseController
           @notification = t(".success")
           render :file_operation_total
         end
-        format.json do
-          location = [:admin, @job_application, @job_application_file]
-          render :show, status: :ok, location: location
-        end
+        format.json { render :show, status: :ok, location: }
       else
         format.html { render :new }
         format.js do
@@ -49,10 +46,7 @@ class Admin::JobApplicationFilesController < Admin::BaseController
           @notification = t(".success")
           render :file_operation_total
         end
-        format.json do
-          location = [:admin, @job_application, @job_application_file]
-          render :show, status: :ok, location: location
-        end
+        format.json { render :show, status: :ok, location: }
       end
     else
       respond_to do |format|
@@ -81,30 +75,37 @@ class Admin::JobApplicationFilesController < Admin::BaseController
   end
 
   def check
-    check_and_uncheck
-  end
-
-  def uncheck
-    check_and_uncheck
-  end
-
-  protected
-
-  def check_and_uncheck
-    location = [:admin, @job_application, @job_application_file]
-
-    if %w[check uncheck].include?(action_name) && @job_application_file.send(:"#{action_name}!", current_administrator)
+    if @job_application_file.mark_as_valid!(current_administrator)
       @job_application.compute_notifications_counter!
       @notification = t(".success")
       respond_to do |format|
-        format.html { redirect_back(fallback_location: location, notice: @notification) }
+        format.html { redirect_back_or_to location, notice: @notification }
         format.js { render :file_operation }
-        format.json { render :show, status: :ok, location: location }
+        format.json { render :show, status: :ok, location: }
       end
     else
       @notification = @job_application_file.errors.full_messages.to_sentence
       respond_to do |format|
-        format.html { redirect_back(fallback_location: location, alert: @notification) }
+        format.html { redirect_back_or_to location, alert: @notification }
+        format.js { render :file_operation }
+        format.json { render json: @job_application_file.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def uncheck
+    if @job_application_file.mark_as_invalid!(current_administrator)
+      @job_application.compute_notifications_counter!
+      @notification = t(".success")
+      respond_to do |format|
+        format.html { redirect_back_or_to location, notice: @notification }
+        format.js { render :file_operation }
+        format.json { render :show, status: :ok, location: }
+      end
+    else
+      @notification = @job_application_file.errors.full_messages.to_sentence
+      respond_to do |format|
+        format.html { redirect_back_or_to location, alert: @notification }
         format.js { render :file_operation }
         format.json { render json: @job_application_file.errors, status: :unprocessable_entity }
       end
@@ -113,10 +114,9 @@ class Admin::JobApplicationFilesController < Admin::BaseController
 
   private
 
-  # Never trust parameters from the scary internet, only allow the white list through.
   def job_application_file_params
-    params.require(:job_application_file).permit(:content,
-      :job_application_file_type_id,
-      :is_validated)
+    params.require(:job_application_file).permit(:content, :job_application_file_type_id, :is_validated)
   end
+
+  def location = [:admin, @job_application, @job_application_file]
 end

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -3,6 +3,8 @@
 # Container for real file mandatory to fullfill a job application
 class JobApplicationFile < ApplicationRecord
   include Securable
+  include Validatable
+
   attr_accessor :job_application_file_existing_id, :do_not_provide_immediately
 
   belongs_to :job_application
@@ -31,36 +33,6 @@ class JobApplicationFile < ApplicationRecord
     else
       false
     end
-  end
-
-  def check!(administrator)
-    unless job_application_file_type.can_validate?(administrator)
-      errors.add(:base, :not_authorized_to_validate)
-      return false
-    end
-
-    update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def uncheck!(administrator)
-    unless job_application_file_type.can_validate?(administrator)
-      errors.add(:base, :not_authorized_to_validate)
-      return false
-    end
-
-    update_column :is_validated, 2 # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def validated?
-    is_validated == 1
-  end
-
-  def rejected?
-    is_validated == 2
-  end
-
-  def waiting_validation?
-    is_validated == 0
   end
 
   def downloadable? = JobApplication.states[job_application_state] < max_downloadable_state

--- a/app/models/job_application_file/validatable.rb
+++ b/app/models/job_application_file/validatable.rb
@@ -1,7 +1,7 @@
 module JobApplicationFile::Validatable
   extend ActiveSupport::Concern
 
-  def check!(administrator)
+  def mark_as_valid!(administrator)
     unless job_application_file_type.can_validate?(administrator)
       errors.add(:base, :not_authorized_to_validate)
       return false
@@ -10,7 +10,7 @@ module JobApplicationFile::Validatable
     update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
   end
 
-  def uncheck!(administrator)
+  def mark_as_invalid!(administrator)
     unless job_application_file_type.can_validate?(administrator)
       errors.add(:base, :not_authorized_to_validate)
       return false

--- a/app/models/job_application_file/validatable.rb
+++ b/app/models/job_application_file/validatable.rb
@@ -1,0 +1,33 @@
+module JobApplicationFile::Validatable
+  extend ActiveSupport::Concern
+
+  def check!(administrator)
+    unless job_application_file_type.can_validate?(administrator)
+      errors.add(:base, :not_authorized_to_validate)
+      return false
+    end
+
+    update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def uncheck!(administrator)
+    unless job_application_file_type.can_validate?(administrator)
+      errors.add(:base, :not_authorized_to_validate)
+      return false
+    end
+
+    update_column :is_validated, 2 # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def validated?
+    is_validated == 1
+  end
+
+  def rejected?
+    is_validated == 2
+  end
+
+  def waiting_validation?
+    is_validated == 0
+  end
+end

--- a/app/models/job_application_file/validatable.rb
+++ b/app/models/job_application_file/validatable.rb
@@ -25,7 +25,7 @@ module JobApplicationFile::Validatable
     is_validated == 1
   end
 
-  def rejected?
+  def invalidated?
     is_validated == 2
   end
 

--- a/app/models/job_application_file/validatable.rb
+++ b/app/models/job_application_file/validatable.rb
@@ -8,6 +8,7 @@ module JobApplicationFile::Validatable
     end
 
     update_column :is_validated, 1 # rubocop:disable Rails/SkipsModelValidations
+    job_application.compute_notifications_counter!
   end
 
   def mark_as_invalid!(administrator)
@@ -17,6 +18,7 @@ module JobApplicationFile::Validatable
     end
 
     update_column :is_validated, 2 # rubocop:disable Rails/SkipsModelValidations
+    job_application.compute_notifications_counter!
   end
 
   def validated?

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -93,6 +93,8 @@ class JobApplicationFileType < ApplicationRecord
   accepts_nested_attributes_for :visibility_rules, allow_destroy: true
 
   def can_validate?(administrator)
+    return true if administrator.functional_administrator?
+
     VALIDATOR_ROLE_MAPPING.any? { |flag, role_method| self[flag] && administrator.public_send(role_method) }
   end
 

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -14,7 +14,7 @@
         = link_to [:admin, @job_application, :job_application_files, {job_application_file: {job_application_file_type_id: type.id, is_validated: 1}}], class: klasses, title: t('.check'), remote: true, method: :post do
           = fa_icon "check"
         - klasses = %w(btn btn-danger btn-raised btn-sm mb-0 mr-1)
-        - klasses << 'opaque' unless file.rejected?
+        - klasses << 'opaque' unless file.invalidated?
         = link_to [:admin, @job_application, :job_application_files, {job_application_file: {job_application_file_type_id: type.id, is_validated: 2}}], class: klasses, title: t('.uncheck'), remote: true, method: :post do
           = fa_icon "xmark"
       - else
@@ -23,7 +23,7 @@
         = link_to [:check, :admin, @job_application, file], class: klasses, title: t('.check'), remote: true, method: :post do
           = fa_icon "check"
         - klasses = %w(btn btn-danger btn-raised btn-sm mb-0 mr-1)
-        - klasses << 'opaque' unless file.rejected?
+        - klasses << 'opaque' unless file.invalidated?
         = link_to [:uncheck, :admin, @job_application, file], class: klasses, title: t('.uncheck'), remote: true, method: :post do
           = fa_icon "xmark"
     - elsif file.document_content.present?
@@ -32,7 +32,7 @@
       = link_to [:check, :admin, @job_application, file], class: klasses, title: t('.check'), remote: true, method: :post do
         = fa_icon "check"
       - klasses = %w(btn btn-danger btn-raised btn-sm mb-0 mr-1)
-      - klasses << 'opaque' unless file.rejected?
+      - klasses << 'opaque' unless file.invalidated?
       = link_to [:uncheck, :admin, @job_application, file], class: klasses, title: t('.uncheck'), remote: true, method: :post do
         = fa_icon "xmark"
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}

--- a/spec/models/job_application_file/validatable_spec.rb
+++ b/spec/models/job_application_file/validatable_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe JobApplicationFile::Validatable do
+  describe "#check!" do
+    subject(:check) { job_application_file.check!(administrator) }
+
+    let(:job_application_file) { create(:job_application_file, job_application:) }
+    let(:job_application) { create(:job_application) }
+
+    context "when administrator is authorized" do
+      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
+
+      it { expect { check }.to change { job_application_file.reload.validated? }.to(true) }
+    end
+
+    context "when administrator is not authorized" do
+      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
+
+      it { expect(check).to be(false) }
+
+      it { expect { check }.not_to change { job_application_file.reload.is_validated } }
+
+      it "adds an error on base" do
+        check
+        expect(job_application_file.errors[:base]).to be_present
+      end
+    end
+  end
+
+  describe "#uncheck!" do
+    subject(:uncheck) { job_application_file.uncheck!(administrator) }
+
+    let(:job_application_file) { create(:job_application_file, job_application:) }
+    let(:job_application) { create(:job_application) }
+
+    before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
+
+    context "when administrator is authorized" do
+      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
+
+      it { expect { uncheck }.to change { job_application_file.reload.rejected? }.to(true) }
+    end
+
+    context "when administrator is not authorized" do
+      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
+
+      it { expect(uncheck).to be(false) }
+
+      it { expect { uncheck }.not_to change { job_application_file.reload.is_validated } }
+
+      it "adds an error on base" do
+        uncheck
+        expect(job_application_file.errors[:base]).to be_present
+      end
+    end
+  end
+
+  describe "#validated?" do
+    subject { job_application_file.validated? }
+
+    let(:job_application_file) { build(:job_application_file, is_validated:) }
+
+    context "when is_validated is 1" do
+      let(:is_validated) { 1 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when is_validated is 0" do
+      let(:is_validated) { 0 }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when is_validated is 2" do
+      let(:is_validated) { 2 }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#rejected?" do
+    subject { job_application_file.rejected? }
+
+    let(:job_application_file) { build(:job_application_file, is_validated:) }
+
+    context "when is_validated is 2" do
+      let(:is_validated) { 2 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when is_validated is 0" do
+      let(:is_validated) { 0 }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when is_validated is 1" do
+      let(:is_validated) { 1 }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#waiting_validation?" do
+    subject { job_application_file.waiting_validation? }
+
+    let(:job_application_file) { build(:job_application_file, is_validated:) }
+
+    context "when is_validated is 0" do
+      let(:is_validated) { 0 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when is_validated is 1" do
+      let(:is_validated) { 1 }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when is_validated is 2" do
+      let(:is_validated) { 2 }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/models/job_application_file/validatable_spec.rb
+++ b/spec/models/job_application_file/validatable_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe JobApplicationFile::Validatable do
     context "when administrator is authorized" do
       let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
 
-      it { expect { mark_as_invalid }.to change { job_application_file.reload.rejected? }.to(true) }
+      it { expect { mark_as_invalid }.to change { job_application_file.reload.invalidated? }.to(true) }
     end
 
     context "when administrator is not authorized" do
@@ -79,8 +79,8 @@ RSpec.describe JobApplicationFile::Validatable do
     end
   end
 
-  describe "#rejected?" do
-    subject { job_application_file.rejected? }
+  describe "#invalidated?" do
+    subject { job_application_file.invalidated? }
 
     let(:job_application_file) { build(:job_application_file, is_validated:) }
 

--- a/spec/models/job_application_file/validatable_spec.rb
+++ b/spec/models/job_application_file/validatable_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe JobApplicationFile::Validatable do
-  describe "#check!" do
-    subject(:check) { job_application_file.check!(administrator) }
+  describe "#mark_as_valid!" do
+    subject(:mark_as_valid) { job_application_file.mark_as_valid!(administrator) }
 
     let(:job_application_file) { create(:job_application_file, job_application:) }
     let(:job_application) { create(:job_application) }
@@ -10,25 +10,25 @@ RSpec.describe JobApplicationFile::Validatable do
     context "when administrator is authorized" do
       let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
 
-      it { expect { check }.to change { job_application_file.reload.validated? }.to(true) }
+      it { expect { mark_as_valid }.to change { job_application_file.reload.validated? }.to(true) }
     end
 
     context "when administrator is not authorized" do
       let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
 
-      it { expect(check).to be(false) }
+      it { expect(mark_as_valid).to be(false) }
 
-      it { expect { check }.not_to change { job_application_file.reload.is_validated } }
+      it { expect { mark_as_valid }.not_to change { job_application_file.reload.is_validated } }
 
       it "adds an error on base" do
-        check
+        mark_as_valid
         expect(job_application_file.errors[:base]).to be_present
       end
     end
   end
 
-  describe "#uncheck!" do
-    subject(:uncheck) { job_application_file.uncheck!(administrator) }
+  describe "#mark_as_invalid!" do
+    subject(:mark_as_invalid) { job_application_file.mark_as_invalid!(administrator) }
 
     let(:job_application_file) { create(:job_application_file, job_application:) }
     let(:job_application) { create(:job_application) }
@@ -38,18 +38,18 @@ RSpec.describe JobApplicationFile::Validatable do
     context "when administrator is authorized" do
       let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
 
-      it { expect { uncheck }.to change { job_application_file.reload.rejected? }.to(true) }
+      it { expect { mark_as_invalid }.to change { job_application_file.reload.rejected? }.to(true) }
     end
 
     context "when administrator is not authorized" do
       let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
 
-      it { expect(uncheck).to be(false) }
+      it { expect(mark_as_invalid).to be(false) }
 
-      it { expect { uncheck }.not_to change { job_application_file.reload.is_validated } }
+      it { expect { mark_as_invalid }.not_to change { job_application_file.reload.is_validated } }
 
       it "adds an error on base" do
-        uncheck
+        mark_as_invalid
         expect(job_application_file.errors[:base]).to be_present
       end
     end

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -40,60 +40,6 @@ RSpec.describe JobApplicationFile do
     end
   end
 
-  describe "#check!" do
-    subject(:check) { job_application_file.check!(administrator) }
-
-    let(:job_application_file) { create(:job_application_file, job_application:) }
-    let(:job_application) { create(:job_application) }
-
-    context "when administrator is authorized" do
-      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
-
-      it { expect { check }.to change { job_application_file.reload.validated? }.to(true) }
-    end
-
-    context "when administrator is not authorized" do
-      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
-
-      it { expect(check).to be(false) }
-
-      it { expect { check }.not_to change { job_application_file.reload.is_validated } }
-
-      it "adds an error on base" do
-        check
-        expect(job_application_file.errors[:base]).to be_present
-      end
-    end
-  end
-
-  describe "#uncheck!" do
-    subject(:uncheck) { job_application_file.uncheck!(administrator) }
-
-    let(:job_application_file) { create(:job_application_file, job_application:) }
-    let(:job_application) { create(:job_application) }
-
-    before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
-
-    context "when administrator is authorized" do
-      let(:administrator) { build(:administrator, roles: [:employer_recruiter]) }
-
-      it { expect { uncheck }.to change { job_application_file.reload.rejected? }.to(true) }
-    end
-
-    context "when administrator is not authorized" do
-      let(:administrator) { build(:administrator, roles: [:payroll_manager]) }
-
-      it { expect(uncheck).to be(false) }
-
-      it { expect { uncheck }.not_to change { job_application_file.reload.is_validated } }
-
-      it "adds an error on base" do
-        uncheck
-        expect(job_application_file.errors[:base]).to be_present
-      end
-    end
-  end
-
   describe "#downloadable?" do
     subject(:downloadable) { job_application_file.downloadable? }
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe JobApplicationFileType do
 
       it { is_expected.to be(false) }
     end
+
+    context "when administrator is a functional_administrator" do
+      let(:administrator) { build(:administrator, roles: [:functional_administrator]) }
+
+      it { is_expected.to be(true) }
+    end
   end
 
   describe "scopes" do

--- a/spec/requests/admin/job_application_files_spec.rb
+++ b/spec/requests/admin/job_application_files_spec.rb
@@ -208,7 +208,13 @@ RSpec.describe "Admin::JobApplicationFiles" do
         create(:job_application_file, job_application: job_application, job_application_file_type: unauthorized_file_type)
       end
 
-      before { job_application_file.update_column(:is_validated, 2) } # rubocop:disable Rails/SkipsModelValidations
+      let(:unauthorized_administrator) { create(:administrator, roles: [:employer_recruiter]) }
+
+      before do
+        job_application_file.update_column(:is_validated, 2) # rubocop:disable Rails/SkipsModelValidations
+        create(:job_offer_actor, job_offer: job_application.job_offer, administrator: unauthorized_administrator)
+        sign_in unauthorized_administrator
+      end
 
       context "when format is html" do
         subject(:check_request) {
@@ -284,7 +290,13 @@ RSpec.describe "Admin::JobApplicationFiles" do
         create(:job_application_file, job_application: job_application, job_application_file_type: unauthorized_file_type)
       end
 
-      before { job_application_file.update_column(:is_validated, 1) } # rubocop:disable Rails/SkipsModelValidations
+      let(:unauthorized_administrator) { create(:administrator, roles: [:employer_recruiter]) }
+
+      before do
+        job_application_file.update_column(:is_validated, 1) # rubocop:disable Rails/SkipsModelValidations
+        create(:job_offer_actor, job_offer: job_application.job_offer, administrator: unauthorized_administrator)
+        sign_in unauthorized_administrator
+      end
 
       context "when format is html" do
         subject(:uncheck_request) {


### PR DESCRIPTION
# Description
Un administrateur avec le rôle `functional_administrator` peut désormais toujours valider/invalider une pièce, même s'il n'est pas dans la liste des « Acteurs autorisés à valider » du type de fichier.

Ensuite on fait plusieurs refactorings pour améliorer la qualité du code dans cette partie de l'application : 
- extraction de la logique métier de validation de `JobApplicationFile` dans un concern `Validatable`
- renommage `check!`/`uncheck!` → `mark_as_valid!`/`mark_as_invalid!`
- déplacement de `compute_notifications_counter!` depuis le contrôleur vers le modèle
- renommage de `rejected?` → `invalidated?` pour que le vocabulaire utilisé soit homogène.

À lire commit par commit pour la review.


# Plan de test
- [ ] Se connecter en tant qu'administrateur avec le rôle `functional_administrator` uniquement
- [ ] Ouvrir une candidature avec un fichier à valider ou invalider
- [ ] Vérifier que le bouton « valider » fonctionne et passe bien la pièce à l'état validé
- [ ] Vérifier que le bouton « invalider » fonctionne et passe bien la pièce à l'état rejeté
- [ ] Se connecter avec un administrateur ayant seulement un rôle non autorisé sur le type de fichier et vérifier que la validation / invalidation est refusée avec un message d'alerte

# Review app

https://erecrutement-cvd-staging-pr2081.osc-fr1.scalingo.io

# Links

https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/2060#issuecomment-4260685679