### PR TITLE
prevent API call during test, securable failing test fixe

### DIFF
--- a/spec/models/concerns/securable_spec.rb
+++ b/spec/models/concerns/securable_spec.rb
@@ -66,11 +66,16 @@ RSpec.describe Securable do
       let!(:securable) { build(:email_attachment, content: content) }
 
       context "when the content type is pdf" do
+        before { allow(ENV).to receive(:fetch).with("SECURE_CONTENT", false).and_return("1") }
+
         let(:content) {
           Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/document.pdf"), "application/pdf")
         }
 
-        it { expect { commit }.to have_enqueued_job { SecureContentJob }.with(securable.id) }
+        it do
+          commit
+          expect(SecureContentJob).to have_been_enqueued.with(id: securable.id)
+        end
       end
 
       context "when the content type is not pdf" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require "devise"
 require "aasm/rspec"
 
 InvisibleCaptcha.timestamp_enabled = false
+OmniAuth.config.test_mode = true
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
# Description

Pendant l'exécution des tests, un appel API était envoyé vers l'API France-Connect, ce qui n'est pas souhaitable. La PR active le `test_mode` de OmniAuth de manière globale pour empêcher cet appel extern.
De plus, la PR fixe un test (dans `securable_spec.rb`) qui échouait. Désormais, tous les tests sont vert. 

# Review app

https://erecrutement-cvd-staging-pr2148.osc-fr1.scalingo.io

# Links
PR répond en partie au ticket #2110 mais ne le ferme pas. 

# Screenshots
<img width="1246" height="154" alt="image" src="https://github.com/user-attachments/assets/59b4e17b-2217-4464-ad55-532f2cae4c97" />
