### PR TITLE
Auto-validate file types without designated validators

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -327,22 +327,21 @@ class JobApplication < ApplicationRecord
   def requested_files_not_validated = errors.add(:state, :requested_files_missing, documents: requested_files)
 
   def requested_files_validated?
-    mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
-    requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
-    auto_validated_ids = JobApplicationFileType.automatically_validated.pluck(:id).to_set
     types_to_validate = (mandatory_type_ids & requested_type_ids) - auto_validated_ids
-    validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
     types_to_validate.subset?(validated_type_ids)
   end
 
-  def requested_files
-    mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
-    requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
-    auto_validated_ids = JobApplicationFileType.automatically_validated.pluck(:id).to_set
-    validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
-    unvalidated_ids = ((mandatory_type_ids & requested_type_ids) - validated_type_ids) - auto_validated_ids
-    JobApplicationFileType.where(id: unvalidated_ids).pluck(:name).join(", ")
-  end
+  def requested_files = JobApplicationFileType.where(id: unvalidated_ids).pluck(:name).join(", ")
+
+  def mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
+
+  def requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
+
+  def auto_validated_ids = JobApplicationFileType.automatically_validated.pluck(:id).to_set
+
+  def validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
+
+  def unvalidated_ids = ((mandatory_type_ids & requested_type_ids) - validated_type_ids) - auto_validated_ids
 
   def create_required_job_application_files
     existing_type_ids = job_application_files.reload.pluck(:job_application_file_type_id)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -329,7 +329,8 @@ class JobApplication < ApplicationRecord
   def requested_files_validated?
     mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
     requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
-    types_to_validate = mandatory_type_ids & requested_type_ids
+    auto_validated_ids = JobApplicationFileType.automatically_validated.pluck(:id).to_set
+    types_to_validate = (mandatory_type_ids & requested_type_ids) - auto_validated_ids
     validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
     types_to_validate.subset?(validated_type_ids)
   end
@@ -337,8 +338,9 @@ class JobApplication < ApplicationRecord
   def requested_files
     mandatory_type_ids = JobApplicationFileType.mandatory(state).pluck(:id).to_set
     requested_type_ids = job_application_files.pluck(:job_application_file_type_id).to_set
+    auto_validated_ids = JobApplicationFileType.automatically_validated.pluck(:id).to_set
     validated_type_ids = job_application_files.select(&:validated?).map(&:job_application_file_type_id).to_set
-    unvalidated_ids = (mandatory_type_ids & requested_type_ids) - validated_type_ids
+    unvalidated_ids = ((mandatory_type_ids & requested_type_ids) - validated_type_ids) - auto_validated_ids
     JobApplicationFileType.where(id: unvalidated_ids).pluck(:name).join(", ")
   end
 

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -102,6 +102,8 @@ class JobApplicationFileType < ApplicationRecord
 
     VALIDATOR_ROLE_MAPPING.any? { |flag, role_method| self[flag] && administrator.public_send(role_method) }
   end
+
+  def automatically_validated? = VALIDATOR_ROLE_MAPPING.keys.none? { self[it] }
 end
 
 # == Schema Information

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -91,6 +91,8 @@ class JobApplicationFileType < ApplicationRecord
     validate_by_payroll_manager: :payroll_manager?
   }.freeze
 
+  scope :automatically_validated, -> { where(VALIDATOR_ROLE_MAPPING.keys.index_with(false)) }
+
   has_many :job_application_files, dependent: :restrict_with_error
   has_many :visibility_rules, dependent: :destroy
   accepts_nested_attributes_for :visibility_rules, allow_destroy: true

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -9,7 +9,7 @@
   .ml-auto.d-flex.align-items-center
     - if type.check_only_admin_only?
       - if type.automatically_validated?
-        %span.badge.badge-light-gray.text-white= t('.automatically_validated')
+        %span.badge.badge-light-gray.text-white= JobApplicationFileType.human_attribute_name("kind/#{type.kind}")
       - elsif file.new_record?
         - klasses = %w(btn btn-success btn-raised btn-sm mb-0 mr-1)
         - klasses << 'opaque' unless file.validated?
@@ -30,7 +30,7 @@
           = fa_icon "xmark"
     - elsif file.document_content.present?
       - if type.automatically_validated?
-        %span.badge.badge-light-gray.text-white.mr-1= t('.automatically_validated')
+        %span.badge.badge-light-gray.text-white.mr-1= JobApplicationFileType.human_attribute_name("kind/#{type.kind}")
       - else
         - klasses = %w(btn btn-success btn-raised btn-sm mb-0 mr-1)
         - klasses << 'opaque' unless file.validated?

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -6,9 +6,11 @@
     .text-truncate= type.name
   - else
     .text-truncate.text-muted= type.name
-  .ml-auto.d-flex
+  .ml-auto.d-flex.align-items-center
     - if type.check_only_admin_only?
-      - if file.new_record?
+      - if type.automatically_validated?
+        %span.badge.badge-light-gray.text-white= t('.automatically_validated')
+      - elsif file.new_record?
         - klasses = %w(btn btn-success btn-raised btn-sm mb-0 mr-1)
         - klasses << 'opaque' unless file.validated?
         = link_to [:admin, @job_application, :job_application_files, {job_application_file: {job_application_file_type_id: type.id, is_validated: 1}}], class: klasses, title: t('.check'), remote: true, method: :post do
@@ -27,14 +29,17 @@
         = link_to [:admin, @job_application, file, :validation], class: klasses, title: t('.uncheck'), remote: true, method: :delete do
           = fa_icon "xmark"
     - elsif file.document_content.present?
-      - klasses = %w(btn btn-success btn-raised btn-sm mb-0 mr-1)
-      - klasses << 'opaque' unless file.validated?
-      = link_to [:admin, @job_application, file, :validation], class: klasses, title: t('.check'), remote: true, method: :post do
-        = fa_icon "check"
-      - klasses = %w(btn btn-danger btn-raised btn-sm mb-0 mr-1)
-      - klasses << 'opaque' unless file.invalidated?
-      = link_to [:admin, @job_application, file, :validation], class: klasses, title: t('.uncheck'), remote: true, method: :delete do
-        = fa_icon "xmark"
+      - if type.automatically_validated?
+        %span.badge.badge-light-gray.text-white.mr-1= t('.automatically_validated')
+      - else
+        - klasses = %w(btn btn-success btn-raised btn-sm mb-0 mr-1)
+        - klasses << 'opaque' unless file.validated?
+        = link_to [:admin, @job_application, file, :validation], class: klasses, title: t('.check'), remote: true, method: :post do
+          = fa_icon "check"
+        - klasses = %w(btn btn-danger btn-raised btn-sm mb-0 mr-1)
+        - klasses << 'opaque' unless file.invalidated?
+        = link_to [:admin, @job_application, file, :validation], class: klasses, title: t('.uncheck'), remote: true, method: :delete do
+          = fa_icon "xmark"
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}
       - if file.downloadable?
         - url = [:admin, job_application, file, {format: :pdf}]

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -403,7 +403,6 @@ fr:
         uncheck: "Invalider"
         download: "Télécharger"
         do_not_ask: "Ne plus demander"
-        automatically_validated: "Auto validé"
       job_application_file_upload:
         help: "Téléverser un fichier"
       validations:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -403,6 +403,7 @@ fr:
         uncheck: "Invalider"
         download: "Télécharger"
         do_not_ask: "Ne plus demander"
+        automatically_validated: "Auto validé"
       job_application_file_upload:
         help: "Téléverser un fichier"
       validations:

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -63,6 +63,28 @@ RSpec.describe JobApplicationFileType do
     end
   end
 
+  describe "#automatically_validated?" do
+    subject(:automatically_validated) { file_type.automatically_validated? }
+
+    context "when all validate_by_* flags are false" do
+      let(:file_type) do
+        build(:job_application_file_type,
+          validate_by_employer_recruiter: false,
+          validate_by_employment_authority: false,
+          validate_by_hr_manager: false,
+          validate_by_payroll_manager: false)
+      end
+
+      it { expect(automatically_validated).to be(true) }
+    end
+
+    context "when at least one validate_by_* flag is true" do
+      let(:file_type) { build(:job_application_file_type, validate_by_employer_recruiter: true) }
+
+      it { expect(automatically_validated).to be(false) }
+    end
+  end
+
   describe "scopes" do
     describe "#visible_by_user" do
       subject { described_class.visible_by_user(:phone_meeting) }

--- a/spec/models/job_application_file_type_spec.rb
+++ b/spec/models/job_application_file_type_spec.rb
@@ -285,6 +285,22 @@ RSpec.describe JobApplicationFileType do
       it { is_expected.not_to include(cover_letter_type) }
       it { is_expected.to include(other_type) }
     end
+
+    describe ".automatically_validated" do
+      subject { described_class.automatically_validated }
+
+      let!(:auto_validated) do
+        create(:job_application_file_type,
+          validate_by_employer_recruiter: false,
+          validate_by_employment_authority: false,
+          validate_by_hr_manager: false,
+          validate_by_payroll_manager: false)
+      end
+      let!(:manually_validated) { create(:job_application_file_type) }
+
+      it { is_expected.to include(auto_validated) }
+      it { is_expected.not_to include(manually_validated) }
+    end
   end
 end
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -260,6 +260,122 @@ RSpec.describe JobApplication do
     end
   end
 
+  describe "#requested_files_validated?" do
+    subject(:requested_files_validated) { job_application.requested_files_validated? }
+
+    let(:job_application) { create(:job_application, job_offer:, state: :financial_estimate) }
+    let(:job_application_file_type) do
+      create(:job_application_file_type, required: true, **validators).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+      end
+    end
+
+    before do
+      create(:job_application_file, job_application:, job_application_file_type:)
+      job_application.reload
+    end
+
+    context "when the file type has no designated validator" do
+      let(:validators) do
+        {
+          validate_by_employer_recruiter: false,
+          validate_by_employment_authority: false,
+          validate_by_hr_manager: false,
+          validate_by_payroll_manager: false
+        }
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the file type has at least one designated validator" do
+      let(:validators) { {validate_by_employer_recruiter: true} }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when the mandatory file has been validated" do
+      let(:validators) { {validate_by_employer_recruiter: true} }
+
+      before do
+        job_application.job_application_files.first.update_column(:is_validated, 1) # rubocop:disable Rails/SkipsModelValidations
+        job_application.reload
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+
+  describe "#requested_files" do
+    subject(:requested_files) { job_application.requested_files }
+
+    let(:job_application) { create(:job_application, job_offer:, state: :financial_estimate) }
+    let(:job_application_file_type) do
+      create(:job_application_file_type, required: true, **validators).tap do |jaft|
+        jaft.visibility_rules.where(by: :administrator).destroy_all
+        jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+      end
+    end
+
+    before do
+      create(:job_application_file, job_application:, job_application_file_type:)
+      job_application.reload
+    end
+
+    context "when the unvalidated file type has a designated validator" do
+      let(:validators) { {validate_by_employer_recruiter: true} }
+
+      it { is_expected.to eq("CV") }
+    end
+
+    context "when the unvalidated file type has no designated validator" do
+      let(:validators) do
+        {
+          validate_by_employer_recruiter: false,
+          validate_by_employment_authority: false,
+          validate_by_hr_manager: false,
+          validate_by_payroll_manager: false
+        }
+      end
+
+      it { is_expected.to eq("") }
+    end
+
+    context "when the mandatory file has been validated" do
+      let(:validators) { {validate_by_employer_recruiter: true} }
+
+      before do
+        job_application.job_application_files.first.update_column(:is_validated, 1) # rubocop:disable Rails/SkipsModelValidations
+        job_application.reload
+      end
+
+      it { is_expected.to eq("") }
+    end
+
+    context "with multiple unvalidated mandatory file types having a designated validator" do
+      let(:validators) { {validate_by_employer_recruiter: true} }
+      let(:other_file_type) do
+        create(
+          :job_application_file_type,
+          name: "Pièce d'identité",
+          required: true,
+          validate_by_employer_recruiter: true
+        ).tap do |jaft|
+          jaft.visibility_rules.where(by: :administrator).destroy_all
+          jaft.visibility_rules.create!(by: :administrator, state: :to_be_met)
+        end
+      end
+
+      before do
+        create(:job_application_file, job_application:, job_application_file_type: other_file_type)
+        job_application.reload
+      end
+
+      it { expect(requested_files.split(", ")).to contain_exactly("CV", "Pièce d'identité") }
+    end
+  end
+
   describe "cover_letter validations" do
     context "when job_offer does not require a cover letter" do
       let(:job_offer) { create(:job_offer, cover_lettre_required: false) }


### PR DESCRIPTION
# Description

Lorsqu'un type de document n'a aucun rôle validateur désigné, les boutons Valider / Invalider sont masqués dans l'onglet Documents et remplacés par un badge « Auto validé ». Le document n'est plus bloquant pour l'avancement de la candidature aux étapes suivantes.

# Plan de test

- [ ] Sur un type de document avec **au moins un** rôle validateur coché, vérifier que les boutons Valider et Invalider sont toujours affichés dans l'onglet Documents d'une candidature.
- [ ] Sur un type de document **sans aucun** rôle validateur coché, vérifier que les boutons Valider et Invalider sont masqués et qu'un badge « Auto validé » est affiché à la place.
- [ ] Pour un type sans validateur, vérifier que les actions d'upload et de téléchargement restent disponibles.
- [ ] Sur une candidature ayant un document obligatoire de type auto-validé non validé manuellement, vérifier que l'on peut faire avancer la candidature à l'étape suivante sans message d'erreur.
- [ ] Sur une candidature ayant un document obligatoire de type avec validateur non validé, vérifier que l'avancement à l'étape suivante reste bloqué avec le message d'erreur listant les documents manquants.

# Review app

https://erecrutement-cvd-staging-pr2163.osc-fr1.scalingo.io

# Links

Closes #2160

# Screenshots

<img width="1420" height="1236" alt="CleanShot 2026-05-31 at 10 18 25" src="https://github.com/user-attachments/assets/5b39ce18-7acc-4420-b699-e93fcb58d9cb" />

<img width="1704" height="1158" alt="CleanShot 2026-05-31 at 10 18 59" src="https://github.com/user-attachments/assets/dbbfe36c-7d39-4e01-896a-ef8ab8c37393" />

