### PR TITLE
Restrict requestable files to manager_provided for payroll_manager

### DIFF
--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -51,7 +51,7 @@ class JobApplicationFileType < ApplicationRecord
       .where(visibility_rules: {by: :administrator})
       .where("visibility_rules.state <= ?", JobApplication.states[state])
       .distinct
-    scope = scope.manager_provided if administrator.hr_manager?
+    scope = scope.manager_provided if administrator.hr_manager? || administrator.payroll_manager?
     scope
   }
 

--- a/spec/helpers/admin/job_applications_helper_spec.rb
+++ b/spec/helpers/admin/job_applications_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::JobApplicationsHelper do
       end
     end
 
-    context "when administrator is not a hr_manager" do
+    context "when administrator is neither a hr_manager nor a payroll_manager" do
       let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
 
       it { is_expected.to contain_exactly(manager_file_type, employer_file_type) }
@@ -34,6 +34,12 @@ RSpec.describe Admin::JobApplicationsHelper do
 
     context "when administrator is a hr_manager" do
       let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+      it { is_expected.to contain_exactly(manager_file_type) }
+    end
+
+    context "when administrator is a payroll_manager" do
+      let(:administrator) { build(:administrator, roles: %w[payroll_manager]) }
 
       it { is_expected.to contain_exactly(manager_file_type) }
     end

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe JobApplicationFileType do
         end
       end
 
-      context "when administrator is not a hr_manager" do
+      context "when administrator is neither a hr_manager nor a payroll_manager" do
         let(:administrator) { build(:administrator, roles: %w[functional_administrator]) }
 
         it { is_expected.to include(jaft_before) }
@@ -193,6 +193,15 @@ RSpec.describe JobApplicationFileType do
 
       context "when administrator is a hr_manager" do
         let(:administrator) { build(:administrator, roles: %w[hr_manager]) }
+
+        it { is_expected.to include(jaft_before) }
+        it { is_expected.to include(jaft_exact) }
+        it { is_expected.not_to include(jaft_after) }
+        it { is_expected.not_to include(jaft_non_manager) }
+      end
+
+      context "when administrator is a payroll_manager" do
+        let(:administrator) { build(:administrator, roles: %w[payroll_manager]) }
 
         it { is_expected.to include(jaft_before) }
         it { is_expected.to include(jaft_exact) }


### PR DESCRIPTION
# Description

Grâce à la matrice des droits, la plupart des besoins décrits par les tickets sont déjà implémentés.

On ajoute ici l'élément suivant : lorsqu'un administrateur avec le rôle `payroll_manager` consulte les fichiers d'une candidature, la section « Documents complémentaires » ne liste désormais que les types de fichiers dont `kind` est `manager_provided`.

# Plan de test

- [ ] Se connecter en tant qu'administrateur `functional_administrator`, ouvrir l'onglet « Documents » d'une candidature : la section « Documents complémentaires » liste tous les types de fichiers visibles à l'état courant (hors ceux déjà demandés).
- [ ] Se connecter en tant qu'administrateur `payroll_manager` sur la même candidature : seuls les types dont `kind = manager_provided` apparaissent dans « Documents complémentaires ».

# Review app

https://erecrutement-cvd-staging-pr2089.osc-fr1.scalingo.io

# Links

Closes #1958 
Closes #1959 

# Screenshots

<img width="1705" height="937" alt="CleanShot 2026-04-22 at 08 13 07" src="https://github.com/user-attachments/assets/0846661f-d3ae-45f0-9d42-93e3fcf45fd5" />

