### PR TITLE
Add DailySummary and AltchaSolution model specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## Testing
+
+- One `expect` per test. Each example asserts a single behavior; when you need several assertions, split them into separate `it` blocks.
+- When a test fits on a single line, its description adds nothing — omit it and use the one-liner form. For example, prefer:
+
+  ```ruby
+  it { expect(described_class.verify_and_save(encode(solution_params))).to be_truthy }
+  ```
+
+  over:
+
+  ```ruby
+  it "returns a truthy value for a valid submission" do
+    expect(described_class.verify_and_save(encode(solution_params))).to be_truthy
+  end
+  ```
+- For each `describe` that targets a method under test, declare a named `subject` for that method. For example, prefer:
+
+  ```ruby
+  describe ".verify_and_save" do
+    subject(:verify_and_save) { described_class.verify_and_save(encoded) }
+
+    it { expect(verify_and_save).to be_truthy }
+  end
+  ```
+
+  over:
+
+  ```ruby
+  describe ".verify_and_save" do
+    it { expect(described_class.verify_and_save(encoded)).to be_truthy }
+  end
+  ```
+- When a spec needs helper methods, declare them at the bottom of the file, in a `private` section. For example, prefer:
+
+  ```ruby
+  RSpec.describe DailySummary do
+    subject(:summary) { described_class.new }
+
+    it { expect(summary_kinds).to be_empty }
+
+    private
+
+    def summary_kinds
+      summary.concerned_administrators.flat_map(&:kind)
+    end
+  end
+  ```
+
+  over defining the helper near the top of the example group.

--- a/spec/models/altcha_solution_spec.rb
+++ b/spec/models/altcha_solution_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AltchaSolution do
+  before { allow(Altcha).to receive(:hmac_key).and_return("test-hmac-key") }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:algorithm) }
+    it { is_expected.to validate_presence_of(:challenge) }
+    it { is_expected.to validate_presence_of(:salt) }
+    it { is_expected.to validate_presence_of(:signature) }
+    it { is_expected.to validate_presence_of(:number) }
+  end
+
+  describe ".verify_and_save" do
+    subject(:verify_and_save) { described_class.verify_and_save(encoded) }
+
+    context "with a valid submission" do
+      let(:encoded) { encode(solution_params) }
+
+      it { expect { verify_and_save }.to change(described_class, :count).by(1) }
+      it { expect(verify_and_save).to be_truthy }
+    end
+
+    context "when the payload is not valid base64-encoded JSON" do
+      let(:encoded) { Base64.encode64("definitely not json") }
+
+      it { expect(verify_and_save).to be false }
+    end
+
+    context "when the signature is forged" do
+      let(:encoded) { encode(solution_params.merge("signature" => "deadbeef")) }
+
+      it { expect { verify_and_save }.not_to change(described_class, :count) }
+      it { expect(verify_and_save).to be false }
+    end
+
+    context "when the challenge salt has expired" do
+      let(:encoded) { encode(solution_params(salt_time: (Altcha.timeout + 1.minute).ago)) }
+
+      it { expect(verify_and_save).to be false }
+    end
+
+    context "when replaying an already-saved solution" do
+      let(:encoded) { encode(solution_params) }
+
+      before { described_class.verify_and_save(encoded) }
+
+      it { expect { verify_and_save }.not_to change(described_class, :count) }
+      it { expect(verify_and_save).to be false }
+    end
+  end
+
+  describe ".cleanup" do
+    subject(:cleanup) { described_class.cleanup }
+
+    let!(:old) { described_class.create!(solution_params(number: 111).merge("created_at" => (Altcha.timeout + 1.minute).ago)) }
+    let!(:recent) { described_class.create!(solution_params(number: 222).merge("created_at" => 1.minute.ago)) }
+
+    before { cleanup }
+
+    it { expect(described_class.exists?(old.id)).to be false }
+    it { expect(described_class.exists?(recent.id)).to be true }
+  end
+
+  private
+
+  def solution_params(number: 123_456, salt_time: Time.zone.now)
+    salt = [salt_time.to_s, SecureRandom.hex(12)].join("|")
+    challenge = Digest::SHA256.hexdigest(salt + number.to_s)
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(Altcha.algorithm), Altcha.hmac_key, challenge)
+    {
+      "algorithm" => Altcha.algorithm,
+      "challenge" => challenge,
+      "salt" => salt,
+      "signature" => signature,
+      "number" => number
+    }
+  end
+
+  def encode(params)
+    Base64.encode64(params.to_json)
+  end
+end
+
+# == Schema Information
+#
+# Table name: altcha_solutions
+#
+#  id         :bigint           not null, primary key
+#  algorithm  :string
+#  challenge  :string
+#  number     :integer
+#  salt       :string
+#  signature  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_altcha_solutions  (algorithm,challenge,salt,signature,number) UNIQUE
+#

--- a/spec/models/daily_summary_spec.rb
+++ b/spec/models/daily_summary_spec.rb
@@ -3,11 +3,184 @@
 require "rails_helper"
 
 RSpec.describe DailySummary do
-  let(:job_offers) { create_list(:published_job_offer, 5) }
-  let(:job_offer) { job_offers.first }
-  let(:job_applications) { create_list(:job_application, 4, job_offer: job_offer) }
-  let(:job_application) { create(:job_application, job_offer: job_offer, state: :accepted) }
-  let(:summary) { described_class.new(day: Time.zone.now) }
+  subject(:summary) { described_class.new(day: Time.zone.now) }
 
-  it { expect(summary.prepare(Organization.first)).to be_truthy }
+  let(:organization) { Organization.first }
+
+  describe "#initialize" do
+    it { expect(described_class.new.instance_variable_get(:@day)).to eq(Date.yesterday) }
+  end
+
+  describe "#all_admins" do
+    subject(:all_admins) { summary.all_admins }
+
+    before { create(:administrator) }
+
+    it { expect(all_admins).to be_empty }
+  end
+
+  describe "#prepare" do
+    subject(:prepare) { summary.prepare(organization) }
+
+    it { expect(prepare).to be_truthy }
+  end
+
+  describe "#prepare_new_job_offers" do
+    subject(:prepare_new_job_offers) { summary.prepare_new_job_offers(organization) }
+
+    before { create(:job_offer_actor, job_offer:, administrator:, role: :employer) }
+
+    let(:job_offer) { create(:job_offer) }
+    let(:administrator) { create(:administrator) }
+
+    it { expect { prepare_new_job_offers }.to change { summary_kinds }.from([]).to(["NewJobOffer"]) }
+
+    context "with an offer created outside the day window" do
+      let(:job_offer) { create(:job_offer, created_at: 3.days.ago) }
+
+      it { expect { prepare_new_job_offers }.not_to(change { summary_kinds }) }
+    end
+  end
+
+  describe "#prepare_published_job_offers" do
+    subject(:prepare_published_job_offers) { summary.prepare_published_job_offers(organization) }
+
+    let(:job_offer) { create(:published_job_offer, published_at: Time.zone.now) }
+
+    before { create(:job_offer_actor, job_offer:, role: :employer) }
+
+    it { expect { prepare_published_job_offers }.to change { summary_kinds }.from([]).to(["PublishedJobOffer"]) }
+
+    context "with an offer published outside the day window" do
+      let(:job_offer) { create(:published_job_offer, published_at: 3.days.ago) }
+
+      it { expect { prepare_published_job_offers }.not_to(change { summary_kinds }) }
+    end
+  end
+
+  describe "#add_summary_infos_for_job_offer" do
+    subject(:add_summary_infos_for_job_offer) { summary.add_summary_infos_for_job_offer(job_offer, "NewJobOffer") }
+
+    before { create(:job_offer_actor, job_offer:, role: :employer) }
+
+    let(:job_offer) { create(:job_offer) }
+
+    it { expect { add_summary_infos_for_job_offer }.to change(concerned_administrators, :size).by(1) }
+
+    it "links the info to the offer edit page" do
+      add_summary_infos_for_job_offer
+      expect(concerned_administrators.first.summary_infos.first[:link])
+        .to eq(Rails.application.routes.url_helpers.edit_admin_job_offer_url(job_offer))
+    end
+
+    it "titles the info with the offer full title" do
+      add_summary_infos_for_job_offer
+      expect(concerned_administrators.first.summary_infos.first[:title]).to eq(job_offer.full_title)
+    end
+
+    context "when the administrator is already concerned" do
+      before { summary.add_summary_infos_for_job_offer(job_offer, "NewJobOffer") }
+
+      it { expect { add_summary_infos_for_job_offer }.not_to change(concerned_administrators, :size) }
+
+      it { expect { add_summary_infos_for_job_offer }.to change { concerned_administrators.first.summary_infos.size }.by(1) }
+    end
+  end
+
+  describe "#prepare_new_job_applications" do
+    subject(:prepare_new_job_applications) { summary.prepare_new_job_applications(organization) }
+
+    before do
+      create(:job_offer_actor, job_offer:, administrator:, role: :employer)
+      create(:job_application, job_offer:)
+    end
+
+    let(:job_offer) { create(:job_offer) }
+    let(:administrator) { create(:administrator) }
+
+    it { expect { prepare_new_job_applications }.to change { summary_kinds }.from([]).to(["NewJobApplication"]) }
+  end
+
+  describe "#add_summary_infos_for_job_application" do
+    let(:job_application) { create(:job_application, job_offer:) }
+    let(:job_offer) { create(:job_offer) }
+
+    context "without a new state" do
+      subject(:add_summary_infos_for_job_application) { summary.add_summary_infos_for_job_application(job_application) }
+
+      before { create(:job_offer_actor, job_offer:, role: :employer) }
+
+      it { expect { add_summary_infos_for_job_application }.to change { summary_kinds }.from([]).to(["NewJobApplication"]) }
+    end
+
+    context "with a new state" do
+      subject(:add_summary_infos_for_job_application) do
+        summary.add_summary_infos_for_job_application(job_application, "accepted")
+      end
+
+      before { create(:job_offer_actor, job_offer:, role: :grand_employer) }
+
+      it { expect { add_summary_infos_for_job_application }.to change { summary_kinds }.from([]).to(["AcceptedJobApplication"]) }
+
+      it "titles the info with the applicant name and the offer identifier" do
+        add_summary_infos_for_job_application
+        expect(concerned_administrators.first.summary_infos.first[:title])
+          .to eq("#{job_application.user.full_name} ##{job_offer.identifier}")
+      end
+    end
+  end
+
+  describe "#prepare_job_applications" do
+    subject(:prepare_job_applications) { summary.prepare_job_applications(organization) }
+
+    let(:job_application) { create(:job_application, job_offer:) }
+    let(:job_offer) { create(:job_offer) }
+
+    before do
+      create(:job_offer_actor, job_offer:, role: :grand_employer)
+      Audited::Audit.create!(
+        auditable: job_application,
+        action: "update",
+        audited_changes: {"state" => ["initial", "accepted"]}
+      )
+    end
+
+    it { expect { prepare_job_applications }.to change { summary_kinds }.from([]).to(["AcceptedJobApplication"]) }
+  end
+
+  describe "#send_mail" do
+    subject(:send_mail) { summary.send_mail(organization) }
+
+    before do
+      create(:job_offer_actor, administrator:, role: :employer)
+      summary.prepare_new_job_offers(organization)
+    end
+
+    let(:administrator) { create(:administrator) }
+
+    it { expect { send_mail }.to change { ActionMailer::Base.deliveries.size }.by(1) }
+
+    it "delivers to the concerned administrator" do
+      send_mail
+      expect(ActionMailer::Base.deliveries.last.to).to eq([administrator.email])
+    end
+  end
+
+  describe "#prepare_and_send" do
+    subject(:prepare_and_send) { summary.prepare_and_send }
+
+    before { create(:job_offer_actor, role: :employer) }
+
+    it { expect { prepare_and_send }.to change { ActionMailer::Base.deliveries.size }.by(1) }
+  end
+
+  private
+
+  def concerned_administrators
+    summary.instance_variable_get(:@concerned_administrators)
+  end
+
+  def summary_kinds
+    concerned_administrators.flat_map { |concerned| concerned.summary_infos.pluck(:kind) }
+  end
 end


### PR DESCRIPTION
## Résumé

- Documente dans `CLAUDE.md` les conventions d'écriture RSpec
- Ajoute les specs du modèle `AltchaSolution`
- Ajoute la suite de specs de `DailySummary`

Réf. #2110 (contribue à la complétion de la suite de tests, sans clôturer l'issue).
