### PR TITLE
Enable prefix search on job offer full-text scope

### DIFF
--- a/app/models/job_offer.rb
+++ b/app/models/job_offer.rb
@@ -30,7 +30,8 @@ class JobOffer < ApplicationRecord
     },
     associated_against: SETTINGS.index_with { |obj|
       %i[name]
-    }
+    },
+    using: {tsearch: {prefix: true}}
 
   ## Relationships
   belongs_to :owner, class_name: "Administrator"

--- a/spec/models/job_offer_spec.rb
+++ b/spec/models/job_offer_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe JobOffer do
       it { is_expected.not_to include(never_published) }
     end
 
+    describe ".search_full_text" do
+      let!(:matching) { create(:job_offer, title: "Ingénieur logiciel F/H") }
+      let!(:unmatching) { create(:job_offer, title: "Chef de projet F/H") }
+
+      it "matches by full word" do
+        result = described_class.search_full_text("ingénieur")
+        expect(result).to include(matching)
+        expect(result).not_to include(unmatching)
+      end
+
+      it "matches by prefix" do
+        result = described_class.search_full_text("ingé")
+        expect(result).to include(matching)
+        expect(result).not_to include(unmatching)
+      end
+
+      it "ignores accents in the query" do
+        result = described_class.search_full_text("ingenieur")
+        expect(result).to include(matching)
+        expect(result).not_to include(unmatching)
+      end
+    end
+
     describe ".with_open_applications_in" do # rubocop:disable RSpec/MultipleMemoizedHelpers
       subject(:scope) { described_class.with_open_applications_in(:phone_meeting) }
 


### PR DESCRIPTION
# Description

On fait évoluer la recherche d'offres d'emploi en front office, pour répondre à ce qui est actuellement perçu comme un bug.

Avant la modification, voici comment fonctionnait la recherche : 
- Pas de stemming : « ingénieur » ≠ « ingénieurs »
- Accents ignorés :  développeur » trouve « developpeur »
- Préfixes désactivés : « ingé » ne trouve pas « ingénieur »
- Casse ignorée : « INGE » revient à « inge »
- Pondération : identifier/title (A) > description (B) > location (C)

**En conséquence, comme la recherche par préfixe est désactivée, même si l'identifier commence par "AMIAD", les offres ne remontent que si le mot "AMIAD" est contenu dans le titre ou dans la description.**

<img width="1705" height="1314" alt="CleanShot 2026-05-12 at 08 30 42" src="https://github.com/user-attachments/assets/428ff1ca-0b16-4abc-bfc6-c4af5c365c65" />


Dans cette PR, on active la recherche par préfixe, afin que les offres dont l'identifier commence par "AMIAD" soient affichés.

# Review app

https://erecrutement-cvd-staging-pr2129.osc-fr1.scalingo.io

# Links

Closes #2103
