### PR TITLE
Allow admin destroy to cascade through related records

### DIFF
--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -37,6 +37,7 @@ class Administrator < ApplicationRecord
     inverse_of: :grand_employer_administrator,
     dependent: :nullify
   has_many :owned_job_offers, class_name: "JobOffer", foreign_key: "owner_id", inverse_of: :owner, dependent: :nullify
+  has_many :messages, dependent: :nullify
   has_many :job_offer_actors, dependent: :destroy
   has_many :job_offers, through: :job_offer_actors
   has_many :administrator_employers, dependent: :destroy

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -26,6 +26,16 @@ class Administrator < ApplicationRecord
   belongs_to :grand_employer_administrator, optional: true, class_name: "Administrator" # Deprecated on 2025-04-26, replaced by employers
 
   has_many :invitees, class_name: "Administrator", foreign_key: "inviter_id", inverse_of: :inviter, dependent: :nullify
+  has_many :supervisees,
+    class_name: "Administrator",
+    foreign_key: "supervisor_administrator_id",
+    inverse_of: :supervisor_administrator,
+    dependent: :nullify
+  has_many :grand_employees,
+    class_name: "Administrator",
+    foreign_key: "grand_employer_administrator_id",
+    inverse_of: :grand_employer_administrator,
+    dependent: :nullify
   has_many :owned_job_offers, class_name: "JobOffer", foreign_key: "owner_id", inverse_of: :owner, dependent: :nullify
   has_many :job_offer_actors, dependent: :destroy
   has_many :job_offers, through: :job_offer_actors

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,7 +3,7 @@
 # Internal messaging system exchanged by recruiters around a specific job application
 class Message < ApplicationRecord
   belongs_to :job_application
-  belongs_to :administrator
+  belongs_to :administrator, optional: true
 
   validates :body, presence: true
 

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Administrator do
 
     it { is_expected.to have_many(:owned_job_offers).inverse_of(:owner) }
 
+    it { is_expected.to have_many(:messages).dependent(:nullify) }
+
     it { is_expected.to have_many(:administrator_employers).dependent(:destroy) }
 
     it { is_expected.to have_many(:employers).through(:administrator_employers) }
@@ -29,6 +31,15 @@ RSpec.describe Administrator do
 
       it "nullifies the grand_employer_administrator_id of grand_employees" do
         expect { administrator.destroy! }.to change { grand_employee.reload.grand_employer_administrator_id }.to(nil)
+      end
+    end
+
+    describe "destroy behavior on authored messages" do
+      let!(:administrator) { create(:administrator) }
+      let!(:message) { create(:message, administrator:) }
+
+      it "nullifies the administrator_id of authored messages" do
+        expect { administrator.destroy! }.to change { message.reload.administrator_id }.to(nil)
       end
     end
   end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Administrator do
 
     it { is_expected.to have_many(:messages).dependent(:nullify) }
 
+    it { is_expected.to have_many(:preferred_users_lists).dependent(:destroy) }
+
     it { is_expected.to have_many(:administrator_employers).dependent(:destroy) }
 
     it { is_expected.to have_many(:employers).through(:administrator_employers) }
@@ -40,6 +42,16 @@ RSpec.describe Administrator do
 
       it "nullifies the administrator_id of authored messages" do
         expect { administrator.destroy! }.to change { message.reload.administrator_id }.to(nil)
+      end
+    end
+
+    describe "destroy behavior on owned preferred_users_lists" do
+      let!(:administrator) { create(:administrator) }
+
+      before { create(:preferred_users_list, administrator:) }
+
+      it "destroys owned preferred_users_lists" do
+        expect { administrator.destroy! }.to change(PreferredUsersList, :count).by(-1)
       end
     end
   end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -8,11 +8,29 @@ RSpec.describe Administrator do
   describe "associations" do
     it { is_expected.to have_many(:invitees).inverse_of(:inviter) }
 
+    it { is_expected.to have_many(:supervisees).inverse_of(:supervisor_administrator).dependent(:nullify) }
+
+    it { is_expected.to have_many(:grand_employees).inverse_of(:grand_employer_administrator).dependent(:nullify) }
+
     it { is_expected.to have_many(:owned_job_offers).inverse_of(:owner) }
 
     it { is_expected.to have_many(:administrator_employers).dependent(:destroy) }
 
     it { is_expected.to have_many(:employers).through(:administrator_employers) }
+
+    describe "destroy behavior on self-referencing associations" do
+      let!(:administrator) { create(:administrator) }
+      let!(:supervisee) { create(:administrator, supervisor_administrator: administrator) }
+      let!(:grand_employee) { create(:administrator, grand_employer_administrator: administrator) }
+
+      it "nullifies the supervisor_administrator_id of supervisees" do
+        expect { administrator.destroy! }.to change { supervisee.reload.supervisor_administrator_id }.to(nil)
+      end
+
+      it "nullifies the grand_employer_administrator_id of grand_employees" do
+        expect { administrator.destroy! }.to change { grand_employee.reload.grand_employer_administrator_id }.to(nil)
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -3,7 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Message do
-  it { is_expected.to validate_presence_of(:body) }
+  describe "associations" do
+    it { is_expected.to belong_to(:job_application) }
+
+    it { is_expected.to belong_to(:administrator).optional }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:body) }
+  end
 end
 
 # == Schema Information

--- a/spec/models/preferred_users_list_spec.rb
+++ b/spec/models/preferred_users_list_spec.rb
@@ -3,7 +3,17 @@
 require "rails_helper"
 
 RSpec.describe PreferredUsersList do
-  it { is_expected.to validate_presence_of(:name) }
+  describe "associations" do
+    it { is_expected.to belong_to(:administrator) }
+
+    it { is_expected.to have_many(:preferred_users).dependent(:destroy) }
+
+    it { is_expected.to have_many(:users).through(:preferred_users) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Description

Fix `PG::ForeignKeyViolation` when destroying an `Administrator` who is still referenced from:

- another administrator's `supervisor_administrator_id`
- another administrator's `grand_employer_administrator_id`
- a `messages.administrator_id` (authored message)


# Review app

https://erecrutement-cvd-staging-pr2125.osc-fr1.scalingo.io

# Links

Closes #2102