### PR TITLE
1972 cmg fix

### DIFF
--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -59,7 +59,7 @@ class Admin::JobOffersController < Admin::BaseController
     if @administrator.present?
       render action: "add_actor", layout: false
     else
-      render :add_actor_error
+      render :add_actor_error, status: :unprocessable_content
     end
   end
 
@@ -225,7 +225,9 @@ class Admin::JobOffersController < Admin::BaseController
   def find_administrator_and_build_job_offer_actor(job_offer, email, role)
     return nil if email.blank?
 
-    administrator = Administrator.find_by!(email:)
+    administrator = Administrator.find_by(email:)
+    return nil if administrator.nil?
+
     job_offer_actor = job_offer.job_offer_actors.build(role:)
     job_offer_actor.administrator = administrator
     administrator

--- a/spec/controllers/admin/job_offers_controller_spec.rb
+++ b/spec/controllers/admin/job_offers_controller_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Admin::JobOffersController do
             email: "pipo"
           }
 
-          post :add_actor, params: invalid_attributes
+          post :add_actor, params: invalid_attributes, xhr: true
 
           expect(response).not_to be_successful
         end


### PR DESCRIPTION
# Description

Les tests en pre prod ont relevé que Appuyer sur le bouton ajouter, pour ajouter un CMG, ne déclenchait aucune action. 
Il s'est avéré que quand un compte admin correspondant à l'adresse mail CMG sélectionnée dans le dropdown n'existait pas le serveur renvoyait une 404 au lieu d'envoyer une erreur. 
La PR répare ce problème. 
Désormais, si on trouve un compte admin correspondant on l'ajoute, sinon, on affiche un message d'erreur. 


# Review app

https://erecrutement-cvd-staging-pr2168.osc-fr1.scalingo.io

# Links

Closes #1972

# Screenshots

Quand email n'est pas lié à un compte admin : 

<img width="2080" height="1436" alt="image" src="https://github.com/user-attachments/assets/eb791db2-8f21-4832-994e-b37f76f75f05" />

quand email a un compte : 

<img width="2050" height="396" alt="image" src="https://github.com/user-attachments/assets/4b2e23a1-5692-4c8e-9d2f-df90527bed84" />
