### PR TITLE
Fix files visibility for user

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -41,16 +41,38 @@ module UsersHelper
     asset_path("default_user_avatar.svg")
   end
 
-  def hint_text_for_file(job_application, job_application_file)
-    link = [:account, job_application, job_application_file, {format: :pdf}]
-    fichier_text = link_to("fichier", link, target: "_blank", class: "text-dark-gray", rel: "noopener")
-    if job_application_file.is_validated == 1
-      "<span class=\"valid-text\">Ce #{fichier_text} a été validé !</span>".html_safe # rubocop:disable Rails/OutputSafety
-    elsif job_application_file.is_validated == 2
-      "<span class=\"error-text\">Votre #{fichier_text} n'est pas valide, veuillez en téléverser un nouveau.</span>".html_safe # rubocop:disable Rails/OutputSafety
-    elsif job_application_file.document_content.present?
-      "<span class=\"font-weight-bold\">Vous avez déjà téléversé ce #{fichier_text}</span>, il est en attente de validation.<br/>Pour téléverser une nouvelle version,
-              vous pouvez utiliser la zone ci-dessous.".html_safe # rubocop:disable Rails/OutputSafety
+  def file_hint(job_application_file)
+    if job_application_file.job_application_file_type.applicant_provided?
+      applicant_kind_file_hint(job_application_file, file_link(job_application_file))
+    else
+      not_applicant_kind_file_hint(file_link(job_application_file))
     end
+  end
+
+  private
+
+  def applicant_kind_file_hint(job_application_file, link)
+    if job_application_file.is_validated == 1
+      "<span class=\"valid-text\">Ce #{link} a été validé !</span>".html_safe # rubocop:disable Rails/OutputSafety
+    elsif job_application_file.is_validated == 2
+      "<span class=\"error-text\">Votre #{link} n'est pas valide, veuillez en téléverser un nouveau.</span>".html_safe # rubocop:disable Rails/OutputSafety
+    elsif job_application_file.document_content.present?
+      "<span class=\"font-weight-bold\">Vous avez déjà téléversé ce #{link}</span>, il est en attente de validation.
+      <br/>Pour téléverser une nouvelle version, vous pouvez utiliser la zone ci-dessous.".html_safe # rubocop:disable Rails/OutputSafety
+    end
+  end
+
+  def not_applicant_kind_file_hint(link)
+    "<span class=\"font-weight-bold\">Ce #{link}</span> a été téléversé par un tiers.".html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def file_link(job_application_file)
+    link_to(
+      "fichier",
+      [:account, job_application_file.job_application, job_application_file, {format: :pdf}],
+      target: "_blank",
+      class: "text-dark-gray",
+      rel: "noopener"
+    )
   end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -160,6 +160,16 @@ class JobApplication < ApplicationRecord
     "end_user_state_#{end_user_state_number}"
   end
 
+  def file_types_for_user
+    uploaded_types = job_application_files.select { |f| f.document_content.present? }.map(&:job_application_file_type)
+    (JobApplicationFileType.visible_by_user(state) + uploaded_types).uniq
+  end
+
+  def file_for(type)
+    job_application_files.find { |f| f.job_application_file_type == type } ||
+      job_application_files.build(job_application_file_type: type)
+  end
+
   counter_culture :job_offer,
     column_name: proc { |model| "#{model.state}_job_applications_count" },
     column_names: aasm.states.each_with_object({}) { |obj, memo|

--- a/app/views/account/job_application_files/_file_name_upload.html.haml
+++ b/app/views/account/job_application_files/_file_name_upload.html.haml
@@ -1,19 +1,23 @@
 - file_type = job_application_file.job_application_file_type
-- is_validated_value = job_application_file.is_validated
-- hint_text = hint_text_for_file(job_application, job_application_file)
-- klasses = ["is-validated-#{ is_validated_value }"]
-- html = { id: "job_application_file_#{file_type.name.parameterize}", class: klasses, "data-file-drop-target" => "form", "data-controller" => "file-drop" }
-- options = { html: html, namespace: file_type.name.parameterize }
-= turbo_frame_tag dom_id(job_application_file.job_application_file_type) do
+
+- if file_type.applicant_provided?
+  - is_validated_value = job_application_file.is_validated
+  - klasses = ["is-validated-#{ is_validated_value }"]
+  - html = { id: "job_application_file_#{file_type.name.parameterize}", class: klasses, "data-file-drop-target" => "form", "data-controller" => "file-drop" }
+  - options = { html: html, namespace: file_type.name.parameterize }
+  = turbo_frame_tag dom_id(job_application_file.job_application_file_type) do
+    %h3= file_type.name
+    .rf-mb-1w= file_hint(job_application_file)
+    - data = { action: "dragenter->file-drop#highlight dragover->file-drop#highlight dragleave->file-drop#unhighlight drop->file-drop#unhighlight drop->file-drop#setFile" }
+    = simple_form_for([:account, job_application, job_application_file], options) do |f|
+      %label
+        .rf-card.rf-card--no-arrow.rf-card--no-full-height.rf-mb-3w.hidden-file-input{ data: data }
+          .rf-card__body
+            - if job_application_file.new_record?
+              = f.hidden_field :job_application_file_type_id
+            - data = { controller: "auto-submit", action: "change->auto-submit#submit", "file-drop-target" => "input" }
+            %span= t('buttons.choose_file_drop_zone_html')
+            = f.input :content, label: false, hint: "Seuls les fichiers PDF de taille inférieure à 2Mo sont acceptés.", input_html: { data: data }
+- else
   %h3= file_type.name
-  .rf-mb-1w= hint_text
-  - data = { action: "dragenter->file-drop#highlight dragover->file-drop#highlight dragleave->file-drop#unhighlight drop->file-drop#unhighlight drop->file-drop#setFile" }
-  = simple_form_for([:account, job_application, job_application_file], options) do |f|
-    %label
-      .rf-card.rf-card--no-arrow.rf-card--no-full-height.rf-mb-3w.hidden-file-input{ data: data }
-        .rf-card__body
-          - if job_application_file.new_record?
-            = f.hidden_field :job_application_file_type_id
-          - data = { controller: "auto-submit", action: "change->auto-submit#submit", "file-drop-target" => "input" }
-          %span= t('buttons.choose_file_drop_zone_html')
-          = f.input :content, label: false, hint: "Seuls les fichiers PDF de taille inférieure à 2Mo sont acceptés.", input_html: { data: data }
+  .rf-mb-1w.rf-mb-3w= file_hint(job_application_file)

--- a/app/views/account/job_application_files/index.html.haml
+++ b/app/views/account/job_application_files/index.html.haml
@@ -1,5 +1,2 @@
-- job_application_files = @job_application.job_application_files.to_a
-- JobApplicationFileType.visible_by_user(@job_application.state).each do |job_application_file_type|
-  - job_application_file = job_application_files.detect { |x| x.job_application_file_type == job_application_file_type }
-  - job_application_file ||= @job_application.job_application_files.build(job_application_file_type: job_application_file_type)
-  = render partial: 'file_name_upload', locals: {job_application_file: job_application_file, job_application: @job_application}
+- @job_application.file_types_for_user.each do |type|
+  = render partial: 'file_name_upload', locals: {job_application_file: @job_application.file_for(type), job_application: @job_application}

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsersHelper do
+  describe "#file_hint" do
+    subject(:hint) { helper.file_hint(job_application_file) }
+
+    let(:job_application) { create(:job_application) }
+    let(:job_application_file_type) { create(:job_application_file_type, kind:) }
+    let(:job_application_file) do
+      create(:job_application_file, job_application:, job_application_file_type:, is_validated:)
+    end
+
+    context "when the file type is applicant_provided" do
+      let(:kind) { :applicant_provided }
+
+      context "when the file is validated" do
+        let(:is_validated) { 1 }
+
+        it { is_expected.to include("a été validé") }
+        it { is_expected.to include("valid-text") }
+      end
+
+      context "when the file is invalidated" do
+        let(:is_validated) { 2 }
+
+        it { is_expected.to include("n'est pas valide") }
+        it { is_expected.to include("error-text") }
+      end
+
+      context "when the file is pending validation and has uploaded content" do
+        let(:is_validated) { 0 }
+
+        it { is_expected.to include("Vous avez déjà téléversé") }
+        it { is_expected.to include("en attente de validation") }
+      end
+
+      context "when the file is pending validation but has no uploaded content" do
+        let(:is_validated) { 0 }
+        let(:job_application_file) do
+          create(
+            :job_application_file,
+            job_application:,
+            job_application_file_type:,
+            content: nil,
+            do_not_provide_immediately: true
+          )
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context "when the file type is not applicant_provided" do
+      let(:kind) { :employer_provided }
+      let(:is_validated) { 0 }
+
+      it { is_expected.to include("a été téléversé par un tiers") }
+    end
+  end
+end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -98,6 +98,79 @@ RSpec.describe JobApplication do
     end
   end
 
+  describe "#file_types_for_user" do
+    subject(:file_types_for_user) { job_application.file_types_for_user }
+
+    let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
+    let!(:visible_type) do
+      create(:job_application_file_type).tap do |jaft|
+        jaft.visibility_rules.where(by: :user).destroy_all
+        jaft.visibility_rules.create!(by: :user, state: :phone_meeting)
+      end
+    end
+    let!(:hidden_type) do
+      create(:job_application_file_type).tap do |jaft|
+        jaft.visibility_rules.where(by: :user).destroy_all
+        jaft.visibility_rules.create!(by: :user, state: :financial_estimate)
+      end
+    end
+    let!(:already_uploaded_hidden_type) do
+      create(:job_application_file_type).tap do |jaft|
+        jaft.visibility_rules.where(by: :user).destroy_all
+        jaft.visibility_rules.create!(by: :user, state: :financial_estimate)
+      end
+    end
+
+    before do
+      create(:job_application_file, job_application:, job_application_file_type: already_uploaded_hidden_type)
+      job_application.reload
+    end
+
+    it { is_expected.to include(visible_type) }
+
+    it { is_expected.to include(already_uploaded_hidden_type) }
+
+    it { is_expected.not_to include(hidden_type) }
+
+    it "returns each type only once" do
+      create(:job_application_file, job_application:, job_application_file_type: visible_type)
+      job_application.reload
+      expect(file_types_for_user.count(visible_type)).to eq(1)
+    end
+
+    it "ignores placeholder files without uploaded content" do
+      empty_type = create(:job_application_file_type).tap do |jaft|
+        jaft.visibility_rules.where(by: :user).destroy_all
+        jaft.visibility_rules.create!(by: :user, state: :financial_estimate)
+      end
+      create(:job_application_file, job_application:, job_application_file_type: empty_type, content: nil, do_not_provide_immediately: true)
+      job_application.reload
+      expect(file_types_for_user).not_to include(empty_type)
+    end
+  end
+
+  describe "#file_for" do
+    subject(:file_for) { job_application.file_for(type) }
+
+    let(:job_application) { create(:job_application) }
+    let(:type) { create(:job_application_file_type) }
+
+    context "when a file already exists for the type" do
+      let!(:existing_file) { create(:job_application_file, job_application:, job_application_file_type: type) }
+
+      before { job_application.reload }
+
+      it { is_expected.to eq(existing_file) }
+    end
+
+    context "when no file exists for the type" do
+      it "builds a new unsaved file with the given type" do
+        expect(file_for).to be_new_record
+        expect(file_for.job_application_file_type).to eq(type)
+      end
+    end
+  end
+
   describe "#create_required_job_application_files" do
     let(:job_application) { create(:job_application, job_offer:, state: :phone_meeting) }
     let!(:required_file_type) do


### PR DESCRIPTION
# Description

On corrige le bug décrit dans le ticket : 

> Lors de l’ajout d’un document côté BO (par un gestionnaire / employeur / autorité d’emploi), le fichier n’est pas visible côté Front Office (FO) pour le candidat.

En fait ce n'est pas tout à fait un bug mais un cas non prévu, donc une évolution. En effet, pour rester fonctionnellement cohérent, on réalise les deux modifications suivantes : 
- on affiche les fichiers visibles pour le candidat, plus ceux qui ont été ajoutés en back office
- on ne permet pas au candidat de modifier ces derniers

# Test plan

Étapes pour reproduire

Se connecter en BO
Aller dans Paramètres > Types de fichiers
Créer ou modifier un type de fichier :
Type : fourni par le gestionnaire / employeur / autorité d’emploi
Cocher des étapes dans :
Étapes où le fichier est accessible et visible en BO
Étapes où le fichier est accessible et visible en FO
Enregistrer
Créer une candidature (ou utiliser une candidature existante)
Ajouter un document sur la candidature via ce type de fichier
Se connecter en candidat (FO)
Accéder à la candidature > Mes documents

**=> le candidat peut consulter les documents déposés par les acteurs BO**

# Review app

https://erecrutement-cvd-staging-pr2096.osc-fr1.scalingo.io

# Links

Closes #2093

# Screenshots

<img width="1704" height="1309" alt="CleanShot 2026-04-29 at 08 53 35" src="https://github.com/user-attachments/assets/ad45b4d9-49e0-48af-938a-edbc7b3c3413" />

