### PR TITLE
Remove JobApplicationFile ability

### DIFF
--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -3,8 +3,9 @@
 class Admin::JobApplicationFilesController < Admin::BaseController
   include SendFileContent
 
+  skip_load_and_authorize_resource
   load_and_authorize_resource :job_application, except: :show
-  load_and_authorize_resource :job_application_file
+  load_resource :job_application_file
 
   def show
     if @job_application_file.document_content.blank?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,7 +40,6 @@ class Ability
     cannot :transfer, JobOffer, job_offer_actors: {administrator_id: administrator.id}
     can :transfer, JobOffer, owner_id: administrator.id
     can :manage, JobApplication, job_application_read_query(administrator)
-    can :manage, JobApplicationFile
     can :manage, Message
     can :manage, Email
     can :update, User, employer_users_query(administrator)
@@ -51,7 +50,6 @@ class Ability
   def ability_other_administrators(administrator)
     can :read, JobOffer, job_offer_actors: {administrator_id: administrator.id}
     can :manage, JobApplication, job_application_read_query(administrator)
-    can :manage, JobApplicationFile
     can :manage, Message
     can :manage, Email
   end


### PR DESCRIPTION


# Description

Permissions on files are now managed by validate_by_* booleans on JobApplicationFile model. We don't need this ability anymore.

# Review app

https://erecrutement-cvd-staging-pr2090.osc-fr1.scalingo.io

# Links

Closes #2086
