### PR TITLE
Fix export job offer

### DIFF
--- a/lib/services/exporter/stat_job_applications.rb
+++ b/lib/services/exporter/stat_job_applications.rb
@@ -8,6 +8,7 @@ class Exporter::StatJobApplications < Exporter::Base
     )
     fill_filters
     fill_filling
+    fill_rejection
     fill_application
     fill_state_duration
   end
@@ -59,6 +60,24 @@ class Exporter::StatJobApplications < Exporter::Base
       I18n.t("#{i18n_key}.title_job_applications_affected_number_html"),
       stat_data[:per_state].values_at("affected").compact.sum
     )
+  end
+
+  def fill_rejection
+    add_row("Statistiques des candidats refusés")
+
+    total = stat_data[:per_rejection_reason].values.sum
+    add_row(
+      "",
+      I18n.t("#{i18n_key}.title_job_applications_all_rejected_number_html"),
+      total
+    )
+
+    add_row("", "Motif des refus")
+    stat_data[:per_rejection_reason].each do |k, v|
+      txt = stat_data[:rejection_reasons].detect { |x| x.id == k }&.name || I18n.t("unknown")
+      percentage = (v * 100.0) / total
+      add_row("", "", txt, number_to_percentage(percentage, precision: 2))
+    end
   end
 
   def fill_application


### PR DESCRIPTION
# Description

L'export Excel d'une offre d'emploi depuis le BO levait une `NoMethodError` parce qu'on appelait toujours une méthode supprimée en #2033 lors du retrait des états « rejected ».

On restaure la méthode supprimée, adaptée au nouveau modèle (booléen `rejected` + `rejection_reason` validée comme requise).

# Review app

https://erecrutement-cvd-staging-pr2097.osc-fr1.scalingo.io

# Links

Closes #2094
