### PR TITLE
Refine daily and weekly report emails

### DIFF
--- a/app/models/reports/base.rb
+++ b/app/models/reports/base.rb
@@ -12,7 +12,7 @@ module Reports
     end
 
     def sections
-      @sections ||= [new_offers_section] + JobApplication.states.keys.map { |state| applications_section(state) }
+      @sections ||= ([new_offers_section] + JobApplication.states.keys.map { |state| applications_section(state) }).compact
     end
   end
 end

--- a/app/models/reports/base.rb
+++ b/app/models/reports/base.rb
@@ -12,7 +12,11 @@ module Reports
     end
 
     def sections
-      @sections ||= ([new_offers_section] + JobApplication.states.keys.map { |state| applications_section(state) }).compact
+      @sections ||= ([new_offers_section] + states.map { |state| applications_section(state) }).compact
     end
+
+    private
+
+    def states = raise NotImplementedError
   end
 end

--- a/app/models/reports/daily.rb
+++ b/app/models/reports/daily.rb
@@ -8,6 +8,8 @@ module Reports
 
     def new_offers_section
       offers = @administrator.job_offers.last_day
+      return nil if offers.empty?
+
       Section.new(
         key: "new_offers",
         human_state: I18n.t("reports.daily.sections.new_offers"),
@@ -18,6 +20,8 @@ module Reports
 
     def applications_section(state)
       offers = @administrator.job_offers.with_open_applications_in(state)
+      return nil if offers.empty?
+
       Section.new(
         key: state,
         human_state: JobApplication.human_attribute_name("state/#{state}"),

--- a/app/models/reports/daily.rb
+++ b/app/models/reports/daily.rb
@@ -29,5 +29,7 @@ module Reports
         items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
       )
     end
+
+    def states = JobApplication.states.keys
   end
 end

--- a/app/models/reports/weekly.rb
+++ b/app/models/reports/weekly.rb
@@ -9,6 +9,8 @@ module Reports
 
     def new_offers_section
       offers = @administrator.job_offers.last_week
+      return nil if offers.empty?
+
       Section.new(
         key: "new_offers",
         human_state: I18n.t("reports.weekly.sections.new_offers"),
@@ -19,6 +21,8 @@ module Reports
 
     def applications_section(state)
       offers = @administrator.job_offers.with_open_applications_in(state)
+      return nil if offers.empty?
+
       Section.new(
         key: state,
         human_state: JobApplication.human_attribute_name("state/#{state}"),

--- a/app/models/reports/weekly.rb
+++ b/app/models/reports/weekly.rb
@@ -7,6 +7,8 @@ module Reports
   class Weekly < Base
     private
 
+    STATES = %w[accepted contract_drafting contract_feedback_waiting contract_received affected].freeze
+
     def new_offers_section
       offers = @administrator.job_offers.last_week
       return nil if offers.empty?
@@ -30,5 +32,7 @@ module Reports
         items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
       )
     end
+
+    def states = STATES
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -209,7 +209,7 @@ fr:
       published_job_offers:
         title: "Offres publiées récemment"
     employer_recruiter_daily_report:
-      subject: "[%{service_name}] Rapport quotidien « Employeur »"
+      subject: "[%{service_name}] Rapport journalier « Employeur »"
     employment_authority_weekly_report:
       subject: "[%{service_name}] Rapport hebdomadaire « Autorité d'emploi »"
   platform_mailer:

--- a/spec/models/reports/daily_spec.rb
+++ b/spec/models/reports/daily_spec.rb
@@ -9,16 +9,30 @@ RSpec.describe Reports::Daily do
     let(:administrator) { create(:administrator, roles: %w[employer_recruiter]) }
     let(:other_administrator) { create(:administrator, roles: %w[employer_recruiter]) }
 
-    it "returns new_offers followed by every application state in order" do
-      expect(sections.map(&:key)).to eq(["new_offers"] + JobApplication.states.keys)
+    context "when the administrator has neither new offer nor open application" do
+      it { is_expected.to be_empty }
     end
 
-    it "exposes count, human_state and items for each section" do
-      sections.each do |section|
-        expect(section).to be_a(described_class::Section)
-        expect(section.count).to eq(section.items.size)
-        expect(section.human_state).to be_a(String).and be_present
-        expect(section.items).to all(be_a(described_class::Item))
+    context "when the administrator has a new offer and one application in every state" do
+      before do
+        create(:published_job_offer, published_at: 1.day.ago.beginning_of_day + 12.hours).tap { |offer| link_admin_to(offer) }
+        JobApplication.states.keys.each do |state|
+          job_offer = create(:published_job_offer).tap { |offer| link_admin_to(offer) }
+          create(:job_application, job_offer:, state:, dar: true)
+        end
+      end
+
+      it "returns new_offers followed by every application state in order" do
+        expect(sections.map(&:key)).to eq(["new_offers"] + JobApplication.states.keys)
+      end
+
+      it "exposes count, human_state and items for each section" do
+        sections.each do |section|
+          expect(section).to be_a(described_class::Section)
+          expect(section.count).to eq(section.items.size)
+          expect(section.human_state).to be_a(String).and be_present
+          expect(section.items).to all(be_a(described_class::Item))
+        end
       end
     end
 
@@ -84,15 +98,12 @@ RSpec.describe Reports::Daily do
 
       it "excludes rejected applications" do
         create(:job_application, :rejected, job_offer: job_offer, state: :phone_meeting)
-        section = sections.find { |s| s.key == "phone_meeting" }
-        expect(section.count).to eq(0)
-        expect(section.items).to be_empty
+        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
       end
 
       it "excludes applications on offers the administrator is not an actor on" do
         create(:job_application, job_offer: other_offer, state: :phone_meeting)
-        section = sections.find { |s| s.key == "phone_meeting" }
-        expect(section.count).to eq(0)
+        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
       end
 
       it "lists an offer only once even when several applications share the same state" do
@@ -104,8 +115,7 @@ RSpec.describe Reports::Daily do
 
       it "does not surface an offer in states where none of its applications match" do
         create(:job_application, job_offer:, state: :phone_meeting)
-        section = sections.find { |s| s.key == "to_be_met" }
-        expect(section.count).to eq(0)
+        expect(sections.find { |s| s.key == "to_be_met" }).to be_nil
       end
     end
   end

--- a/spec/models/reports/weekly_spec.rb
+++ b/spec/models/reports/weekly_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Reports::Weekly do
         end
       end
 
-      it "returns new_offers followed by every application state in order" do
-        expect(sections.map(&:key)).to eq(["new_offers"] + JobApplication.states.keys)
+      it "returns new_offers followed by every reported application state in order" do
+        expect(sections.map(&:key)).to eq(["new_offers"] + described_class::STATES)
       end
 
       it "exposes count, human_state and items for each section" do
@@ -74,7 +74,7 @@ RSpec.describe Reports::Weekly do
       end
     end
 
-    JobApplication.states.keys.each do |state|
+    described_class::STATES.each do |state|
       describe "#{state} section" do
         subject(:section) { sections.find { |s| s.key == state } }
 
@@ -93,29 +93,34 @@ RSpec.describe Reports::Weekly do
     end
 
     describe "application sections filtering" do
-      let(:job_offer) { create(:published_job_offer).tap { |offer| link_admin_to(offer) } }
-      let(:other_offer) { create(:published_job_offer).tap { |offer| link_admin_to(offer, admin: other_administrator) } }
+      let(:job_offer) { create(:published_job_offer, positions_count: 10).tap { |offer| link_admin_to(offer) } }
+      let(:other_offer) { create(:published_job_offer, positions_count: 10).tap { |offer| link_admin_to(offer, admin: other_administrator) } }
 
       it "excludes rejected applications" do
-        create(:job_application, :rejected, job_offer: job_offer, state: :phone_meeting)
-        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
+        create(:job_application, :rejected, job_offer: job_offer, state: :accepted)
+        expect(sections.find { |s| s.key == "accepted" }).to be_nil
       end
 
       it "excludes applications on offers the administrator is not an actor on" do
-        create(:job_application, job_offer: other_offer, state: :phone_meeting)
-        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
+        create(:job_application, job_offer: other_offer, state: :accepted)
+        expect(sections.find { |s| s.key == "accepted" }).to be_nil
       end
 
       it "lists an offer only once even when several applications share the same state" do
-        create_list(:job_application, 3, job_offer:, state: :phone_meeting)
-        section = sections.find { |s| s.key == "phone_meeting" }
+        create_list(:job_application, 3, job_offer:, state: :accepted)
+        section = sections.find { |s| s.key == "accepted" }
         expect(section.count).to eq(1)
         expect(section.items.size).to eq(1)
       end
 
       it "does not surface an offer in states where none of its applications match" do
+        create(:job_application, job_offer:, state: :accepted)
+        expect(sections.find { |s| s.key == "contract_drafting" }).to be_nil
+      end
+
+      it "ignores states not listed in the report" do
         create(:job_application, job_offer:, state: :phone_meeting)
-        expect(sections.find { |s| s.key == "to_be_met" }).to be_nil
+        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
       end
     end
   end

--- a/spec/models/reports/weekly_spec.rb
+++ b/spec/models/reports/weekly_spec.rb
@@ -9,16 +9,30 @@ RSpec.describe Reports::Weekly do
     let(:administrator) { create(:administrator, roles: %w[employment_authority]) }
     let(:other_administrator) { create(:administrator, roles: %w[employment_authority]) }
 
-    it "returns new_offers followed by every application state in order" do
-      expect(sections.map(&:key)).to eq(["new_offers"] + JobApplication.states.keys)
+    context "when the administrator has neither new offer nor open application" do
+      it { is_expected.to be_empty }
     end
 
-    it "exposes count, human_state and items for each section" do
-      sections.each do |section|
-        expect(section).to be_a(described_class::Section)
-        expect(section.count).to eq(section.items.size)
-        expect(section.human_state).to be_a(String).and be_present
-        expect(section.items).to all(be_a(described_class::Item))
+    context "when the administrator has a new offer and one application in every state" do
+      before do
+        create(:published_job_offer, published_at: 1.week.ago.beginning_of_week + 1.day).tap { |offer| link_admin_to(offer) }
+        JobApplication.states.keys.each do |state|
+          job_offer = create(:published_job_offer).tap { |offer| link_admin_to(offer) }
+          create(:job_application, job_offer:, state:, dar: true)
+        end
+      end
+
+      it "returns new_offers followed by every application state in order" do
+        expect(sections.map(&:key)).to eq(["new_offers"] + JobApplication.states.keys)
+      end
+
+      it "exposes count, human_state and items for each section" do
+        sections.each do |section|
+          expect(section).to be_a(described_class::Section)
+          expect(section.count).to eq(section.items.size)
+          expect(section.human_state).to be_a(String).and be_present
+          expect(section.items).to all(be_a(described_class::Item))
+        end
       end
     end
 
@@ -84,15 +98,12 @@ RSpec.describe Reports::Weekly do
 
       it "excludes rejected applications" do
         create(:job_application, :rejected, job_offer: job_offer, state: :phone_meeting)
-        section = sections.find { |s| s.key == "phone_meeting" }
-        expect(section.count).to eq(0)
-        expect(section.items).to be_empty
+        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
       end
 
       it "excludes applications on offers the administrator is not an actor on" do
         create(:job_application, job_offer: other_offer, state: :phone_meeting)
-        section = sections.find { |s| s.key == "phone_meeting" }
-        expect(section.count).to eq(0)
+        expect(sections.find { |s| s.key == "phone_meeting" }).to be_nil
       end
 
       it "lists an offer only once even when several applications share the same state" do
@@ -104,8 +115,7 @@ RSpec.describe Reports::Weekly do
 
       it "does not surface an offer in states where none of its applications match" do
         create(:job_application, job_offer:, state: :phone_meeting)
-        section = sections.find { |s| s.key == "to_be_met" }
-        expect(section.count).to eq(0)
+        expect(sections.find { |s| s.key == "to_be_met" }).to be_nil
       end
     end
   end


### PR DESCRIPTION
# Description

Trois ajustements sur les rapports email à destination des recruteurs :

- **Sections vides masquées** : on ne génère plus de section quand il n'y a aucune offre ou candidature à afficher. Le mail correspondant n'affiche donc plus de `<h3>État : 0</h3>` orphelin ni de bloc vide.
- **Périmètre du rapport hebdomadaire** : on ne couvre plus que les états aval du process (`accepted`, `contract_drafting`, `contract_feedback_waiting`, `contract_received`, `affected`).
- **Wording sujet rapport journalier** : `« Rapport quotidien »` devient `« Rapport journalier »`.

# Review app

https://erecrutement-cvd-staging-pr2135.osc-fr1.scalingo.io

# Links

Closes #1973
Closes #1974
Closes #2130


# Screenshots

<img width="742" height="648" alt="CleanShot 2026-05-13 at 08 47 54" src="https://github.com/user-attachments/assets/6dd6c353-c68b-4e88-9625-c642ecd91841" />

<img width="773" height="985" alt="CleanShot 2026-05-13 at 08 48 09" src="https://github.com/user-attachments/assets/fac60add-48e0-4fae-9222-3eec5bf9da8c" />
