### PR TITLE
Refine daily and weekly report rendering

### DIFF
--- a/app/mailers/reports_mailer.rb
+++ b/app/mailers/reports_mailer.rb
@@ -13,7 +13,9 @@ class ReportsMailer < ApplicationMailer
     @sections = Reports::Daily.new(@administrator).sections
     @service_name = @administrator.organization.service_name
 
-    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+    message = mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+    message.perform_deliveries = false if @sections.empty?
+    message
   end
 
   def employment_authority_weekly_report
@@ -22,6 +24,8 @@ class ReportsMailer < ApplicationMailer
     @service_name = @administrator.organization.service_name
     @week_starts_on = 1.week.ago.beginning_of_week.to_date
 
-    mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+    message = mail to: @administrator.email, subject: t(".subject", service_name: @service_name)
+    message.perform_deliveries = false if @sections.empty?
+    message
   end
 end

--- a/app/models/reports/base.rb
+++ b/app/models/reports/base.rb
@@ -5,7 +5,7 @@ module Reports
     include Rails.application.routes.url_helpers
 
     Section = Struct.new(:key, :human_state, :count, :items, keyword_init: true)
-    Item = Struct.new(:title, :link, keyword_init: true)
+    Item = Struct.new(:title, :link, :applications_count, keyword_init: true)
 
     def initialize(administrator)
       @administrator = administrator

--- a/app/models/reports/daily.rb
+++ b/app/models/reports/daily.rb
@@ -24,7 +24,10 @@ module Reports
 
       Section.new(
         key: state,
-        human_state: JobApplication.human_attribute_name("state/#{state}"),
+        human_state: I18n.t(
+          "reports.sections.application_step",
+          state: JobApplication.human_attribute_name("state/#{state}")
+        ),
         count: offers.size,
         items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
       )

--- a/app/models/reports/daily.rb
+++ b/app/models/reports/daily.rb
@@ -22,6 +22,12 @@ module Reports
       offers = @administrator.job_offers.with_open_applications_in(state)
       return nil if offers.empty?
 
+      counts = JobApplication
+        .where(job_offer_id: offers.map(&:id), state:, rejected: false)
+        .reorder(nil)
+        .group(:job_offer_id)
+        .count
+
       Section.new(
         key: state,
         human_state: I18n.t(
@@ -29,7 +35,13 @@ module Reports
           state: JobApplication.human_attribute_name("state/#{state}")
         ),
         count: offers.size,
-        items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
+        items: offers.map do |offer|
+          Item.new(
+            title: offer.full_title,
+            link: admin_job_offer_url(offer),
+            applications_count: counts[offer.id] || 0
+          )
+        end
       )
     end
 

--- a/app/models/reports/weekly.rb
+++ b/app/models/reports/weekly.rb
@@ -25,6 +25,12 @@ module Reports
       offers = @administrator.job_offers.with_open_applications_in(state)
       return nil if offers.empty?
 
+      counts = JobApplication
+        .where(job_offer_id: offers.map(&:id), state:, rejected: false)
+        .reorder(nil)
+        .group(:job_offer_id)
+        .count
+
       Section.new(
         key: state,
         human_state: I18n.t(
@@ -32,7 +38,13 @@ module Reports
           state: JobApplication.human_attribute_name("state/#{state}")
         ),
         count: offers.size,
-        items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
+        items: offers.map do |offer|
+          Item.new(
+            title: offer.full_title,
+            link: admin_job_offer_url(offer),
+            applications_count: counts[offer.id] || 0
+          )
+        end
       )
     end
 

--- a/app/models/reports/weekly.rb
+++ b/app/models/reports/weekly.rb
@@ -27,7 +27,10 @@ module Reports
 
       Section.new(
         key: state,
-        human_state: JobApplication.human_attribute_name("state/#{state}"),
+        human_state: I18n.t(
+          "reports.sections.application_step",
+          state: JobApplication.human_attribute_name("state/#{state}")
+        ),
         count: offers.size,
         items: offers.map { |offer| Item.new(title: offer.full_title, link: admin_job_offer_url(offer)) }
       )

--- a/app/views/reports_mailer/employer_recruiter_daily_report.html.erb
+++ b/app/views/reports_mailer/employer_recruiter_daily_report.html.erb
@@ -6,7 +6,7 @@
 <p>Découvrez ci-dessous votre rapport journalier.</p>
 
 <% @sections.each do |section| %>
-  <h3><%= section.human_state %> : <%= section.count %></h3>
+  <h3><%= section.human_state %></h3>
   <% if section.items.any? %>
     <ul>
       <% section.items.each do |item| %>

--- a/app/views/reports_mailer/employer_recruiter_daily_report.html.erb
+++ b/app/views/reports_mailer/employer_recruiter_daily_report.html.erb
@@ -12,6 +12,10 @@
       <% section.items.each do |item| %>
         <li>
           <%= link_to item.title, item.link %>
+          <% if item.applications_count %>
+            <br>
+            <span style="color: #999;"><%= t("reports.sections.applications_count", count: item.applications_count) %></span>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/reports_mailer/employment_authority_weekly_report.html.erb
+++ b/app/views/reports_mailer/employment_authority_weekly_report.html.erb
@@ -6,7 +6,7 @@
 <p>Découvrez ci-dessous votre rapport hebdomadaire – semaine du <%= l(@week_starts_on, format: "%d/%m/%Y") %>.</p>
 
 <% @sections.each do |section| %>
-  <h3><%= section.human_state %> : <%= section.count %></h3>
+  <h3><%= section.human_state %></h3>
   <% if section.items.any? %>
     <ul>
       <% section.items.each do |item| %>

--- a/app/views/reports_mailer/employment_authority_weekly_report.html.erb
+++ b/app/views/reports_mailer/employment_authority_weekly_report.html.erb
@@ -12,6 +12,10 @@
       <% section.items.each do |item| %>
         <li>
           <%= link_to item.title, item.link %>
+          <% if item.applications_count %>
+            <br>
+            <span style="color: #999;"><%= t("reports.sections.applications_count", count: item.applications_count) %></span>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -236,6 +236,10 @@ fr:
   reports:
     sections:
       application_step: "Étape « %{state} »"
+      applications_count:
+        zero: "Pas de candidature"
+        one: "1 candidature"
+        other: "%{count} candidatures"
     daily:
       sections:
         new_offers: "Nouvelles offres"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -234,6 +234,8 @@ fr:
       job_offers: "Nos offres"
       logout: "Déconnexion"
   reports:
+    sections:
+      application_step: "Étape « %{state} »"
     daily:
       sections:
         new_offers: "Nouvelles offres"

--- a/spec/mailers/reports_mailer_spec.rb
+++ b/spec/mailers/reports_mailer_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe ReportsMailer do
       expect(body).to include(administrator.organization.service_name)
     end
 
+    context "when the administrator has no activity to report" do
+      it "skips delivery" do
+        expect(Reports::Daily.new(administrator).sections).to be_empty
+        expect(mail.perform_deliveries).to be(false)
+      end
+    end
+
     context "with an offer published yesterday the recruiter is actor on" do
       let(:job_offer) { create(:published_job_offer, published_at: 1.day.ago.beginning_of_day + 12.hours) }
 
@@ -65,6 +72,10 @@ RSpec.describe ReportsMailer do
 
       it "lists the offer in the mail body" do
         expect(mail.body.encoded).to include(job_offer.full_title)
+      end
+
+      it "delivers the mail" do
+        expect(mail.perform_deliveries).to be(true)
       end
     end
   end
@@ -106,6 +117,13 @@ RSpec.describe ReportsMailer do
       expect(body).to include(administrator.organization.service_name)
     end
 
+    context "when the administrator has no activity to report" do
+      it "skips delivery" do
+        expect(Reports::Weekly.new(administrator).sections).to be_empty
+        expect(mail.perform_deliveries).to be(false)
+      end
+    end
+
     context "with an offer published last week the authority is actor on" do
       let(:job_offer) do
         create(:published_job_offer, published_at: 1.week.ago.beginning_of_week + 1.day)
@@ -115,6 +133,10 @@ RSpec.describe ReportsMailer do
 
       it "lists the offer in the mail body" do
         expect(mail.body.encoded).to include(job_offer.full_title)
+      end
+
+      it "delivers the mail" do
+        expect(mail.perform_deliveries).to be(true)
       end
     end
   end

--- a/spec/models/reports/daily_spec.rb
+++ b/spec/models/reports/daily_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Reports::Daily do
         expect(link).to include("/offresdemploi/")
         expect(link).not_to include("/admin/")
       end
+
+      it "leaves applications_count nil on items" do
+        expect(section.items.first.applications_count).to be_nil
+      end
     end
 
     JobApplication.states.keys.each do |state|
@@ -111,6 +115,13 @@ RSpec.describe Reports::Daily do
         section = sections.find { |s| s.key == "phone_meeting" }
         expect(section.count).to eq(1)
         expect(section.items.size).to eq(1)
+      end
+
+      it "exposes the number of non-rejected applications per offer" do
+        create_list(:job_application, 2, job_offer:, state: :phone_meeting)
+        create(:job_application, :rejected, job_offer:, state: :phone_meeting)
+        section = sections.find { |s| s.key == "phone_meeting" }
+        expect(section.items.first.applications_count).to eq(2)
       end
 
       it "does not surface an offer in states where none of its applications match" do

--- a/spec/models/reports/weekly_spec.rb
+++ b/spec/models/reports/weekly_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Reports::Weekly do
         expect(link).to include("/offresdemploi/")
         expect(link).not_to include("/admin/")
       end
+
+      it "leaves applications_count nil on items" do
+        expect(section.items.first.applications_count).to be_nil
+      end
     end
 
     described_class::STATES.each do |state|
@@ -111,6 +115,13 @@ RSpec.describe Reports::Weekly do
         section = sections.find { |s| s.key == "accepted" }
         expect(section.count).to eq(1)
         expect(section.items.size).to eq(1)
+      end
+
+      it "exposes the number of non-rejected applications per offer" do
+        create_list(:job_application, 2, job_offer:, state: :accepted)
+        create(:job_application, :rejected, job_offer:, state: :accepted)
+        section = sections.find { |s| s.key == "accepted" }
+        expect(section.items.first.applications_count).to eq(2)
       end
 
       it "does not surface an offer in states where none of its applications match" do


### PR DESCRIPTION
# Description

Ajustements demandés sur les rapports journaliers (employer recruiters) et hebdomadaires (employment authorities) :

- N'envoie plus le mail lorsque le rapport est entièrement vide.
- Retire le compteur total affiché dans le titre `<h3>` de chaque section.
- Préfixe les titres des sections d'état applicatif par `Étape « … »` pour les distinguer clairement des nouvelles offres publiées (la section « Nouvelles offres » reste inchangée).
- Affiche sous chaque offre le nombre de candidatures ouvertes dans l'étape.

# Review app

https://erecrutement-cvd-staging-pr2137.osc-fr1.scalingo.io

# Links

Closes #2130

# Screenshots

<img width="813" height="1093" alt="CleanShot 2026-05-17 at 10 36 32" src="https://github.com/user-attachments/assets/b4cd39ac-c28a-4d9e-8e3c-1f34d75302c0" />

<img width="611" height="667" alt="CleanShot 2026-05-17 at 10 36 43" src="https://github.com/user-attachments/assets/8854ad64-4f3c-4d55-9635-adacc5791909" />

