### PR TITLE
Add DAR validation and update employment authority rights

### DIFF
--- a/app/controllers/admin/dars_controller.rb
+++ b/app/controllers/admin/dars_controller.rb
@@ -1,0 +1,23 @@
+class Admin::DarsController < Admin::BaseController
+  skip_load_and_authorize_resource
+
+  before_action :set_job_application
+
+  def update
+    if current_administrator.can?(:update_application_dar, @job_application)
+      @job_application.update!(job_application_params)
+      flash.now[:notice] = t(".success")
+    else
+      flash.now[:notice] = t(".unauthorized")
+    end
+  end
+
+  private
+
+  def set_job_application
+    @job_application = JobApplication.find(params[:job_application_id])
+    authorize! :validate_dar, @job_application
+  end
+
+  def job_application_params = params.require(:job_application).permit(:dar)
+end

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -1,5 +1,11 @@
 import "@hotwired/turbo-rails"
+import { StreamActions } from "@hotwired/turbo"
 import "./controllers"
+
+StreamActions.notify = function () {
+  const message = this.getAttribute("message")
+  if (message) Snackbar.show({ showAction: false, text: message })
+}
 
 import Rails from '@rails/ujs'
 Rails.start()

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,8 @@ class Ability
 
     if administrator.functional_administrator?
       ability_functional_administrator(administrator)
+    elsif administrator.employment_authority?
+      ability_employment_authority(administrator)
     elsif administrator.employer_recruiter?
       ability_employer_recruiter(administrator)
     else
@@ -31,6 +33,16 @@ class Ability
     can :manage, :all
     can :manage, PreferredUsersList, administrator_id: administrator.id
     can :manage, JobApplication
+  end
+
+  def ability_employment_authority(administrator)
+    can :read, JobOffer, job_offer_actors: {administrator_id: administrator.id}
+    cannot :transfer, JobOffer
+    can :manage, JobApplication, job_application_read_query(administrator)
+    can :manage, JobApplicationFile
+    can :manage, Message
+    can :manage, Email
+    can :read, User
   end
 
   def ability_employer_recruiter(administrator)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -54,6 +54,7 @@ class JobApplication < ApplicationRecord
     if: -> { state_changed? && state_was.present? && JobApplication.states[state] > JobApplication.states[state_was] },
     unless: -> { requested_files_validated? }
   validate :cant_be_accepted_twice, if: -> { accepted? }, unless: -> { has_accepted_other_job_application? }
+  validate :dar_validated, if: -> { state_changed? && contract_drafting? }, unless: :dar?
 
   before_validation :set_employer
   before_save :compute_notifications_counter
@@ -299,6 +300,8 @@ class JobApplication < ApplicationRecord
   end
 
   def cant_be_accepted_twice = errors.add(:state, :cant_be_accepted_twice)
+
+  def dar_validated = errors.add(:state, :dar_unvalidated)
 
   def has_accepted_other_job_application? = user.job_applications.where(state: "accepted").where.not(id: id).empty?
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -329,6 +329,7 @@ end
 #
 #  id                                :uuid             not null, primary key
 #  administrator_notifications_count :integer          default(0)
+#  dar                               :boolean          default(FALSE), not null
 #  emails_administrator_unread_count :integer          default(0)
 #  emails_count                      :integer          default(0)
 #  emails_unread_count               :integer          default(0)

--- a/app/views/admin/dars/update.turbo_stream.erb
+++ b/app/views/admin/dars/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.replace @job_application,
+                         partial: "admin/job_offers/job_application",
+                         locals: {
+                           job_application: @job_application,
+                           preselection: false,
+                           dar: true
+                         } %>
+
+<turbo-stream action="notify" message="<%= flash[:notice] %>"><template></template></turbo-stream>

--- a/app/views/admin/job_applications/_job_application_activity.html.haml
+++ b/app/views/admin/job_applications/_job_application_activity.html.haml
@@ -43,6 +43,9 @@
                   - state_name = JobApplication.states.find { |k, v| v == state_index }&.first
                   - state_name_i18n = JobApplication.human_attribute_name("state/#{state_name}")
                   = t('.activities.change_state_html', admin_name: whodunnit, name: full_name, state_name: state_name_i18n)
+                - elsif audited_changes.key?('dar')
+                  - key = audited_changes['dar'].last ? '.activities.dar_change_true_html' : '.activities.dar_change_false_html'
+                  = t(key, admin_name: whodunnit)
                 - elsif audit.auditable_type == "Message"
                   = t('.activities.message_html', admin_name: whodunnit, name: full_name)
                   .card.my-2

--- a/app/views/admin/job_offers/_board_column.html.haml
+++ b/app/views/admin/job_offers/_board_column.html.haml
@@ -7,4 +7,4 @@
           %span.total= job_applications.size
       = link_to fa_icon('envelope'), [:new, :admin, @job_offer, :multiple_recipients_email, state: state_name], title: t('buttons.email')
   .d-flex.flex-column.cards{data: {state: state_name}}
-    = render partial: 'job_application', collection: job_applications, locals: {preselection: (state_name == "initial")}
+    = render partial: 'job_application', collection: job_applications, locals: {preselection: (state_name == "initial"), dar: (state_name == "accepted")}

--- a/app/views/admin/job_offers/_board_column.html.haml
+++ b/app/views/admin/job_offers/_board_column.html.haml
@@ -7,4 +7,4 @@
           %span.total= job_applications.size
       = link_to fa_icon('envelope'), [:new, :admin, @job_offer, :multiple_recipients_email, state: state_name], title: t('buttons.email')
   .d-flex.flex-column.cards{data: {state: state_name}}
-    = render partial: 'job_application', collection: job_applications, locals: {preselection: (state_name == "initial"), dar: (state_name == "accepted")}
+    = render partial: 'job_application', collection: job_applications, locals: {preselection: (state_name == "initial"), dar: JobApplication::FILLED_STATES.include?(state_name)}

--- a/app/views/admin/job_offers/_job_application.html.haml
+++ b/app/views/admin/job_offers/_job_application.html.haml
@@ -44,6 +44,10 @@
               - else
                 %span.btn.btn-sm.btn-link.disabled= fa_icon('thumbs-down', flavor: 'regular')
 
+  - if dar
+    = simple_form_for job_application, url: admin_job_application_dar_path(job_application), namespace: "dar_#{job_application.id}", html: { class: 'mx-3', data: { controller: 'auto-submit' } } do |f|
+      = f.input :dar, input_html: { data: { action: 'change->auto-submit#submit' } }, disabled: !current_administrator.can?(:update_application_dar, job_application)
+
   .card-footer.d-flex.flex-column.flex-md-row.align-items-center
     .mr-auto= t('admin.job_applications.job_application.applied_on', date: I18n.l(job_application.created_at.to_date))
     - klasses = %w(emails-count badge job-application-modal-link mr-2)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -343,6 +343,8 @@ fr:
         activities:
           creation_html: "<span class='user-name'>%{name}</span> a postulé"
           change_state_html: "<span class='user-name'>%{admin_name}</span> a déplacé <span class='user-name'>%{name}</span> dans la colonne “%{state_name}”"
+          dar_change_true_html: "<span class='user-name'>%{admin_name}</span> a validé le DAR"
+          dar_change_false_html: "<span class='user-name'>%{admin_name}</span> a invalidé le DAR"
           message_html: "<span class='user-name'>%{admin_name}</span> a commenté la candidature de <span class='user-name'>%{name}</span>"
           email_html: "<span class='user-name'>%{admin_name}</span> a envoyé un courriel à <span class='user-name'>%{name}</span>"
           email_simple_html: "<span class='user-name'>%{from_name}</span> a envoyé un courriel"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1192,7 +1192,7 @@ fr:
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               dar_unvalidated: 'Une autorité d''emploi affiliée à l''offre doit cocher la case "DAR validée" pour permettre la poursuite du processus de recrutement.'
               immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
-              cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
+              cant_skip_state: "Impossible passer à l’étape suivante sans la validation de l’étape précédente."
             cover_letter_content_type:
               invalid: "PDF uniquement, max 2Mo"
             resume_content_type:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1188,6 +1188,9 @@ fr:
               cant_accept_remaining_initial_job_applications: "Toutes les nouvelles candidatures doivent être traitées avant d'accepter une candidature"
               requested_files_missing: "Des documents obligatoires sont manquants ou non validés : %{documents}"
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
+              dar_unvalidated: 'Une autorité d''emploi affiliée à l''offre doit cocher la case "DAR validée" pour permettre la poursuite du processus de recrutement.'
+              immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
+              cant_skip_state: "Impossible passer à l’étape supérieure sans la validation de l’étape précédente."
             cover_letter_content_type:
               invalid: "PDF uniquement, max 2Mo"
             resume_content_type:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -376,6 +376,10 @@ fr:
         help: "Téléverser un fichier"
       uncheck:
         success: "Fichier invalidé !"
+    dars:
+      update:
+        success: "Validation DAR mise à jour avec succès"
+        unauthorized: "Vous n'êtes pas autorisé(e) à valider ou invalider la DAR de cette candidature."
     rejections:
       new:
         title: "Refus ou désistement"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -94,6 +94,7 @@ fr:
       job_application:
         experiences_fit_job_offer: "Expérience pour l'offre"
         skills_fit_job_offer: "Adéquate pour l'offre"
+        dar: "DAR validée"
       job_application_files:
         job_application_file_existing_id: Choisir un fichier existant
       job_application_file_type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
         end
       end
       resource :rejection, only: %i[new create destroy]
+      resource :dar, only: %i[update]
       resources :messages, only: %i[create]
       resources :emails, only: %i[create] do
         member do

--- a/db/migrate/20260210072230_add_dar_to_job_applications.rb
+++ b/db/migrate/20260210072230_add_dar_to_job_applications.rb
@@ -1,0 +1,3 @@
+class AddDarToJobApplications < ActiveRecord::Migration[7.1]
+  def change = add_column :job_applications, :dar, :boolean, default: false, null: false
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -425,6 +425,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_15_083311) do
     t.uuid "category_id"
     t.boolean "rejected", default: false
     t.integer "preselection", default: 0
+    t.boolean "dar", default: false, null: false
     t.index ["category_id"], name: "index_job_applications_on_category_id"
     t.index ["employer_id"], name: "index_job_applications_on_employer_id"
     t.index ["job_offer_id"], name: "index_job_applications_on_job_offer_id"

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -29,6 +29,7 @@ end
 #
 #  id                                :uuid             not null, primary key
 #  administrator_notifications_count :integer          default(0)
+#  dar                               :boolean          default(FALSE), not null
 #  emails_administrator_unread_count :integer          default(0)
 #  emails_count                      :integer          default(0)
 #  emails_unread_count               :integer          default(0)

--- a/spec/models/job_application/notifiable_spec.rb
+++ b/spec/models/job_application/notifiable_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JobApplication::Notifiable do
     describe "#notify_hr_managers_contract_drafting" do
       subject(:contract_drafting) { job_application.contract_drafting! }
 
-      let(:job_application) { create(:job_application, state: :accepted) }
+      let(:job_application) { create(:job_application, state: :accepted, dar: true) }
 
       context "when the job application has at least one hr_manager" do
         let(:administrator) { create(:administrator, roles: [:hr_manager]) }
@@ -44,7 +44,7 @@ RSpec.describe JobApplication::Notifiable do
     describe "#notify_hr_managers_contract_feedback_waiting" do
       subject(:contract_feedback_waiting) { job_application.contract_feedback_waiting! }
 
-      let(:job_application) { create(:job_application, state: :contract_drafting) }
+      let(:job_application) { create(:job_application, state: :contract_drafting, dar: true) }
 
       context "when the job application has at least one hr_manager" do
         let(:administrator) { create(:administrator, roles: [:hr_manager]) }

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -151,6 +151,7 @@ end
 #
 #  id                                :uuid             not null, primary key
 #  administrator_notifications_count :integer          default(0)
+#  dar                               :boolean          default(FALSE), not null
 #  emails_administrator_unread_count :integer          default(0)
 #  emails_count                      :integer          default(0)
 #  emails_unread_count               :integer          default(0)

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe JobApplication do
         it { is_expected.to be(true) }
       end
     end
+
+    describe "#dar_validated" do
+      subject(:contract_drafting) { job_application.contract_drafting! }
+
+      let(:job_application) { create(:job_application, state: :accepted, dar:) }
+
+      context "when the dar is validated" do
+        let(:dar) { true }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the dar is not validated" do
+        let(:dar) { false }
+
+        it { expect { contract_drafting }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
+    end
   end
 
   describe "scopes" do

--- a/spec/requests/admin/dars_spec.rb
+++ b/spec/requests/admin/dars_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Dars" do
+  before { sign_in admin }
+
+  describe "PATCH /admin/candidatures/:job_application_id/dar" do
+    subject(:update_dar) do
+      patch admin_job_application_dar_path(job_application), params: {job_application: {dar: true}}, as: :turbo_stream
+    end
+
+    let(:job_application) { create(:job_application, dar: false, state: :accepted) }
+
+    before { job_application.job_offer.job_offer_actors.create!(role: :employer, administrator: admin) }
+
+    context "when the administrator is employment authority" do
+      let(:admin) { create(:administrator, roles: [:employment_authority]) }
+
+      it "changes the dar value" do
+        expect { update_dar }.to change { job_application.reload.dar }.from(false).to(true)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(flash[:notice]).to eq(I18n.t("admin.dars.update.success"))
+      end
+    end
+
+    context "when the administrator is not employment authority" do
+      let(:admin) { create(:administrator, roles: [:hr_manager]) }
+
+      it "does not change the dar value" do
+        expect { update_dar }.not_to change { job_application.reload.dar }
+        expect(flash[:notice]).to eq(I18n.t("admin.dars.update.unauthorized"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description


**DAR (Droit Au Recrutement)** : ajout d'un booléen `dar` sur `JobApplication`, d'un formulaire dédié, et d'une validation bloquant le passage à `contract_drafting` tant que la DAR n'est pas validée. La case est éditable par l'autorité d'emploi à l'état `accepted` et s'affiche grisée pour les états suivants.


# Test plan


- [ ] Board admin : case DAR visible et éditable en colonne « accepted » (autorité d'emploi et super admin uniquement), grisée pour les 4 états suivants.
- [ ] Tenter `contract_drafting` sans DAR validée → blocage.
- [ ] Les droits par action / état respectent la matrice `administrator_permissions.yml`.

# Review app

https://erecrutement-cvd-staging-pr2085.osc-fr1.scalingo.io

# Links

Closes #1954
Closes #2062
Closes #2063

# Screenshots

<img width="1703" height="516" alt="CleanShot 2026-04-20 at 17 40 06" src="https://github.com/user-attachments/assets/9f754a79-6e2a-4d04-92e0-de66ffd4163b" />

<img width="1689" height="1298" alt="CleanShot 2026-04-20 at 17 40 35" src="https://github.com/user-attachments/assets/01f8a3ab-77d8-44ba-8a22-bc9436c82e88" />

