### PR TITLE
add libyaml-dev to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     git \
     imagemagick \
     libpq-dev \
+    libyaml-dev \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Description

Après upgrade de la version de ruby vers 4.0.5, et quand j'ai voulu rebuild l'image docker, j'ai eu cette erreur:
```
61.84 An error occurred while installing psych (5.2.6), and Bundler cannot continue.
61.84 
61.84 In Gemfile:
61.84   cssbundling-rails was resolved to 1.4.0, which depends on
61.84     railties was resolved to 7.2.3.1, which depends on
61.84       irb was resolved to 1.15.2, which depends on
61.84         rdoc was resolved to 6.15.0, which depends on
61.84           psych
```
qui empêchait le build. 

J'ai eu ça comme réponse : 
>psych 5.x builds a C extension that links against libyaml. ruby:4.0.5-slim strips it out. Adding libyaml-dev provides the yaml.h header psych needs to compile.

J'ai donc ajouté cette librairie au docker file. 

# Review app

https://erecrutement-cvd-staging-pr2155.osc-fr1.scalingo.io

# Links

Pas de ticket pour cette PR. Il s'agit d'un problème technique. 

