### PR TITLE
Restrict requestable files to manager_provided kind for hr_manager

### DIFF
--- a/app/helpers/admin/job_applications_helper.rb
+++ b/app/helpers/admin/job_applications_helper.rb
@@ -74,6 +74,12 @@ module Admin::JobApplicationsHelper
     allowed_change_states(job_application, administrator).any? { |state| state.name.to_s != job_application.state }
   end
 
+  def requestable_file_types(job_application, administrator)
+    JobApplicationFileType
+      .visible_by(administrator, job_application.state)
+      .where.not(id: job_application.job_application_files.select(:job_application_file_type_id))
+  end
+
   def job_application_resume_url(job_application)
     return unless job_application
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,7 @@ class Ability
   def ability_other_administrators(administrator)
     can :read, JobOffer, job_offer_actors: {administrator_id: administrator.id}
     can :manage, JobApplication, job_application_read_query(administrator)
+    can :manage, JobApplicationFile
     can :manage, Message
     can :manage, Email
   end

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -51,7 +51,7 @@ class JobApplicationFileType < ApplicationRecord
       .where(visibility_rules: {by: :administrator})
       .where("visibility_rules.state <= ?", JobApplication.states[state])
       .distinct
-    scope = scope.manager_provided if administrator.hr_manager?
+    scope = scope.manager_provided if administrator.hr_manager? || administrator.payroll_manager?
     scope
   }
 

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -46,11 +46,13 @@ class JobApplicationFileType < ApplicationRecord
       .distinct
   }
 
-  scope :visible_by_administrator, ->(state) {
-    joins(:visibility_rules)
+  scope :visible_by, ->(administrator, state) {
+    scope = joins(:visibility_rules)
       .where(visibility_rules: {by: :administrator})
       .where("visibility_rules.state <= ?", JobApplication.states[state])
       .distinct
+    scope = scope.manager_provided if administrator.hr_manager?
+    scope
   }
 
   scope :required, ->(state) {

--- a/app/views/admin/job_applications/files.html.haml
+++ b/app/views/admin/job_applications/files.html.haml
@@ -1,5 +1,5 @@
 - requested_files = @job_application.job_application_files
-- other_file_types = JobApplicationFileType.visible_by_administrator(@job_application.state).where.not(id: requested_files.select(:job_application_file_type_id))
+- other_file_types = JobApplicationFileType.visible_by(current_administrator, @job_application.state).where.not(id: requested_files.select(:job_application_file_type_id))
 
 .card.job-application-files
   .card-header.with-subheader.bg-white.font-weight-bold.text-secondary

--- a/app/views/admin/job_applications/files.html.haml
+++ b/app/views/admin/job_applications/files.html.haml
@@ -1,6 +1,3 @@
-- requested_files = @job_application.job_application_files
-- other_file_types = JobApplicationFileType.visible_by(current_administrator, @job_application.state).where.not(id: requested_files.select(:job_application_file_type_id))
-
 .card.job-application-files
   .card-header.with-subheader.bg-white.font-weight-bold.text-secondary
     = fa_icon('file-lines', class: 'text-secondary')
@@ -8,6 +5,7 @@
   .card-subheader.bg-card-bg.font-weight-bold.text-muted
     = t('.subtitle_1')
   .card-body.bg-white.files-list
+    - requested_files = @job_application.job_application_files
     - if requested_files.any?
       = render partial: "/admin/job_application_files/job_application_file", collection: requested_files
     - else
@@ -16,6 +14,7 @@
     = t('.subtitle_2')
   .card-body.bg-white.files-list
     %small.text-italic.d-block.mb-3= t('.note')
+    - other_file_types = requestable_file_types(@job_application, current_administrator)
     - if other_file_types.any?
       = render partial: "/admin/job_application_files/optional_job_application_file_type", collection: other_file_types, as: :job_application_file_type, locals: {job_application: @job_application}
     - else

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1192,7 +1192,6 @@ fr:
               cant_be_accepted_twice: 'Cette action n''est pas possible. Ce candidat est déjà à l''état "Retenu" dans une offre d''emploi.'
               dar_unvalidated: 'Une autorité d''emploi affiliée à l''offre doit cocher la case "DAR validée" pour permettre la poursuite du processus de recrutement.'
               immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
-              cant_skip_state: "Impossible passer à l’étape suivante sans la validation de l’étape précédente."
             cover_letter_content_type:
               invalid: "PDF uniquement, max 2Mo"
             resume_content_type:

--- a/spec/helpers/admin/job_applications_helper_spec.rb
+++ b/spec/helpers/admin/job_applications_helper_spec.rb
@@ -3,6 +3,42 @@
 require "rails_helper"
 
 RSpec.describe Admin::JobApplicationsHelper do
+  describe "#requestable_file_types" do
+    subject(:requestable_file_types) { helper.requestable_file_types(job_application, administrator) }
+
+    let(:job_application) { create(:job_application, state: :to_be_met) }
+    let!(:manager_file_type) do
+      create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+      end
+    end
+    let!(:employer_file_type) do
+      create(:job_application_file_type, kind: :employer_provided).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+      end
+    end
+
+    context "when administrator is not a hr_manager" do
+      let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
+
+      it { is_expected.to contain_exactly(manager_file_type, employer_file_type) }
+
+      context "when a file has already been requested" do
+        before { create(:job_application_file, job_application:, job_application_file_type: manager_file_type) }
+
+        it { is_expected.to contain_exactly(employer_file_type) }
+      end
+    end
+
+    context "when administrator is a hr_manager" do
+      let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+      it { is_expected.to contain_exactly(manager_file_type) }
+    end
+  end
+
   describe "#job_application_resume_url" do
     subject(:resume_url) { helper.job_application_resume_url(job_application) }
 

--- a/spec/helpers/admin/job_applications_helper_spec.rb
+++ b/spec/helpers/admin/job_applications_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::JobApplicationsHelper do
       end
     end
 
-    context "when administrator is not a hr_manager" do
+    context "when administrator is neither a hr_manager nor a payroll_manager" do
       let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
 
       it { is_expected.to contain_exactly(manager_file_type, employer_file_type) }
@@ -34,6 +34,12 @@ RSpec.describe Admin::JobApplicationsHelper do
 
     context "when administrator is a hr_manager" do
       let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+      it { is_expected.to contain_exactly(manager_file_type) }
+    end
+
+    context "when administrator is a payroll_manager" do
+      let(:administrator) { build(:administrator, roles: %w[payroll_manager]) }
 
       it { is_expected.to contain_exactly(manager_file_type) }
     end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -154,31 +154,51 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(jaft_not_notifiable) }
     end
 
-    describe "#visible_by_administrator" do
-      subject { described_class.visible_by_administrator(:to_be_met) }
+    describe "#visible_by" do
+      subject { described_class.visible_by(administrator, :to_be_met) }
 
       let!(:jaft_before) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
         end
       end
       let!(:jaft_exact) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
         end
       end
       let!(:jaft_after) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
         end
       end
+      let!(:jaft_non_manager) do
+        create(:job_application_file_type, kind: :employer_provided).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
+      end
 
-      it { is_expected.to include(jaft_before) }
-      it { is_expected.to include(jaft_exact) }
-      it { is_expected.not_to include(jaft_after) }
+      context "when administrator is not a hr_manager" do
+        let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.to include(jaft_non_manager) }
+      end
+
+      context "when administrator is a hr_manager" do
+        let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.not_to include(jaft_non_manager) }
+      end
     end
 
     describe "#required" do

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe JobApplicationFileType do
         end
       end
 
-      context "when administrator is not a hr_manager" do
+      context "when administrator is neither a hr_manager nor a payroll_manager" do
         let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
 
         it { is_expected.to include(jaft_before) }
@@ -199,6 +199,15 @@ RSpec.describe JobApplicationFileType do
 
       context "when administrator is a hr_manager" do
         let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.not_to include(jaft_non_manager) }
+      end
+
+      context "when administrator is a payroll_manager" do
+        let(:administrator) { build(:administrator, roles: %w[payroll_manager]) }
 
         it { is_expected.to include(jaft_before) }
         it { is_expected.to include(jaft_exact) }

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -160,31 +160,51 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(jaft_not_notifiable) }
     end
 
-    describe "#visible_by_administrator" do
-      subject { described_class.visible_by_administrator(:to_be_met) }
+    describe "#visible_by" do
+      subject { described_class.visible_by(administrator, :to_be_met) }
 
       let!(:jaft_before) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
         end
       end
       let!(:jaft_exact) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
         end
       end
       let!(:jaft_after) do
-        create(:job_application_file_type).tap do |jaft|
+        create(:job_application_file_type, kind: :manager_provided).tap do |jaft|
           jaft.visibility_rules.where(by: :administrator).destroy_all
           jaft.visibility_rules.create!(by: :administrator, state: :contract_drafting)
         end
       end
+      let!(:jaft_non_manager) do
+        create(:job_application_file_type, kind: :employer_provided).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :phone_meeting)
+        end
+      end
 
-      it { is_expected.to include(jaft_before) }
-      it { is_expected.to include(jaft_exact) }
-      it { is_expected.not_to include(jaft_after) }
+      context "when administrator is not a hr_manager" do
+        let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.to include(jaft_non_manager) }
+      end
+
+      context "when administrator is a hr_manager" do
+        let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.not_to include(jaft_non_manager) }
+      end
     end
 
     describe "#required" do


### PR DESCRIPTION
# Description

Grâce à la matrice des droits, la plupart des besoins décrits par les tickets sont déjà implémentés.

On ajoute ici l'élément suivant : lorsqu'un administrateur avec le rôle `hr_manager` consulte les fichiers d'une candidature, la section « Documents complémentaires » ne liste désormais que les types de fichiers dont `kind` est `manager_provided`. 

# Plan de test

- [ ] Se connecter en tant qu'administrateur `functional_administrator`, ouvrir l'onglet « Documents » d'une candidature : la section « Documents complémentaires » liste tous les types de fichiers visibles à l'état courant (hors ceux déjà demandés).
- [ ] Se connecter en tant qu'administrateur `hr_manager` sur la même candidature : seuls les types dont `kind = manager_provided` apparaissent dans « Documents complémentaires ».

# Review app

https://erecrutement-cvd-staging-pr2088.osc-fr1.scalingo.io

# Links

Closes #1957
Closes #2064

# Screenshots

<img width="1703" height="947" alt="CleanShot 2026-04-21 at 17 06 07" src="https://github.com/user-attachments/assets/773185bd-786f-4679-b0ee-d002b9ac2976" />

