### PR TITLE
crudify suspension actions on users

### DIFF
--- a/app/controllers/admin/users/suspensions_controller.rb
+++ b/app/controllers/admin/users/suspensions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Admin::Users::SuspensionsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_user
+  before_action :authorize_suspension
+
+  def create
+    reason = params.require(:user).permit(:suspension_reason).fetch(:suspension_reason)
+    reason = nil if reason.blank?
+    @user.suspend!(reason)
+    redirect_back(fallback_location: [:admin, @user], notice: t(".success"))
+  end
+
+  def destroy
+    @user.unsuspend!
+    redirect_back(fallback_location: [:admin, @user], notice: t(".success"))
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def authorize_suspension
+    authorize! :suspend, @user
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -68,18 +68,6 @@ class Admin::UsersController < Admin::InheritedResourcesController
     end
   end
 
-  def suspend
-    reason = params.require(:user).permit(:suspension_reason).fetch(:suspension_reason)
-    reason = nil if reason.blank?
-    @user.suspend!(reason)
-    redirect_back(fallback_location: [:admin, @user], notice: t(".success"))
-  end
-
-  def unsuspend
-    @user.unsuspend!
-    redirect_back(fallback_location: [:admin, @user], notice: t(".success"))
-  end
-
   def photo
     send_data(
       @user.photo.big.read,

--- a/app/views/admin/users/_actions.html.haml
+++ b/app/views/admin/users/_actions.html.haml
@@ -22,7 +22,7 @@
           Raison :
           %em= user.suspension_reason.present? ? user.suspension_reason : 'Aucune raison donnée'
     - if can?(:suspend, user)
-      = link_to [:unsuspend, :admin, user], method: :post, data: {confirm: t('buttons.confirm')}, class: 'btn btn-primary mb-0' do
+      = link_to [:admin, user, :suspension], method: :delete, data: {confirm: t('buttons.confirm')}, class: 'btn btn-primary mb-0' do
         = t('buttons.unsuspend_user')
         = fa_icon('paper-plane', class: 'ml-1')
   - else
@@ -43,7 +43,7 @@
     .modal-dialog{role: :document}
       .modal-content
         .modal-body
-          = simple_form_for(user, url: [:suspend, :admin, user], method: :post) do |f|
+          = simple_form_for(user, url: [:admin, user, :suspension], method: :post) do |f|
             = f.input :suspension_reason, as: :text
             .form-actions.d-flex.mt-4
               %button{type: :button, class: 'btn btn-link mb-0', data: {dismiss: :modal}, aria: {label: t('buttons.close')}}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -602,10 +602,11 @@ fr:
           other: "%{count} résultats de recherche"
       listing:
         title: "Ajouter/supprimer ce candidat de mes listes"
-      suspend:
-        success: "Utilisateur suspendu"
-      unsuspend:
-        success: "Utilisateur réactivé"
+      suspensions:
+        create:
+          success: "Utilisateur suspendu"
+        destroy:
+          success: "Utilisateur réactivé"
       user:
         my_preferred_user_lists: "Listes"
         remove_user: "Retirer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,8 +118,9 @@ Rails.application.routes.draw do
       member do
         get :listing, :photo
         put :update_listing
-        post :suspend, :unsuspend, :send_job_offer
+        post :send_job_offer
       end
+      resource :suspension, only: %i[create destroy], module: :users
     end
     resources :job_applications, path: "candidatures", only: %i[index show update] do
       member do

--- a/spec/requests/admin/users/suspensions_spec.rb
+++ b/spec/requests/admin/users/suspensions_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Users::Suspensions" do
+  let(:admin) { create(:administrator) }
+  let(:user) { create(:confirmed_user) }
+
+  before { sign_in admin }
+
+  describe "POST /admin/candidats/:user_id/suspension" do
+    subject(:create_request) {
+      post admin_user_suspension_path(user), params: {user: {suspension_reason: "Raison"}}
+    }
+
+    it "suspends the user" do
+      expect { create_request }.to change { user.reload.suspended? }.to(true)
+    end
+
+    it "redirects to the user" do
+      expect(create_request).to redirect_to(admin_user_path(user))
+    end
+  end
+
+  describe "DELETE /admin/candidats/:user_id/suspension" do
+    subject(:destroy_request) { delete admin_user_suspension_path(user) }
+
+    before { user.suspend! }
+
+    it "unsuspends the user" do
+      expect { destroy_request }.to change { user.reload.suspended? }.to(false)
+    end
+
+    it "redirects to the user" do
+      expect(destroy_request).to redirect_to(admin_user_path(user))
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -409,5 +409,4 @@ RSpec.describe "Admin::Users" do
       end
     end
   end
-
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -410,29 +410,4 @@ RSpec.describe "Admin::Users" do
     end
   end
 
-  describe "POST /admin/candidats/:id/suspend" do
-    subject(:suspend_request) { post suspend_admin_user_path(user), params: {user: {suspension_reason: ""}} }
-
-    it "redirects to user" do
-      expect(suspend_request).to redirect_to(admin_user_path(user))
-    end
-
-    it "suspends the user" do
-      expect { suspend_request }.to change { user.reload.suspended? }.to(true)
-    end
-  end
-
-  describe "POST /admin/candidats/:id/unsuspend" do
-    subject(:unsuspend_request) { post unsuspend_admin_user_path(user) }
-
-    before { user.suspend! }
-
-    it "redirects to user" do
-      expect(unsuspend_request).to redirect_to(admin_user_path(user))
-    end
-
-    it "unsuspends the user" do
-      expect { unsuspend_request }.to change { user.reload.suspended? }.to(false)
-    end
-  end
 end


### PR DESCRIPTION
# Description
Refacto et épuration de deux routes customs :
La PR remplace les routes et actions custom suspend / unsuspend sur les users par des routes "resourceful" :

Les routes custom ont été supprimées
nouvelles routes (create et destroy) ajoutées
nouveau controller ajouté
URL dans le template a été mise à jour
les tests ont été mis à jour

# Review app

https://erecrutement-cvd-staging-pr2145.osc-fr1.scalingo.io

# Links

La PR répond en partie au ticket 2109
https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/2109 mais ne le ferme pas. Il y a d'autres routes/actions à modifier de la même manière.


# Screenshots

<img width="2902" height="1486" alt="image" src="https://github.com/user-attachments/assets/544fd820-7168-43e5-bb53-3e2ec67a6a8b" />


<img width="2898" height="1496" alt="image" src="https://github.com/user-attachments/assets/4819e98b-7858-44f4-af10-1137ec534484" />
