### PR TITLE
Block deletion of job application file types still in use

### DIFF
--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -94,7 +94,7 @@ class JobApplicationFileType < ApplicationRecord
     validate_by_payroll_manager: :payroll_manager?
   }.freeze
 
-  has_many :job_application_files, dependent: :nullify
+  has_many :job_application_files, dependent: :restrict_with_error
   has_many :visibility_rules, dependent: :destroy
   accepts_nested_attributes_for :visibility_rules, allow_destroy: true
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe JobApplicationFileType do
     end
   end
 
+  describe "#destroy" do
+    subject(:destroy) { file_type.destroy }
+
+    let(:file_type) { create(:job_application_file_type) }
+
+    context "when no JobApplicationFile references the type" do
+      it { is_expected.to eq(file_type) }
+    end
+
+    context "when at least one JobApplicationFile references the type" do
+      before { create(:job_application_file, job_application_file_type: file_type) }
+
+      it "does not destroy and adds an error on the association" do
+        expect(destroy).to be(false)
+        expect(file_type).not_to be_destroyed
+        expect(file_type.errors[:base]).to be_present
+      end
+    end
+  end
+
   describe "#can_validate?" do
     subject { file_type.can_validate?(administrator) }
 


### PR DESCRIPTION
# Description

Bloque la suppression d'un type de fichier dès lors qu'au moins un document y est encore rattaché.

# Review app

https://erecrutement-cvd-staging-pr2138.osc-fr1.scalingo.io

# Links

Closes #2131

# Screenshots

<img width="1705" height="1311" alt="CleanShot 2026-05-17 at 11 16 50" src="https://github.com/user-attachments/assets/eb4c73d9-425f-4a5f-8028-030d81d3621d" />
