### PR TITLE
Restrict "Ne plus demander" to on-demand documents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 A quick description of what the PR is adding / changing.
 
+# Test plan
+
+Functional verification steps (from the user / business perspective).
+
 # Review app
 
 https://erecrutement-cvd-staging-pr<PR-NUMBER>.osc-fr1.scalingo.io

--- a/app/controllers/admin/job_application_files_controller.rb
+++ b/app/controllers/admin/job_application_files_controller.rb
@@ -63,15 +63,25 @@ class Admin::JobApplicationFilesController < Admin::BaseController
   end
 
   def destroy
-    @job_application_file.destroy
-
-    respond_to do |format|
-      format.html { redirect_to([:admin, @job_application], notice: t(".success")) }
-      format.js do
-        @notification = t(".success")
-        render :file_operation_total
+    if @job_application_file.unrequest!
+      respond_to do |format|
+        format.html { redirect_to([:admin, @job_application], notice: t(".success")) }
+        format.js do
+          @notification = t(".success")
+          render :file_operation_total
+        end
+        format.json { head :no_content, location: [:admin, @job_application] }
       end
-      format.json { head :no_content, location: [:admin, @job_application] }
+    else
+      message = @job_application_file.errors.full_messages.join(", ")
+      respond_to do |format|
+        format.html { redirect_to([:admin, @job_application], alert: message) }
+        format.js do
+          @notification = message
+          render :file_operation_total
+        end
+        format.json { render json: @job_application_file.errors, status: :unprocessable_content }
+      end
     end
   end
 

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -39,6 +39,15 @@ class JobApplicationFile < ApplicationRecord
 
   def unrequestable? = !job_application_file_type.required?
 
+  def unrequest!
+    if unrequestable?
+      destroy
+    else
+      errors.add(:base, :cant_unrequest)
+      false
+    end
+  end
+
   private
 
   def max_downloadable_state

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -37,6 +37,8 @@ class JobApplicationFile < ApplicationRecord
 
   def downloadable? = JobApplication.states[job_application_state] < max_downloadable_state
 
+  def unrequestable? = !job_application_file_type.required?
+
   private
 
   def max_downloadable_state

--- a/app/views/admin/job_application_files/_job_application_file.html.haml
+++ b/app/views/admin/job_application_files/_job_application_file.html.haml
@@ -41,7 +41,8 @@
         = link_to t('.download'), url, target: "_blank", class: "btn btn-primary btn-raised btn-sm mb-0"
     - elsif file.persisted?
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}
-      - url = [:admin, job_application, file]
-      = link_to t('.do_not_ask'), url, method: :delete, remote: true, data: {confirm: t('buttons.confirm')}, class: "btn btn-primary btn-raised btn-sm mb-0 ml-1"
+      - if file.unrequestable?
+        - url = [:admin, job_application, file]
+        = link_to t('.do_not_ask'), url, method: :delete, remote: true, data: {confirm: t('buttons.confirm')}, class: "btn btn-primary btn-raised btn-sm mb-0 ml-1"
     - else
       = render partial: "/admin/job_application_files/job_application_file_upload", locals: {job_application: job_application, job_application_file: file, file_type: type}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1245,6 +1245,7 @@ fr:
               file_size_is_less_than: "Fichier trop volumineux, doit être max. 2Mo"
             base:
               not_authorized_to_validate: "Vous n'êtes pas autorisé(e) à valider ou invalider ce type de pièce"
+              cant_unrequest: "Ce document est obligatoire et ne peut pas être retiré"
         job_offer:
           attributes:
             base:

--- a/spec/controllers/admin/job_application_files_controller_spec.rb
+++ b/spec/controllers/admin/job_application_files_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::JobApplicationFilesController do
+  describe "DELETE #destroy" do
+    login_admin
+
+    subject(:destroy_file) do
+      delete :destroy, params: {job_application_id: job_application.to_param, id: job_application_file.to_param}
+    end
+
+    let(:job_application) { create(:job_application) }
+    let(:job_application_file_type) { create(:job_application_file_type, required:) }
+    let!(:job_application_file) do
+      create(:job_application_file, job_application:, job_application_file_type:)
+    end
+
+    context "when the file type is not required by default" do
+      let(:required) { false }
+
+      it { expect { destroy_file }.to change(JobApplicationFile, :count).by(-1) }
+    end
+
+    context "when the file type is required by default" do
+      let(:required) { true }
+
+      it { expect { destroy_file }.not_to change(JobApplicationFile, :count) }
+    end
+  end
+end

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -67,6 +67,25 @@ RSpec.describe JobApplicationFile do
       it { is_expected.to be(false) }
     end
   end
+
+  describe "#unrequestable?" do
+    subject(:unrequestable) { job_application_file.unrequestable? }
+
+    let(:job_application_file) { build(:job_application_file, job_application_file_type:) }
+    let(:job_application_file_type) { build(:job_application_file_type, required:) }
+
+    context "when the file type is not required by default" do
+      let(:required) { false }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the file type is required by default" do
+      let(:required) { true }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -86,6 +86,34 @@ RSpec.describe JobApplicationFile do
       it { is_expected.to be(false) }
     end
   end
+
+  describe "#unrequest!" do
+    subject(:unrequest) { job_application_file.unrequest! }
+
+    let!(:job_application_file) { create(:job_application_file, job_application_file_type:) }
+    let(:job_application_file_type) { create(:job_application_file_type, required:) }
+
+    context "when the file type is not required by default" do
+      let(:required) { false }
+
+      it { is_expected.to be_truthy }
+
+      it { expect { unrequest }.to change(described_class, :count).by(-1) }
+    end
+
+    context "when the file type is required by default" do
+      let(:required) { true }
+
+      it { is_expected.to be(false) }
+
+      it { expect { unrequest }.not_to change(described_class, :count) }
+
+      it do
+        unrequest
+        expect(job_application_file.errors).to be_of_kind(:base, :cant_unrequest)
+      end
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Description

Le bouton « Ne plus demander » n'est plus disponible pour les documents obligatoires par défaut pour tous les candidats. Il reste disponible uniquement pour les documents obligatoires seulement si un acteur notifié de l'offre en fait la demande.

Le bouton est masqué côté front et une garde côté back rejette le cas incohérent.

# Test plan

- Paramétrer un type de document comme « Obligatoire par défaut pour tous les candidats ».
- Ouvrir une candidature, onglet « Documents » : le bouton « Ne plus demander » n'apparaît pas pour ce document.
- Paramétrer un type de document comme « Obligatoire uniquement si l'un des acteurs notifiés dans l'offre en fait la demande ».
- Ouvrir une candidature, onglet « Documents » : le bouton « Ne plus demander » apparaît, et le clic retire bien le document de la liste.

# Review app

https://erecrutement-cvd-staging-pr2164.osc-fr1.scalingo.io

# Links

Closes #2158

# Screenshots

<img width="1413" height="536" alt="CleanShot 2026-06-01 at 08 20 47" src="https://github.com/user-attachments/assets/a0932b5b-c905-4b65-bd89-a352ad1d272a" />

<img width="1703" height="683" alt="CleanShot 2026-06-01 at 08 21 10" src="https://github.com/user-attachments/assets/46464a99-86b9-48b9-aba2-74c10bf42a41" />

