### PR TITLE
Add SimpleCov for test coverage reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,9 @@ group :test do
 
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers", "~> 5.3.0"
+
+  # Code coverage
+  gem "simplecov", require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    docile (1.4.1)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -551,6 +552,12 @@ GEM
     simple_form (5.2.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -706,6 +713,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq (~> 7.1.6)
   simple_form
+  simplecov
   sprockets-rails
   standard
   stimulus-rails (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Pour lancer les test RSpec :
 bundle exec rspec
 ```
 
+## Couverture de test
+
+La couverture de test est mesurée avec [SimpleCov](https://github.com/simplecov-ruby/simplecov). Après avoir exécuté toute la suite de tests avec `bundle exec rspec`, ouvrir le rapport généré :
+
+```
+open coverage/index.html
+```
+
 ## Style de code
 
 Pour lancer l'outil d'analyse statique de formatage Rubocop :

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
+require "simplecov"
+SimpleCov.start
+
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
# Description

Ajout de [SimpleCov](https://github.com/simplecov-ruby/simplecov) pour mesurer la couverture de test de la suite RSpec.

Permet d'alimenter le ticket #2110 avec les specs à compléter.

# Links

Refs #2110


# Screenshots

<img width="1705" height="1317" alt="CleanShot 2026-05-28 at 08 26 50" src="https://github.com/user-attachments/assets/6b28863e-b27d-40da-a9d9-2e5560ecf796" />
