### PR TITLE
asc ict_tct attrs removed from job_offer_head

### DIFF
--- a/app/views/job_offers/_job_offer_head.html.haml
+++ b/app/views/job_offers/_job_offer_head.html.haml
@@ -1,4 +1,4 @@
-- attributes = %i[contract_type contract_start_on application_deadline location study_level category experience_level salary is_remote_possible benefits drawbacks asc ict_tct cover_lettre_required positions_count]
+- attributes = %i[contract_type contract_start_on application_deadline location study_level category experience_level salary is_remote_possible benefits drawbacks cover_lettre_required positions_count]
 - attributes.each_with_index do |attribute, index|
   .d-flex.align-items-center.mb-2{class: index == 0 ? nil : 'rf-mt-1w'}
     = fa_icon job_offer_icon_for_attribute(attribute), class: 'mr-3'


### PR DESCRIPTION
# Description

L'affichage des attributs *asc ict-tct* a été enlevé de la barre latérale gauche d'une offre.  
# Review app

https://erecrutement-cvd-staging-pr2136.osc-fr1.scalingo.io

# Links

Closes #1969 

# Screenshots
<img width="996" height="1556" alt="image" src="https://github.com/user-attachments/assets/206f3d53-5f2b-456b-a28f-da5d01210b37" />
