### PR TITLE
Loosen mandatory configuration rules on file types

### DIFF
--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -16,7 +16,6 @@ class JobApplicationFileType < ApplicationRecord
   validates :name, :kind, presence: true
   validate :must_have_administrator_visibility_rule
   validate :must_have_user_visibility_rule
-  validate :must_have_at_least_one_validator
 
   enum kind: {
     applicant_provided: 10,
@@ -114,14 +113,6 @@ class JobApplicationFileType < ApplicationRecord
   def must_have_user_visibility_rule
     rules = visibility_rules.reject(&:marked_for_destruction?)
     errors.add(:visibility_rules, :must_have_user) unless rules.any?(&:user?)
-  end
-
-  def must_have_at_least_one_validator
-    at_least_one_validator = validate_by_employer_recruiter? ||
-      validate_by_employment_authority? ||
-      validate_by_hr_manager? ||
-      validate_by_payroll_manager?
-    errors.add(:base, :must_have_at_least_one_validator) unless at_least_one_validator
   end
 end
 

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -14,8 +14,6 @@ class JobApplicationFileType < ApplicationRecord
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
 
   validates :name, :kind, presence: true
-  validate :must_have_administrator_visibility_rule
-  validate :must_have_user_visibility_rule
 
   enum kind: {
     applicant_provided: 10,
@@ -101,18 +99,6 @@ class JobApplicationFileType < ApplicationRecord
     return true if administrator.functional_administrator?
 
     VALIDATOR_ROLE_MAPPING.any? { |flag, role_method| self[flag] && administrator.public_send(role_method) }
-  end
-
-  private
-
-  def must_have_administrator_visibility_rule
-    rules = visibility_rules.reject(&:marked_for_destruction?)
-    errors.add(:visibility_rules, :must_have_administrator) unless rules.any?(&:administrator?)
-  end
-
-  def must_have_user_visibility_rule
-    rules = visibility_rules.reject(&:marked_for_destruction?)
-    errors.add(:visibility_rules, :must_have_user) unless rules.any?(&:user?)
   end
 end
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -303,9 +303,9 @@ fr:
         title: "Danger"
         destroy: "Je veux supprimer mon compte"
     withdrawals:
-        create:
-          success: "Désistement enregistré"
-          failure: "Impossible de modifier cette candidature"
+      create:
+        success: "Désistement enregistré"
+        failure: "Impossible de modifier cette candidature"
   admin:
     accounts:
       show:
@@ -1231,8 +1231,6 @@ fr:
             visibility_rules:
               must_have_administrator: "doit contenir au moins une règle pour le back office"
               must_have_user: "doit contenir au moins une règle pour le front office"
-            base:
-              must_have_at_least_one_validator: "Vous devez sélectionner au moins un acteur autorisé à valider la pièce"
         job_application_file:
           attributes:
             content:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1226,11 +1226,6 @@ fr:
             photo:
               file_size_is_less_than_or_equal_to: "Est trop volumineuse (ne doit pas dépasser %{count})"
               allowed_file_content_types: "au mauvais format (seuls les formats JPG et PNG sont acceptés)"
-        job_application_file_type:
-          attributes:
-            visibility_rules:
-              must_have_administrator: "doit contenir au moins une règle pour le back office"
-              must_have_user: "doit contenir au moins une règle pour le front office"
         job_application_file:
           attributes:
             content:

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -15,25 +15,6 @@ RSpec.describe JobApplicationFileType do
       it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
     end
 
-    context "without any validator" do
-      subject(:jaft) do
-        build(:job_application_file_type,
-          validate_by_employer_recruiter: false,
-          validate_by_employment_authority: false,
-          validate_by_hr_manager: false,
-          validate_by_payroll_manager: false)
-      end
-
-      it { is_expected.not_to be_valid }
-      it { expect(jaft.tap(&:valid?).errors[:base]).to be_present }
-    end
-
-    context "with at least one validator" do
-      subject(:jaft) { build(:job_application_file_type, validate_by_hr_manager: true) }
-
-      it { is_expected.to be_valid }
-    end
-
     context "without a user visibility rule" do
       subject(:jaft) { build(:job_application_file_type) }
 

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -5,24 +5,6 @@ require "rails_helper"
 RSpec.describe JobApplicationFileType do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
-
-    context "without an administrator visibility rule" do
-      subject(:jaft) { build(:job_application_file_type) }
-
-      before { jaft.visibility_rules.target.reject!(&:administrator?) }
-
-      it { is_expected.not_to be_valid }
-      it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
-    end
-
-    context "without a user visibility rule" do
-      subject(:jaft) { build(:job_application_file_type) }
-
-      before { jaft.visibility_rules.target.reject!(&:user?) }
-
-      it { is_expected.not_to be_valid }
-      it { expect(jaft.tap(&:valid?).errors[:visibility_rules]).to be_present }
-    end
   end
 
   describe "#can_validate?" do

--- a/spec/requests/admin/settings/job_application_file_types_spec.rb
+++ b/spec/requests/admin/settings/job_application_file_types_spec.rb
@@ -90,17 +90,6 @@ RSpec.describe "Admin::Settings::JobApplicationFileTypes" do
       expect { create_request }.to change(VisibilityRule, :count).by(2)
       expect(response).to redirect_to(admin_settings_job_application_file_types_path)
     end
-
-    context "when visibility rules are missing" do
-      let(:params) do
-        {job_application_file_type: attributes_for(:job_application_file_type)}
-      end
-
-      it "does not create the job application file type" do
-        expect { create_request }.not_to change(JobApplicationFileType, :count)
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-    end
   end
 
   describe "PATCH /admin/parametres/job_application_file_types/:id" do


### PR DESCRIPTION
# Description

Suite à la recette PPROD, les règles « au moins une case cochée » sur le paramétrage d'un `JobApplicationFileType` se sont avérées trop bloquantes pour certains cas métier (ex. document fourni uniquement par un gestionnaire RH sans étape de validation).

Cette PR retire trois validations côté modèle :

- `must_have_at_least_one_validator` (acteur autorisé à valider la pièce)
- `must_have_administrator_visibility_rule` (visibilité BO)
- `must_have_user_visibility_rule` (visibilité FO)

Le paramétrage reste entièrement à la main de l'administrateur BO.

# Review app

https://erecrutement-cvd-staging-pr2139.osc-fr1.scalingo.io

# Links

Closes #2134

