### PR TITLE
Update rejection and new documents email subjects

### DIFF
--- a/app/mailers/applicant_notifications_mailer.rb
+++ b/app/mailers/applicant_notifications_mailer.rb
@@ -88,7 +88,11 @@ class ApplicantNotificationsMailer < ApplicationMailer
     @document_names = params[:document_names]
     @service_name = @job_offer.organization.service_name
 
-    mail to: @user.email, subject: t(".subject")
+    mail to: @user.email, subject: t(
+      ".subject",
+      job_offer_title: @job_offer.title,
+      service_name: @service_name
+    )
   end
 
   def notify_rejected
@@ -96,6 +100,10 @@ class ApplicantNotificationsMailer < ApplicationMailer
     @job_offer = params[:job_offer]
     @service_name = @job_offer.organization.service_name
 
-    mail to: @user.email, subject: t(".subject")
+    mail to: @user.email, subject: t(
+      ".subject",
+      job_offer_title: @job_offer.title,
+      service_name: @service_name
+    )
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -179,9 +179,9 @@ fr:
     notify_new_state:
       subject: "Votre candidature à l'offre %{job_offer_identifier} sur %{service_name}"
     notify_new_documents:
-      subject: "Nouveaux documents à consulter"
+      subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name} – Nouveaux documents à consulter"
     notify_rejected:
-      subject: "Votre candidature a été refusée"
+      subject: "Votre candidature à l'offre %{job_offer_title} sur %{service_name}"
   notifications_mailer:
     new_email:
       subject: "[%{service_name}] Notification « Employeur » - Etape %{state}"

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -64,7 +64,11 @@ RSpec.describe ApplicantNotificationsMailer do
     let(:job_offer) { job_application.job_offer }
     let(:document_names) { ["CV", "Lettre de motivation"] }
 
-    it { expect(mail.subject).to eq("Nouveaux documents à consulter") }
+    it {
+      expect(mail.subject).to eq(
+        "Votre candidature à l'offre #{job_offer.title} sur #{job_offer.organization.service_name} – Nouveaux documents à consulter"
+      )
+    }
 
     it { expect(mail.to).to match([user.email]) }
 
@@ -82,7 +86,11 @@ RSpec.describe ApplicantNotificationsMailer do
     let(:user) { job_application.user }
     let(:job_offer) { job_application.job_offer }
 
-    it { expect(notify_rejected.subject).to eq("Votre candidature a été refusée") }
+    it {
+      expect(notify_rejected.subject).to eq(
+        "Votre candidature à l'offre #{job_offer.title} sur #{job_offer.organization.service_name}"
+      )
+    }
 
     it { expect(notify_rejected.body.encoded).to match(/nous ne pouvons pas actuellement y donner une suite favorable/) }
   end


### PR DESCRIPTION
# Description

Met à jour l'objet de deux emails envoyés aux candidats afin d'inclure l'intitulé de l'offre et le nom de la plateforme :

- **Mail de refus candidat** : `Votre candidature à l'offre [INTITULÉ DE L'OFFRE] sur [PLATEFORME]`
- **Mail – Nouveaux documents à consulter** : `Votre candidature à l'offre [INTITULÉ DE L'OFFRE] sur [PLATEFORME] – Nouveaux documents à consulter`

# Review app

https://erecrutement-cvd-staging-pr2098.osc-fr1.scalingo.io

# Links

Closes #2095

# Screenshots

<img width="814" height="475" alt="CleanShot 2026-04-30 at 08 47 23" src="https://github.com/user-attachments/assets/7a788c8c-169f-46e1-8f3d-282d77cbcadf" />

<img width="829" height="542" alt="CleanShot 2026-04-30 at 08 47 35" src="https://github.com/user-attachments/assets/a96cbe39-1fad-48d7-b6d0-51a267f63809" />
