### PR TITLE
2109/crudify activation adminitrator

### DIFF
--- a/app/controllers/admin/settings/administrators/activations_controller.rb
+++ b/app/controllers/admin/settings/administrators/activations_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Admin::Settings::Administrators::ActivationsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_administrator
+  before_action :authorize_activation
+
+  def create
+    @administrator.deactivate
+    respond_to do |format|
+      format.html { redirect_to %i[admin settings root], notice: t(".success") }
+      format.json { head :no_content }
+    end
+  end
+
+  def destroy
+    @administrator.reactivate
+    respond_to do |format|
+      format.html { redirect_to %i[admin settings root], notice: t(".success") }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def set_administrator
+    @administrator = Administrator.find(params[:administrator_id])
+  end
+
+  def authorize_activation
+    authorize! :manage, @administrator
+  end
+end

--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -85,26 +85,6 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
     end
   end
 
-  # POST /admin/settings/administrators/1/deactivate
-  # POST /admin/settings/administrators/1/deactivate.json
-  def deactivate
-    @administrator.deactivate
-    respond_to do |format|
-      format.html { redirect_to %i[admin settings root], notice: t(".success") }
-      format.json { head :no_content }
-    end
-  end
-
-  # POST /admin/settings/administrators/1/reactivate
-  # POST /admin/settings/administrators/1/reactivate.json
-  def reactivate
-    @administrator.reactivate
-    respond_to do |format|
-      format.html { redirect_to %i[admin settings root], notice: t(".success") }
-      format.json { head :no_content }
-    end
-  end
-
   # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions
   # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions.json
   def resend_confirmation_instructions

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -44,10 +44,10 @@
             = link_to fa_icon('arrows-rotate'), [:resend_confirmation_instructions, :admin, :settings, administrator], method: :post, title: t('buttons.resend_confirmation_instructions'), data: {confirm: t('buttons.confirm')}
       - if can?(:deactivate, administrator) && administrator.active?
         %li.list-inline-item
-          = link_to fa_icon('close'), [:deactivate, :admin, :settings, administrator], method: :post, title: t('buttons.deactivate'), data: {confirm: t('buttons.confirm')}
+          = link_to fa_icon('close'), [:admin, :settings, administrator, :activation], method: :post, title: t('buttons.deactivate'), data: {confirm: t('buttons.confirm')}
       - if can?(:reactivate, administrator) && administrator.inactive?
         %li.list-inline-item
-          = link_to fa_icon('check'), [:reactivate, :admin, :settings, administrator], method: :post, title: t('buttons.reactivate'), data: {confirm: t('buttons.confirm')}
+          = link_to fa_icon('check'), [:admin, :settings, administrator, :activation], method: :delete, title: t('buttons.reactivate'), data: {confirm: t('buttons.confirm')}
       - if can?(:destroy, administrator) && administrator.inactive?
         %li.list-inline-item
           = link_to fa_icon('trash'), [:admin, :settings, administrator], method: :delete, remote: true, title: t('buttons.destroy'), data: {confirm: t('buttons.confirm')}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -704,10 +704,11 @@ fr:
           transfer_email_label: "Email du nouveau propriétaire des offres"
           submit: "Transférer"
           list: "Liste des offres"
-        deactivate:
-          success: "Compte désactivé"
-        reactivate:
-          success: "Compte réactivé"
+        activations:
+          create:
+            success: "Compte désactivé"
+          destroy:
+            success: "Compte réactivé"
         resend_confirmation_instructions:
           success: "Invitation renvoyée !"
       cmgs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,10 +183,9 @@ Rails.application.routes.draw do
         member do
           post :resend_confirmation_instructions
           post :send_unlock_instructions
-          post :deactivate
-          post :reactivate
           post :transfer
         end
+        resource :activation, only: %i[create destroy], module: :administrators
       end
       resources :employers, :categories do
         member do

--- a/spec/requests/admin/settings/administrators/activations_spec.rb
+++ b/spec/requests/admin/settings/administrators/activations_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Admin::Settings::Administrators::Activations" do
   before { sign_in create(:administrator) }
 
   describe "POST /admin/parametres/administrateurs/:administrator_id/activation" do
-    let(:administrator) { create(:administrator) }
-
     subject(:create_request) { post admin_settings_administrator_activation_path(administrator) }
+
+    let(:administrator) { create(:administrator) }
 
     it "deactivates the administrator" do
       expect { create_request }.to change { administrator.reload.inactive? }.to(true)
@@ -20,9 +20,9 @@ RSpec.describe "Admin::Settings::Administrators::Activations" do
   end
 
   describe "DELETE /admin/parametres/administrateurs/:administrator_id/activation" do
-    let(:administrator) { create(:administrator, :deactivated) }
-
     subject(:destroy_request) { delete admin_settings_administrator_activation_path(administrator) }
+
+    let(:administrator) { create(:administrator, :deactivated) }
 
     it "reactivates the administrator" do
       expect { destroy_request }.to change { administrator.reload.active? }.to(true)

--- a/spec/requests/admin/settings/administrators/activations_spec.rb
+++ b/spec/requests/admin/settings/administrators/activations_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Settings::Administrators::Activations" do
+  before { sign_in create(:administrator) }
+
+  describe "POST /admin/parametres/administrateurs/:administrator_id/activation" do
+    let(:administrator) { create(:administrator) }
+
+    subject(:create_request) { post admin_settings_administrator_activation_path(administrator) }
+
+    it "deactivates the administrator" do
+      expect { create_request }.to change { administrator.reload.inactive? }.to(true)
+    end
+
+    it "redirects to settings root" do
+      expect(create_request).to redirect_to(admin_settings_root_path)
+    end
+  end
+
+  describe "DELETE /admin/parametres/administrateurs/:administrator_id/activation" do
+    let(:administrator) { create(:administrator, :deactivated) }
+
+    subject(:destroy_request) { delete admin_settings_administrator_activation_path(administrator) }
+
+    it "reactivates the administrator" do
+      expect { destroy_request }.to change { administrator.reload.active? }.to(true)
+    end
+
+    it "redirects to settings root" do
+      expect(destroy_request).to redirect_to(admin_settings_root_path)
+    end
+  end
+end

--- a/spec/requests/admin/settings/administrators_spec.rb
+++ b/spec/requests/admin/settings/administrators_spec.rb
@@ -188,34 +188,6 @@ RSpec.describe "Admin::Settings::Administrators" do
     end
   end
 
-  describe "POST /admin/parametres/administrateurs/:id/deactivate" do
-    subject(:deactivate_request) { post deactivate_admin_settings_administrator_path(administrator) }
-
-    let(:administrator) { create(:administrator) }
-
-    it "deactivates the administrator" do
-      expect { deactivate_request }.to change { administrator.reload.inactive? }.to(true)
-    end
-
-    it "redirects to admin settings" do
-      expect(deactivate_request).to redirect_to(admin_settings_root_path)
-    end
-  end
-
-  describe "POST /admin/parametres/administrateurs/:id/reactivate" do
-    subject(:reactivate_request) { post reactivate_admin_settings_administrator_path(administrator) }
-
-    let(:administrator) { create(:administrator, :deactivated) }
-
-    it "reactivates the administrator" do
-      expect { reactivate_request }.to change { administrator.reload.active? }.to(true)
-    end
-
-    it "redirects to admin settings" do
-      expect(reactivate_request).to redirect_to(admin_settings_root_path)
-    end
-  end
-
   describe "POST /admin/parametres/administrateurs/:id/transfer" do
     subject(:transfer_request) do
       post transfer_admin_settings_administrator_path(administrator), params: {transfer_email:}


### PR DESCRIPTION
# Description

Refacto et épuration de deux routes customs :
La PR remplace les routes et actions custom `deactivate / reactivate` sur les users admin (paramètres -> comptes utilisateurs) par des routes "resourceful" :

- Les routes custom ont été supprimées
- nouvelles routes (create et destroy) ajoutées
- nouveau controller ajouté
- URL dans le template a été mise à jour
- les tests ont été mis à jour

# Review app
https://erecrutement-cvd-staging-pr2147.osc-fr1.scalingo.io

# Links
La PR répond en partie au ticket 2109
https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/issues/2109 mais ne le ferme pas. Il y a d'autres routes/actions à modifier de la même manière.
