### PR TITLE
Crudify feature actions on admin job offers

### DIFF
--- a/app/controllers/admin/job_offers/features_controller.rb
+++ b/app/controllers/admin/job_offers/features_controller.rb
@@ -11,7 +11,10 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
     if @job_offer.update(featured: true)
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
     else
-      redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
+      redirect_back(
+        fallback_location: %i[admin job_offers],
+        notice: t(".error", message: @job_offer.errors.full_messages.to_sentence)
+      )
     end
   end
 
@@ -19,7 +22,10 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
     if @job_offer.update(featured: false)
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
     else
-      redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
+      redirect_back(
+        fallback_location: %i[admin job_offers],
+        notice: t(".error", message: @job_offer.errors.full_messages.to_sentence)
+      )
     end
   end
 

--- a/app/controllers/admin/job_offers/features_controller.rb
+++ b/app/controllers/admin/job_offers/features_controller.rb
@@ -4,9 +4,11 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
   skip_load_and_authorize_resource
 
   before_action :check_authorized
+  before_action :set_job_offer
+  before_action :notice_not_found, unless: -> { @job_offer }, only: :create
 
   def create
-    if job_offer&.update(featured: true)
+    if @job_offer.update(featured: true)
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
     else
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
@@ -14,7 +16,7 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
   end
 
   def destroy
-    if job_offer&.update(featured: false)
+    if @job_offer.update(featured: false)
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
     else
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
@@ -23,13 +25,15 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
 
   private
 
-  def job_offer
-    if params[:job_offer_identifier].present?
+  def set_job_offer
+    @job_offer = if params[:job_offer_identifier].present?
       JobOffer.find_by(identifier: params[:job_offer_identifier])
     else
       JobOffer.find(params[:job_offer_id])
     end
   end
+
+  def notice_not_found = redirect_back(fallback_location: %i[admin job_offers], notice: t(".not_found"))
 
   def check_authorized = authorize! :feature, :job_offer
 end

--- a/app/controllers/admin/job_offers/features_controller.rb
+++ b/app/controllers/admin/job_offers/features_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::JobOffers::FeaturesController < Admin::BaseController
+  skip_load_and_authorize_resource
+
+  def create
+    authorize! :feature, :job_offer
+
+    if job_offer&.update(featured: true)
+      redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
+    else
+      redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
+    end
+  end
+
+  private
+
+  def job_offer
+    if params[:job_offer_identifier].present?
+      JobOffer.find_by(identifier: params[:job_offer_identifier])
+    else
+      JobOffer.find(params[:job_offer_id])
+    end
+  end
+end

--- a/app/controllers/admin/job_offers/features_controller.rb
+++ b/app/controllers/admin/job_offers/features_controller.rb
@@ -3,10 +3,18 @@
 class Admin::JobOffers::FeaturesController < Admin::BaseController
   skip_load_and_authorize_resource
 
-  def create
-    authorize! :feature, :job_offer
+  before_action :check_authorized
 
+  def create
     if job_offer&.update(featured: true)
+      redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
+    else
+      redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
+    end
+  end
+
+  def destroy
+    if job_offer&.update(featured: false)
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
     else
       redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
@@ -22,4 +30,6 @@ class Admin::JobOffers::FeaturesController < Admin::BaseController
       JobOffer.find(params[:job_offer_id])
     end
   end
+
+  def check_authorized = authorize! :feature, :job_offer
 end

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -26,15 +26,6 @@ class Admin::JobOffersController < Admin::BaseController
   def featured
   end
 
-  def unfeature
-    job_offer = JobOffer.find(params[:id])
-    if job_offer.update(featured: false)
-      redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
-    else
-      render json: job_offer.errors, status: :unprocessable_entity
-    end
-  end
-
   def export
     job_offer = JobOffer.find(params[:id])
     file = Exporter::JobOffer.new({stats: export_data, job_offer: job_offer}, current_administrator).generate

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -26,19 +26,6 @@ class Admin::JobOffersController < Admin::BaseController
   def featured
   end
 
-  def feature
-    job_offer = if params[:job_offer_identifier]
-      JobOffer.find_by(identifier: params[:job_offer_identifier])
-    else
-      JobOffer.find(params[:id])
-    end
-    if job_offer&.update(featured: true)
-      redirect_back(fallback_location: %i[admin job_offers], notice: t(".success"))
-    else
-      redirect_back(fallback_location: %i[admin job_offers], notice: t(".error"))
-    end
-  end
-
   def unfeature
     job_offer = JobOffer.find(params[:id])
     if job_offer.update(featured: false)

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -87,7 +87,7 @@
                         = fa_icon('star', class: 'mr-1')
                         Retirer de la une
                     - else
-                      = link_to [:feature, :admin, job_offer], class: "dropdown-item", method: :post do
+                      = link_to admin_job_offer_feature_path(job_offer), class: "dropdown-item", method: :post do
                         = fa_icon('star', class: 'mr-1')
                         Afficher à la une
                   - if can? :transfer, job_offer

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -83,7 +83,7 @@
                       = t("buttons.copy")
                   - if can? :feature, :job_offer
                     - if job_offer.featured
-                      = link_to [:unfeature, :admin, job_offer], class: "dropdown-item", method: :post do
+                      = link_to admin_job_offer_feature_path(job_offer), class: "dropdown-item", method: :delete do
                         = fa_icon('star', class: 'mr-1')
                         Retirer de la une
                     - else

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -430,8 +430,9 @@ fr:
         create:
           success: "Annonce mise à la une"
           error: "L'offre n'a pa pu être mise à la une, veuillez vérifier la référence"
-      unfeature:
-        success: "Annonce retirée de la une"
+        destroy:
+          success: "Annonce retirée de la une"
+          error: "L'offre n'a pa pu être retirée de la une"
       administrator:
         new_record: 'Cliquer sur "Enregistrer" pour inviter'
         waiting: "En attente de confirmation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -303,9 +303,9 @@ fr:
         title: "Danger"
         destroy: "Je veux supprimer mon compte"
     withdrawals:
-        create:
-          success: "Désistement enregistré"
-          failure: "Impossible de modifier cette candidature"
+      create:
+        success: "Désistement enregistré"
+        failure: "Impossible de modifier cette candidature"
   admin:
     accounts:
       show:
@@ -430,6 +430,7 @@ fr:
         create:
           success: "Annonce mise à la une"
           error: "L'offre n'a pa pu être mise à la une, veuillez vérifier la référence"
+          not_found: "Annonce introuvable, veuillez vérifier la référence"
         destroy:
           success: "Annonce retirée de la une"
           error: "L'offre n'a pa pu être retirée de la une"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -429,11 +429,11 @@ fr:
       features:
         create:
           success: "Annonce mise à la une"
-          error: "L'offre n'a pa pu être mise à la une, veuillez vérifier la référence"
+          error: "L'offre n'a pas pu être mise à la une : %{message}"
           not_found: "Annonce introuvable, veuillez vérifier la référence"
         destroy:
           success: "Annonce retirée de la une"
-          error: "L'offre n'a pa pu être retirée de la une"
+          error: "L'offre n'a pas pu être retirée de la une : %{message}"
       administrator:
         new_record: 'Cliquer sur "Enregistrer" pour inviter'
         waiting: "En attente de confirmation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -426,9 +426,10 @@ fr:
         error: "L'annonce n'a pas pu être transférée, veuillez vérifier l'email du nouveau propriétaire"
       send_to_list:
         success: "Annonce diffusées !"
-      feature:
-        success: "Annonce mise à la une"
-        error: "L'offre n'a pa pu être mise à la une, veuillez vérifier la référence"
+      features:
+        create:
+          success: "Annonce mise à la une"
+          error: "L'offre n'a pa pu être mise à la une, veuillez vérifier la référence"
       unfeature:
         success: "Annonce retirée de la une"
       administrator:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
       end
       member do
         get :export, :board, :stats, :new_transfer, :new_send
-        post :transfer, :unfeature, :send_to_list
+        post :transfer, :send_to_list
         JobOffer.aasm.events.map(&:name).each do |event_name|
           patch(event_name.to_sym)
           action_name = :"update_and_#{event_name}"
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
           resources :readings, only: :create
         end
       end
-      resource :feature, only: :create, module: :job_offers
+      resource :feature, only: %i[create destroy], module: :job_offers
       resources :job_applications, path: "candidatures" do
         member do
           get :cvlm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,8 @@ Rails.application.routes.draw do
     resources :job_offer_terms, only: %i[index]
     resources :job_offers, path: "offresdemploi" do
       collection do
-        post :exports, :feature
+        post :exports
+        post :feature, to: "job_offers/features#create"
         post :init, to: "job_offers#new"
         get :init, to: "job_offer_terms#index"
         get :add_actor, :featured, :archived
@@ -77,7 +78,7 @@ Rails.application.routes.draw do
       end
       member do
         get :export, :board, :stats, :new_transfer, :new_send
-        post :transfer, :feature, :unfeature, :send_to_list
+        post :transfer, :unfeature, :send_to_list
         JobOffer.aasm.events.map(&:name).each do |event_name|
           patch(event_name.to_sym)
           action_name = :"update_and_#{event_name}"
@@ -87,6 +88,7 @@ Rails.application.routes.draw do
           resources :readings, only: :create
         end
       end
+      resource :feature, only: :create, module: :job_offers
       resources :job_applications, path: "candidatures" do
         member do
           get :cvlm

--- a/spec/requests/admin/job_offers/features_spec.rb
+++ b/spec/requests/admin/job_offers/features_spec.rb
@@ -54,4 +54,27 @@ RSpec.describe "Admin::JobOffers::Features" do
       end
     end
   end
+
+  describe "DELETE /admin/offresdemploi/:job_offer_id/feature" do
+    subject(:unfeature_request) { delete admin_job_offer_feature_path(job_offer) }
+
+    let(:job_offer) { create(:job_offer, featured: true) }
+
+    context "when administrator can feature" do
+      it "removes the featured flag and redirects back with the success notice" do
+        expect { unfeature_request }.to change { job_offer.reload.featured }.from(true).to(false)
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.destroy.success"))
+      end
+    end
+
+    context "when administrator cannot feature" do
+      before { allow_any_instance_of(Ability).to receive(:can?).and_return(false) }
+
+      it "does not change the offer and responds with forbidden" do
+        expect { unfeature_request }.not_to change { job_offer.reload.featured }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/job_offers/features_spec.rb
+++ b/spec/requests/admin/job_offers/features_spec.rb
@@ -46,11 +46,10 @@ RSpec.describe "Admin::JobOffers::Features" do
     context "when the identifier matches no offer" do
       let(:identifier) { "unknown-reference" }
 
-      it "does not change any offer and redirects back with the error notice" do
-        job_offer
+      it "does not change any offer and redirects back with the not_found notice" do
         expect { feature_request }.not_to change { job_offer.reload.featured }
         expect(response).to redirect_to(admin_job_offers_path)
-        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.error"))
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.not_found"))
       end
     end
   end

--- a/spec/requests/admin/job_offers/features_spec.rb
+++ b/spec/requests/admin/job_offers/features_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::JobOffers::Features" do
+  before { sign_in create(:administrator) }
+
+  describe "POST /admin/offresdemploi/:job_offer_id/feature" do
+    subject(:feature_request) { post admin_job_offer_feature_path(job_offer) }
+
+    let(:job_offer) { create(:job_offer) }
+
+    context "when administrator can feature" do
+      it "marks as featured and redirects back with the success notice" do
+        expect { feature_request }.to change { job_offer.reload.featured }.to(true)
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.success"))
+      end
+    end
+
+    context "when administrator cannot feature" do
+      before { allow_any_instance_of(Ability).to receive(:can?).and_return(false) }
+
+      it "does not feature the offer and responds with forbidden" do
+        expect { feature_request }.not_to change { job_offer.reload.featured }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST /admin/offresdemploi/feature" do
+    subject(:feature_request) { post feature_admin_job_offers_path, params: {job_offer_identifier: identifier} }
+
+    let(:job_offer) { create(:job_offer) }
+
+    context "when the identifier matches an existing offer" do
+      let(:identifier) { job_offer.identifier }
+
+      it "marks the matched offer as featured and redirects back with the success notice" do
+        expect { feature_request }.to change { job_offer.reload.featured }.from(false).to(true)
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.success"))
+      end
+    end
+
+    context "when the identifier matches no offer" do
+      let(:identifier) { "unknown-reference" }
+
+      it "does not change any offer and redirects back with the error notice" do
+        job_offer
+        expect { feature_request }.not_to change { job_offer.reload.featured }
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.error"))
+      end
+    end
+  end
+end

--- a/spec/requests/admin/job_offers/features_spec.rb
+++ b/spec/requests/admin/job_offers/features_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe "Admin::JobOffers::Features" do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context "when the update fails" do
+      before do
+        allow_any_instance_of(JobOffer).to receive(:update) do |instance, *|
+          instance.errors.add(:base, "Boom")
+          false
+        end
+      end
+
+      it "redirects back with the error notice including the validation message" do
+        feature_request
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.create.error", message: "Boom"))
+      end
+    end
   end
 
   describe "POST /admin/offresdemploi/feature" do
@@ -73,6 +88,21 @@ RSpec.describe "Admin::JobOffers::Features" do
       it "does not change the offer and responds with forbidden" do
         expect { unfeature_request }.not_to change { job_offer.reload.featured }
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the update fails" do
+      before do
+        allow_any_instance_of(JobOffer).to receive(:update) do |instance, *|
+          instance.errors.add(:base, "Boom")
+          false
+        end
+      end
+
+      it "redirects back with the error notice including the validation message" do
+        unfeature_request
+        expect(response).to redirect_to(admin_job_offers_path)
+        expect(flash[:notice]).to eq(I18n.t("admin.job_offers.features.destroy.error", message: "Boom"))
       end
     end
   end


### PR DESCRIPTION
# Description

Refactor et correction de la mise à la une / retrait de la une des offres d'emploi côté admin. En particulier, on affiche un message d'erreur différent si l'offre n'est pas trouvée, ou si elle ne peut pas être mise à la une pour une raison technique. 

En effet, précédemment, ces deux situations étaient confondues, donc l'agent·e ne pouvait pas comprendre pourquoi son offre n'était pas mise à la une (tel que décrit par #2133).

À lire commit par commit : 
- D'abord on CRUDifie la mise à la une
- Ensuite on CRUDifie le retrait de la une
- Ensuite on affiche une erreur si l'offre n'est pas trouvée
- Enfin on affiche une erreur si l'offre ne peut pas être mise à la une, avec un détail de l'erreur

# Review app

https://erecrutement-cvd-staging-pr2141.osc-fr1.scalingo.io

# Links

Closes #2133

# Screenshots

<img width="1702" height="1307" alt="CleanShot 2026-05-19 at 08 22 18" src="https://github.com/user-attachments/assets/5fb4e858-bd80-4f66-8e38-ad19cea39ec7" />

<img width="1699" height="1308" alt="CleanShot 2026-05-19 at 08 22 54" src="https://github.com/user-attachments/assets/8707e7b2-ab5c-4190-9981-74032d7e2609" />
