### PR TITLE
Remove useless admin permissions

### DIFF
--- a/config/administrator_permissions.yml
+++ b/config/administrator_permissions.yml
@@ -1,460 +1,235 @@
 ---
 functional_administrator:
   initial:
-    show_application: true
     update_application_state: [phone_meeting, to_be_met, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   phone_meeting:
-    show_application: true
     update_application_state: [initial, to_be_met, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   to_be_met:
-    show_application: true
     update_application_state: [phone_meeting, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   financial_estimate:
-    show_application: true
     update_application_state: [to_be_met, accepted]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   accepted:
-    show_application: true
     update_application_state: [financial_estimate, contract_drafting]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: true
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_drafting:
-    show_application: true
     update_application_state: [accepted, contract_feedback_waiting]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_feedback_waiting:
-    show_application: true
     update_application_state: [contract_drafting, contract_received]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_received:
-    show_application: true
     update_application_state: [contract_feedback_waiting, affected]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   affected:
-    show_application: true
     update_application_state: [contract_received]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
 
 employer_recruiter:
   initial:
-    show_application: true
     update_application_state: [phone_meeting, to_be_met, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   phone_meeting:
-    show_application: true
     update_application_state: [initial, to_be_met, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   to_be_met:
-    show_application: true
     update_application_state: [phone_meeting, financial_estimate]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   financial_estimate:
-    show_application: true
     update_application_state: [to_be_met, accepted]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   accepted:
-    show_application: true
     update_application_state: [financial_estimate, contract_drafting]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_drafting:
-    show_application: true
     update_application_state: [accepted, contract_feedback_waiting]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_feedback_waiting:
-    show_application: true
     update_application_state: [contract_drafting, contract_received]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   contract_received:
-    show_application: true
     update_application_state: [contract_feedback_waiting, affected]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
   affected:
-    show_application: true
     update_application_state: [contract_received]
     update_user_info: true
     update_application_rejected: true
     update_application_dar: false
-    update_file_validation: true
-    create_file: true
-    create_comment: true
-    create_email: true
 
 employment_authority:
   initial:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   phone_meeting:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   to_be_met:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   financial_estimate:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   accepted:
-    show_application: true
     update_application_state: [contract_drafting]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: true
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   contract_drafting:
-    show_application: true
     update_application_state: [accepted]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   contract_feedback_waiting:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   contract_received:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   affected:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
 
 hr_manager:
   initial:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   phone_meeting:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   to_be_met:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   financial_estimate:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   accepted:
-    show_application: true
     update_application_state: [contract_drafting]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   contract_drafting:
-    show_application: true
     update_application_state: [accepted, contract_feedback_waiting]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   contract_feedback_waiting:
-    show_application: true
     update_application_state: [contract_drafting, contract_received]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   contract_received:
-    show_application: true
     update_application_state: [contract_feedback_waiting, affected]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   affected:
-    show_application: true
     update_application_state: [contract_received]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
 
 payroll_manager:
   initial:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   phone_meeting:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   to_be_met:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   financial_estimate:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   accepted:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   contract_drafting:
-    show_application: true
     update_application_state: false
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: false
-    create_file: false
-    create_comment: true
-    create_email: true
   contract_feedback_waiting:
-    show_application: true
     update_application_state: [contract_received]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   contract_received:
-    show_application: true
     update_application_state: [contract_feedback_waiting, affected]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true
   affected:
-    show_application: true
     update_application_state: [contract_received]
     update_user_info: false
     update_application_rejected: false
     update_application_dar: false
-    update_file_validation: true
-    create_file: [manager_provided]
-    create_comment: true
-    create_email: true

--- a/spec/models/administrator_permissions_spec.rb
+++ b/spec/models/administrator_permissions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdministratorPermissions do
     context "when the permission value is true" do
       let(:role) { :functional_administrator }
       let(:state) { :initial }
-      let(:action) { :show_application }
+      let(:action) { :update_application_rejected }
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
# Description

On enlève les permissions d'administrateur qui semblent inutiles au regard de la matrice des droits : 

1/ `show_application` => tous les administrateurs ont les mêmes droits : ils accèdent aux offres d'emploi auxquelles ils sont rattachés (sauf le `functional_administrator`, qui accède à toutes les offres)

2/ `update_file_validation` => ça fait doublon avec le paramétrage du type de fichier. Comme vu avec le BSI, on conserve uniquement le paramétrage du type de fichier, et on enlève cette permission.

<img width="1705" height="484" alt="CleanShot 2026-04-21 at 16 25 21" src="https://github.com/user-attachments/assets/c4079ca5-7eaf-48f7-a6e6-b17100434027" />

3/ `create_file` => c'est étrange d'avoir des permissions différentes pour demander un document, et pour valider / invalider un document. Pour plus de cohérence, on prend la même règle que ci-dessus. C'est modélisé par le ticket #2086.

4/ `create_comment` => tous les administrateurs ont le droit de mettre un commentaire sur une candidature à laquelle ils peuvent accéder. Pas besoin d'une permission particulière.

5/ `create_email` => comme on l'a vu dans la matrice des droits, tous les administrateurs ont le droit d'envoyer un email sur une candidature à laquelle ils peuvent accéder. Pas besoin de cette permission.
