### PR TITLE
Job application withdrawal feature with email notification

### DIFF
--- a/app/controllers/account/withdrawals_controller.rb
+++ b/app/controllers/account/withdrawals_controller.rb
@@ -8,7 +8,7 @@ class Account::WithdrawalsController < Account::BaseController
   def create
     @job_application.reject!(rejection_reason:, from_user: true)
     respond_to do |format|
-      format.html { redirect_to account_job_application_path(@job_application), notice: t(".success") }
+      format.html { redirect_to job_offer_account_job_application_path(@job_application), notice: t(".success") }
     end
   end
 
@@ -18,6 +18,7 @@ class Account::WithdrawalsController < Account::BaseController
 
   def set_job_application
     @job_application = JobApplication.find(params[:job_application_id])
+    @job_offer = @job_application.job_offer
   end
 
   def already_affected_or_rejected?

--- a/app/controllers/account/withdrawals_controller.rb
+++ b/app/controllers/account/withdrawals_controller.rb
@@ -2,13 +2,10 @@
 
 class Account::WithdrawalsController < Account::BaseController
   skip_load_and_authorize_resource
+  before_action :set_job_application
+  before_action :redirect_to_job_application, if: :already_affected_or_rejected?
 
   def create
-    @job_application = JobApplication.find(params[:job_application_id])
-    if @job_application.affected? || @job_application.rejected?
-      return redirect_to account_job_application_path(@job_application), notice: t(".failure")
-    end
-
     @job_application.reject!(rejection_reason:)
     respond_to do |format|
       format.html { redirect_to account_job_application_path(@job_application), notice: t(".success") }
@@ -17,5 +14,17 @@ class Account::WithdrawalsController < Account::BaseController
 
   private
 
-  def rejection_reason = RejectionReason.find_by(name: "Désistement du/de la candidat.e")
+  def rejection_reason = RejectionReason.withdrawal_reason
+
+  def set_job_application
+    @job_application = JobApplication.find(params[:job_application_id])
+  end
+
+  def already_affected_or_rejected?
+    @job_application.affected? || @job_application.rejected?
+  end
+
+  def redirect_to_job_application
+    redirect_to account_job_application_path(@job_application), notice: t(".failure")
+  end
 end

--- a/app/controllers/account/withdrawals_controller.rb
+++ b/app/controllers/account/withdrawals_controller.rb
@@ -6,7 +6,7 @@ class Account::WithdrawalsController < Account::BaseController
   before_action :redirect_to_job_application, if: :already_affected_or_rejected?
 
   def create
-    @job_application.reject!(rejection_reason:)
+    @job_application.reject!(rejection_reason:, from_user: true)
     respond_to do |format|
       format.html { redirect_to account_job_application_path(@job_application), notice: t(".success") }
     end

--- a/app/controllers/account/withdrawals_controller.rb
+++ b/app/controllers/account/withdrawals_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Account::WithdrawalsController < Account::BaseController
+  skip_load_and_authorize_resource
+
+  def create
+    @job_application = JobApplication.find(params[:job_application_id])
+    if @job_application.affected? || @job_application.rejected?
+      return redirect_to account_job_application_path(@job_application), notice: t(".failure")
+    end
+
+    @job_application.reject!(rejection_reason:)
+    respond_to do |format|
+      format.html { redirect_to account_job_application_path(@job_application), notice: t(".success") }
+    end
+  end
+
+  private
+
+  def rejection_reason = RejectionReason.find_by(name: "Désistement du/de la candidat.e")
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -40,6 +40,9 @@ application.register("job-offer-term", JobOfferTermController)
 import LocationController from "./location_controller"
 application.register("location", LocationController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import PasswordRulesController from "./password_rules_controller"
 application.register("password-rules", PasswordRulesController)
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open() {
+    this.dialogTarget.showModal()
+    this.dialogTarget.classList.add("rf-modal--opened")
+  }
+
+  close() {
+    this.dialogTarget.classList.remove("rf-modal--opened")
+    this.dialogTarget.close()
+  }
+}

--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -112,6 +112,10 @@ class ApplicantNotificationsMailer < ApplicationMailer
     @job_offer = params[:job_offer]
     @service_name = @job_offer.organization.service_name
 
-    mail to: @user.email, subject: t(".subject")
+    mail to: @user.email, subject: t(
+      ".subject",
+      job_offer_title: @job_offer.title,
+      service_name: @service_name
+    )
   end
 end

--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -106,4 +106,12 @@ class ApplicantNotificationsMailer < ApplicationMailer
       service_name: @service_name
     )
   end
+
+  def notify_withdrawn
+    @user = params[:user]
+    @job_offer = params[:job_offer]
+    @service_name = @job_offer.organization.service_name
+
+    mail to: @user.email, subject: t(".subject")
+  end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -340,7 +340,7 @@ end
 #  experiences_fit_job_offer         :boolean
 #  files_count                       :integer          default(0)
 #  files_unread_count                :integer          default(0)
-#  preselection                      :integer          default(0)
+#  preselection                      :integer          default("pending")
 #  rejected                          :boolean          default(FALSE)
 #  skills_fit_job_offer              :boolean
 #  state                             :integer

--- a/app/models/job_application/rejectable.rb
+++ b/app/models/job_application/rejectable.rb
@@ -7,13 +7,24 @@ module JobApplication::Rejectable
     validate :missing_rejection_reason, if: -> { rejected && rejection_reason.blank? }
 
     before_save :cleanup_rejection_reason, unless: -> { rejected }
-    after_update :notify_applicant_rejected, if: -> { saved_change_to_rejected? && rejected }
 
     scope :rejecteds, -> { where(rejected: true) }
     scope :not_rejecteds, -> { where(rejected: false) }
   end
 
-  def reject!(rejection_reason:) = update!(rejected: true, rejection_reason:)
+  def reject!(rejection_reason:, from_user: false)
+    if from_user && rejection_reason != RejectionReason.withdrawal_reason
+      raise ArgumentError, "rejection_reason must be RejectionReason.withdrawal_reason when from_user is true"
+    end
+
+    update!(rejected: true, rejection_reason:)
+
+    if from_user
+      ApplicantNotificationsMailer.with(user:, job_offer:).notify_withdrawn.deliver_later
+    else
+      ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+    end
+  end
 
   def unreject! = update!(state: :initial, rejected: false, rejection_reason: nil)
 
@@ -22,12 +33,4 @@ module JobApplication::Rejectable
   def missing_rejection_reason = errors.add(:rejection_reason, :blank)
 
   def cleanup_rejection_reason = self.rejection_reason = nil
-
-  def notify_applicant_rejected
-    if rejection_reason == RejectionReason.withdrawal_reason
-      ApplicantNotificationsMailer.with(user:, job_offer:).notify_withdrawn.deliver_later
-    else
-      ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
-    end
-  end
 end

--- a/app/models/job_application/rejectable.rb
+++ b/app/models/job_application/rejectable.rb
@@ -24,6 +24,10 @@ module JobApplication::Rejectable
   def cleanup_rejection_reason = self.rejection_reason = nil
 
   def notify_applicant_rejected
-    ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+    if rejection_reason&.name == "Désistement du/de la candidat.e"
+      ApplicantNotificationsMailer.with(user:, job_offer:).notify_withdrawn.deliver_later
+    else
+      ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later
+    end
   end
 end

--- a/app/models/job_application/rejectable.rb
+++ b/app/models/job_application/rejectable.rb
@@ -24,7 +24,7 @@ module JobApplication::Rejectable
   def cleanup_rejection_reason = self.rejection_reason = nil
 
   def notify_applicant_rejected
-    if rejection_reason&.name == "Désistement du/de la candidat.e"
+    if rejection_reason == RejectionReason.withdrawal_reason
       ApplicantNotificationsMailer.with(user:, job_offer:).notify_withdrawn.deliver_later
     else
       ApplicantNotificationsMailer.with(user:, job_offer:).notify_rejected.deliver_later

--- a/app/models/rejection_reason.rb
+++ b/app/models/rejection_reason.rb
@@ -2,10 +2,15 @@
 
 # Reasons when rejecting a job application. Manageable by admins.
 class RejectionReason < ApplicationRecord
+  WITHDRAWAL_REASON = "Désistement du/de la candidat·e"
   acts_as_list
   default_scope -> { order(position: :asc) }
 
   validates :name, presence: true
+
+  def self.withdrawal_reason
+    find_by(name: WITHDRAWAL_REASON)
+  end
 end
 
 # == Schema Information

--- a/app/tasks/maintenance/add_withdrawal_rejection_reason_task.rb
+++ b/app/tasks/maintenance/add_withdrawal_rejection_reason_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class AddWithdrawalRejectionReasonTask < MaintenanceTasks::Task
+    no_collection
+
+    def process
+      RejectionReason.create!(name: "Désistement du/de la candidat.e")
+    end
+  end
+end

--- a/app/tasks/maintenance/add_withdrawal_rejection_reason_task.rb
+++ b/app/tasks/maintenance/add_withdrawal_rejection_reason_task.rb
@@ -5,7 +5,9 @@ module Maintenance
     no_collection
 
     def process
-      RejectionReason.create!(name: "Désistement du/de la candidat.e")
+      return if RejectionReason.withdrawal_reason
+
+      RejectionReason.create!(name: RejectionReason::WITHDRAWAL_REASON)
     end
   end
 end

--- a/app/views/account/job_applications/_job_application.html.haml
+++ b/app/views/account/job_applications/_job_application.html.haml
@@ -12,5 +12,8 @@
           %span= job_offer_contract_type_display(job_offer)
           %em= job_offer.location
         .d-flex.flex-column.justify-content-center.align-items-center.text-center.ml-auto
-          %span= "Étape #{job_application.end_user_state_number}/#{JobApplication.end_user_states_regrouping.size}"
-          %em= JobApplication.human_attribute_name("state/#{job_application.end_user_state}")
+          - if job_application.rejected?
+            %span= "Refus ou désistement"
+          - else
+            %span= "Étape #{job_application.end_user_state_number}/#{JobApplication.end_user_states_regrouping.size}"
+            %em= JobApplication.human_attribute_name("state/#{job_application.end_user_state}")

--- a/app/views/account/job_applications/job_offer.html.haml
+++ b/app/views/account/job_applications/job_offer.html.haml
@@ -1,1 +1,18 @@
 = render partial: '/job_offers/job_offer_content', locals: {job_offer: @job_offer}
+- unless @job_application.affected? || @job_application.rejected?
+  .rf-input-group.rf-grid-row.justify-content-center.rf-mt-3w
+    %button.btn.rf-btn{aria: {controls: "withdraw-modal"}, data: {rf_opened: ""}}
+      = t('account.job_applications.job_offer.withdraw')
+  %dialog#withdraw-modal.rf-modal{aria: {labelledby: "withdraw-modal-title"}, role: :dialog}
+    .rf-container.rf-container--fluid.rf-grid-row.rf-grid-row--center
+      .rf-col-12.rf-col-md-8.rf-col-lg-6
+        .rf-modal__body
+          .rf-modal__header
+            %button.rf-link.rf-fi-close-line.rf-link--close{aria: {controls: "withdraw-modal"}, title: t('account.job_applications.job_offer.cancel')}
+              = t('account.job_applications.job_offer.cancel')
+          .rf-modal__content.text-center
+            %p#withdraw-modal-title= t('account.job_applications.job_offer.withdraw_confirmation')
+          .rf-modal__footer.justify-content-center
+            = button_to t('account.job_applications.job_offer.confirm'), account_job_application_withdrawal_path(@job_application), class: "btn rf-btn rf-mr-6w"
+            %button.btn.rf-btn.rf-btn--secondary{aria: {controls: "withdraw-modal"}}
+              = t('account.job_applications.job_offer.cancel')

--- a/app/views/account/job_applications/job_offer.html.haml
+++ b/app/views/account/job_applications/job_offer.html.haml
@@ -1,18 +1,18 @@
 = render partial: '/job_offers/job_offer_content', locals: {job_offer: @job_offer}
 - unless @job_application.affected? || @job_application.rejected?
-  .rf-input-group.rf-grid-row.justify-content-center.rf-mt-3w
-    %button.btn.rf-btn{aria: {controls: "withdraw-modal"}, data: {rf_opened: ""}}
+  .rf-input-group.rf-grid-row.justify-content-center.rf-mt-3w{data: {controller: "modal"}}
+    %button.btn.rf-btn{data: {action: "modal#open"}}
       = t('account.job_applications.job_offer.withdraw')
-  %dialog#withdraw-modal.rf-modal{aria: {labelledby: "withdraw-modal-title"}, role: :dialog}
-    .rf-container.rf-container--fluid.rf-grid-row.rf-grid-row--center
-      .rf-col-12.rf-col-md-8.rf-col-lg-6
-        .rf-modal__body
-          .rf-modal__header
-            %button.rf-link.rf-fi-close-line.rf-link--close{aria: {controls: "withdraw-modal"}, title: t('account.job_applications.job_offer.cancel')}
-              = t('account.job_applications.job_offer.cancel')
-          .rf-modal__content.text-center
-            %p#withdraw-modal-title= t('account.job_applications.job_offer.withdraw_confirmation')
-          .rf-modal__footer.justify-content-center
-            = button_to t('account.job_applications.job_offer.confirm'), account_job_application_withdrawal_path(@job_application), class: "btn rf-btn rf-mr-6w"
-            %button.btn.rf-btn.rf-btn--secondary{aria: {controls: "withdraw-modal"}}
-              = t('account.job_applications.job_offer.cancel')
+    %dialog.rf-modal{"data-modal-target" => "dialog", aria: {labelledby: "withdraw-modal-title"}, role: :dialog}
+      .rf-container.rf-container--fluid.rf-grid-row.rf-grid-row--center
+        .rf-col-12.rf-col-md-8.rf-col-lg-6
+          .rf-modal__body
+            .rf-modal__header
+              %button.rf-link.rf-fi-close-line.rf-link--close{data: {action: "modal#close"}, title: t('account.job_applications.job_offer.cancel')}
+                = t('account.job_applications.job_offer.cancel')
+            .rf-modal__content.text-center
+              %p#withdraw-modal-title= t('account.job_applications.job_offer.withdraw_confirmation')
+            .rf-modal__footer.justify-content-center
+              = button_to t('account.job_applications.job_offer.confirm'), account_job_application_withdrawal_path(@job_application), class: "btn rf-btn rf-mr-6w", data: {turbo: false}
+              %button.btn.rf-btn.rf-btn--secondary{data: {action: "modal#close"}}
+                = t('account.job_applications.job_offer.cancel')

--- a/app/views/applicant_notifications_mailer/notify_withdrawn.html.erb
+++ b/app/views/applicant_notifications_mailer/notify_withdrawn.html.erb
@@ -1,0 +1,19 @@
+<p>
+  Bonjour <%= @user.full_name %>,
+</p>
+
+<p>
+  Le désistement suite à votre candidature à l’offre "<%= @job_offer.title %>" a bien été pris en compte.
+</p>
+
+<p>
+  Votre profil candidat reste disponible dans notre vivier de candidature : n’oubliez pas de le mettre à jour régulièrement.
+</p>
+
+<p>
+  Cordialement,
+</p>
+
+<p>
+  L'équipe <%= @service_name %>
+</p>

--- a/app/views/layouts/account/job_application_display.html.haml
+++ b/app/views/layouts/account/job_application_display.html.haml
@@ -12,7 +12,7 @@
         = render partial: '/account/job_applications/state_stepper', locals: {job_application: @job_application}
     .rf-grid-row.rf-mt-3w
       .rf-tabs.w-100{data: {controller: 'rf-tab-management'}}
-        %ul.rf-tabs__list{"aria-label" => "[Candidature]", role: "tablist"}
+        %ul.rf-tabs__list{"aria-label" => "[Candidature]", role: "tablist", 'data-rf-tab-management-target' => 'tablist'}
           %li{role: "presentation"}
             - emails_tab = controller.controller_name == 'job_applications' && controller.action_name  == 'show'
             = link_to [:account, @job_application], class: 'rf-tabs__tab', aria: {controls: 'tabpanel-emails', selected: emails_tab}, role: 'tab', tabindex: emails_tab ? 0 : -1, title: t('.nav_emails') do

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -183,7 +183,7 @@ fr:
     notify_rejected:
       subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name}"
     notify_withdrawn:
-      subject: "Confirmation de votre désistement"
+      subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name} – Confirmation de votre désistement"
   notifications_mailer:
     new_email:
       subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -182,6 +182,8 @@ fr:
       subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name} – Nouveaux documents à consulter"
     notify_rejected:
       subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name}"
+    notify_withdrawn:
+      subject: "Confirmation de votre désistement"
   notifications_mailer:
     new_email:
       subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -242,6 +242,11 @@ fr:
         ongoing_none: "Aucune candidature en cours"
       job_application:
         created_at: "Candidaté il y a %{time_ago_in_words}"
+      job_offer:
+        withdraw: "Retirer ma candidature"
+        withdraw_confirmation: "Souhaitez-vous retirer votre candidature ?"
+        confirm: "Confirmer"
+        cancel: "Annuler"
     emails:
       create:
         success: "Courriel envoyé !"
@@ -282,6 +287,10 @@ fr:
       want_destroy:
         title: "Danger"
         destroy: "Je veux supprimer mon compte"
+    withdrawals:
+        create:
+          success: "Désistement enregistré"
+          failure: "Impossible de modifier cette candidature"
   admin:
     accounts:
       show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,7 @@ Rails.application.routes.draw do
             get :attachment
           end
         end
+        resource :withdrawal, path: "desistement", only: :create
       end
       resource :user, path: "mon-compte", only: %i[show destroy] do
         collection do

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -37,7 +37,7 @@ end
 #  experiences_fit_job_offer         :boolean
 #  files_count                       :integer          default(0)
 #  files_unread_count                :integer          default(0)
-#  preselection                      :integer          default(0)
+#  preselection                      :integer          default("pending")
 #  rejected                          :boolean          default(FALSE)
 #  skills_fit_job_offer              :boolean
 #  state                             :integer

--- a/spec/mailers/previews/applicant_notifications_preview.rb
+++ b/spec/mailers/previews/applicant_notifications_preview.rb
@@ -29,4 +29,11 @@ class ApplicantNotificationsPreview < ActionMailer::Preview
       job_offer: JobOffer.first
     ).notify_rejected
   end
+
+  def notify_withdrawn
+    ApplicantNotificationsMailer.with(
+      user: User.first,
+      job_offer: JobOffer.first
+    ).notify_withdrawn
+  end
 end

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe JobApplication::Rejectable do
 
       context "when rejection reason is a withdrawal" do
         subject(:rejection) do
-          withdrawal_reason = create(:rejection_reason, name: "Désistement du/de la candidat.e")
+          withdrawal_reason = create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON)
           job_application.update!(rejected: true, rejection_reason: withdrawal_reason)
         end
 

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -96,11 +96,24 @@ RSpec.describe JobApplication::Rejectable do
 
   describe "after_update callbacks" do
     describe "#notify_applicant_rejected" do
-      subject(:rejection) { job_application.update!(rejected: true, rejection_reason: create(:rejection_reason)) }
-
       let(:job_application) { create(:job_application) }
 
-      it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
+      context "when rejection reason is a withdrawal" do
+        subject(:rejection) do
+          withdrawal_reason = create(:rejection_reason, name: "Désistement du/de la candidat.e")
+          job_application.update!(rejected: true, rejection_reason: withdrawal_reason)
+        end
+
+        it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn) }
+        it { expect { rejection }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
+      end
+
+      context "when rejection reason is not a withdrawal" do
+        subject(:rejection) { job_application.update!(rejected: true, rejection_reason: create(:rejection_reason)) }
+
+        it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
+        it { expect { rejection }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn) }
+      end
     end
   end
 

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -94,29 +94,6 @@ RSpec.describe JobApplication::Rejectable do
     end
   end
 
-  describe "after_update callbacks" do
-    describe "#notify_applicant_rejected" do
-      let(:job_application) { create(:job_application) }
-
-      context "when rejection reason is a withdrawal" do
-        subject(:rejection) do
-          withdrawal_reason = create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON)
-          job_application.update!(rejected: true, rejection_reason: withdrawal_reason)
-        end
-
-        it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn) }
-        it { expect { rejection }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
-      end
-
-      context "when rejection reason is not a withdrawal" do
-        subject(:rejection) { job_application.update!(rejected: true, rejection_reason: create(:rejection_reason)) }
-
-        it { expect { rejection }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected) }
-        it { expect { rejection }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn) }
-      end
-    end
-  end
-
   describe "#unreject!" do
     subject(:unreject) { job_application.unreject! }
 
@@ -130,13 +107,50 @@ RSpec.describe JobApplication::Rejectable do
   end
 
   describe "#reject!" do
-    subject(:reject) { job_application.reject!(rejection_reason:) }
-
     let(:rejection_reason) { create(:rejection_reason) }
     let(:job_application) { create(:job_application) }
 
-    it { expect { reject }.to change(job_application, :rejected).to(true) }
+    it "updates job application to rejected" do
+      expect { job_application.reject!(rejection_reason:) }.to change(job_application, :rejected).to(true)
+    end
 
-    it { expect { reject }.to change(job_application, :rejection_reason).to(rejection_reason) }
+    it "adds a rejection reason to job application" do
+      job_application.reject!(rejection_reason:)
+      expect(job_application.rejection_reason).to eq(rejection_reason)
+    end
+
+    context "when rejection is from user (withdrawal)" do
+      let(:rejection_reason) { create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON) }
+
+      subject(:reject) { job_application.reject!(rejection_reason:, from_user: true) }
+
+      it "enqueues the notify_withdraw mailer" do
+        expect { reject }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn)
+      end
+
+      it "does not enqueue notify_reject mailer" do
+        expect { reject }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected)
+      end
+
+      context "when rejection_reason is not the withdrawal reason" do
+        let(:rejection_reason) { create(:rejection_reason) }
+
+        it "raises an ArgumentError" do
+          expect { reject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context "when rejection is not from user (employer rejection)" do
+      subject(:reject) { job_application.reject!(rejection_reason:) }
+
+      it "enqueues the notify_reject mailer" do
+        expect { reject }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected)
+      end
+
+      it "does not enqueue notify_withdrawn mailer" do
+        expect { reject }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn)
+      end
+    end
   end
 end

--- a/spec/models/job_application/rejectable_spec.rb
+++ b/spec/models/job_application/rejectable_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe JobApplication::Rejectable do
     end
 
     context "when rejection is from user (withdrawal)" do
-      let(:rejection_reason) { create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON) }
-
       subject(:reject) { job_application.reject!(rejection_reason:, from_user: true) }
+
+      let(:rejection_reason) { create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON) }
 
       it "enqueues the notify_withdraw mailer" do
         expect { reject }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn)

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -177,7 +177,7 @@ end
 #  experiences_fit_job_offer         :boolean
 #  files_count                       :integer          default(0)
 #  files_unread_count                :integer          default(0)
-#  preselection                      :integer          default(0)
+#  preselection                      :integer          default("pending")
 #  rejected                          :boolean          default(FALSE)
 #  skills_fit_job_offer              :boolean
 #  state                             :integer

--- a/spec/requests/account/withdrawals_spec.rb
+++ b/spec/requests/account/withdrawals_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe "Account::Withdrawals" do
         withdrawal_request
         expect(response).to redirect_to(account_job_application_path(job_application))
       end
+
+      it "enqueues a notify_withdrawn email" do
+        expect { withdrawal_request }.to have_enqueued_mail(ApplicantNotificationsMailer, :notify_withdrawn)
+      end
+
+      it "does not enqueue a notify_rejected email" do
+        expect { withdrawal_request }.not_to have_enqueued_mail(ApplicantNotificationsMailer, :notify_rejected)
+      end
     end
   end
 end

--- a/spec/requests/account/withdrawals_spec.rb
+++ b/spec/requests/account/withdrawals_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Account::Withdrawals" do
+  describe "POST /mon-compte/candidatures/:job_application_id/desistement" do
+    let(:user) { create(:confirmed_user) }
+
+    before { sign_in user }
+
+    context "when job application is rejected" do
+      subject(:withdrawal_request) { post account_job_application_withdrawal_path(rejected_application) }
+
+      let(:rejected_application) { create(:job_application, :rejected, user: user) }
+
+      it "does not change job application state" do
+        expect { withdrawal_request }.not_to change { rejected_application.reload.rejected }
+      end
+
+      it "returns an error message" do
+        withdrawal_request
+        expect(flash[:notice]).to eq(I18n.t("account.withdrawals.create.failure"))
+      end
+
+      it "redirects to job application page" do
+        withdrawal_request
+        expect(response).to redirect_to(account_job_application_path(rejected_application))
+      end
+    end
+
+    context "when job application is affected" do
+      subject(:withdrawal_request) { post account_job_application_withdrawal_path(affected_application) }
+
+      let(:affected_application) { create(:job_application, state: :affected, user: user) }
+
+      it "does not change job application state" do
+        expect { withdrawal_request }.not_to change { affected_application.reload.state }
+      end
+
+      it "returns an error message" do
+        withdrawal_request
+        expect(flash[:notice]).to eq(I18n.t("account.withdrawals.create.failure"))
+      end
+
+      it "redirects to job application page" do
+        withdrawal_request
+        expect(response).to redirect_to(account_job_application_path(affected_application))
+      end
+    end
+
+    context "when the job application is not rejected or affected" do
+      subject(:withdrawal_request) { post account_job_application_withdrawal_path(job_application) }
+
+      let!(:rejection_reason) { create(:rejection_reason, name: "Désistement du/de la candidat.e") }
+      let(:job_application) { create(:job_application, user: user) }
+
+      it "updates the job_application state to rejected" do
+        expect { withdrawal_request }.to change { job_application.reload.rejected }.from(false).to(true)
+      end
+
+      it "adds the right rejection_reason_id" do
+        withdrawal_request
+        expect(job_application.reload.rejection_reason).to eq(rejection_reason)
+      end
+
+      it "displays a success message" do
+        withdrawal_request
+        expect(flash[:notice]).to eq(I18n.t("account.withdrawals.create.success"))
+      end
+
+      it "redirects to job application page" do
+        withdrawal_request
+        expect(response).to redirect_to(account_job_application_path(job_application))
+      end
+    end
+  end
+end

--- a/spec/requests/account/withdrawals_spec.rb
+++ b/spec/requests/account/withdrawals_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Account::Withdrawals" do
     context "when the job application is not rejected or affected" do
       subject(:withdrawal_request) { post account_job_application_withdrawal_path(job_application) }
 
-      let!(:rejection_reason) { create(:rejection_reason, name: "Désistement du/de la candidat.e") }
+      let!(:rejection_reason) { create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON) }
       let(:job_application) { create(:job_application, user: user) }
 
       it "updates the job_application state to rejected" do

--- a/spec/requests/account/withdrawals_spec.rb
+++ b/spec/requests/account/withdrawals_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Account::Withdrawals" do
 
       it "redirects to job application page" do
         withdrawal_request
-        expect(response).to redirect_to(account_job_application_path(job_application))
+        expect(response).to redirect_to(job_offer_account_job_application_path(job_application))
       end
 
       it "enqueues a notify_withdrawn email" do

--- a/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
+++ b/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
@@ -6,16 +6,25 @@ module Maintenance
   RSpec.describe AddWithdrawalRejectionReasonTask do
     describe "#process" do
       subject(:process) { described_class.process() }
-      
-      it "creates a RejectionReason" do
-        expect { process }.to change(RejectionReason, :count).by 1
+
+      context "when the withdrawal rejection reason does not exist" do
+        it "creates a RejectionReason" do
+          expect { process }.to change(RejectionReason, :count).by(1)
+        end
+
+        it "gives the right name to the RejectionReason" do
+          RejectionReason.delete_all
+          process
+          expect(RejectionReason.last.name).to eq(RejectionReason::WITHDRAWAL_REASON)
+        end
       end
 
-      it "gives the right name to the RejectionReason" do
-        RejectionReason.delete_all
-        process
+      context "when the withdrawal rejection reason already exists" do
+        before { create(:rejection_reason, name: RejectionReason::WITHDRAWAL_REASON) }
 
-        expect(RejectionReason.last.name).to eq("Désistement du/de la candidat.e")
+        it "does not create a duplicate" do
+          expect { process }.not_to change(RejectionReason, :count)
+        end
       end
     end
   end

--- a/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
+++ b/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe AddWithdrawalRejectionReasonTask do
+    describe "#process" do
+      subject(:process) { described_class.process() }
+      
+      it "creates a RejectionReason" do
+        expect { process }.to change(RejectionReason, :count).by 1
+      end
+
+      it "gives the right name to the RejectionReason" do
+        RejectionReason.delete_all
+        process
+
+        expect(RejectionReason.last.name).to eq("Désistement du/de la candidat.e")
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
+++ b/spec/tasks/maintenance/add_withdrawal_rejection_reason_task_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Maintenance
   RSpec.describe AddWithdrawalRejectionReasonTask do
     describe "#process" do
-      subject(:process) { described_class.process() }
+      subject(:process) { described_class.process }
 
       context "when the withdrawal rejection reason does not exist" do
         it "creates a RejectionReason" do


### PR DESCRIPTION
# Description
Les candidats peuvent désormais se désister d'une candidature. Ils recevront un e-mail automatique suite à ce désistement. 

# Plan de test
Se connecter en tant que candidat. Aller sur une candidature en cours puis l'onglet L'offre. Cliquer sur "Retirer ma candidature". 
Se connecter en tant qu'employeur et vérifier que cette candidature a été placé en colonne "Refusée" dans le tableau "trello". 

# Review app

https://erecrutement-cvd-staging-pr2092.osc-fr1.scalingo.io

# Links

Closes #1949
Closes #1951 
Closes #2080 


