### PR TITLE
Raise upload file size limit to 10 MB

### DIFF
--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -94,7 +94,7 @@ class Administrator < ApplicationRecord
 
   mount_uploader :photo, PhotoUploader, mount_on: :photo_file_name
 
-  validates :photo, file_size: {less_than: 1.megabyte}
+  validates :photo, file_size: {less_than: 10.megabytes}
   validate :password_complexity
   validate :email_conformance
   validates :email, presence: true, uniqueness: true

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -49,7 +49,7 @@ class JobApplication < ApplicationRecord
 
   mount_uploader :cover_letter, DocumentUploader, mount_on: :cover_letter_file_name
   validates :cover_letter, presence: true, if: -> { job_offer.cover_lettre_required? }
-  validates :cover_letter, file_size: {less_than: 2.megabytes}, if: -> { cover_letter_file_name_changed? }
+  validates :cover_letter, file_size: {less_than: 10.megabytes}, if: -> { cover_letter_file_name_changed? }
 
   scope :with_category, -> { where.not(category: nil) }
 

--- a/app/models/job_application_file.rb
+++ b/app/models/job_application_file.rb
@@ -11,7 +11,7 @@ class JobApplicationFile < ApplicationRecord
   belongs_to :job_application_file_type
 
   mount_uploader :content, DocumentUploader, mount_on: :content_file_name
-  validates :content, file_size: {less_than: 2.megabytes}
+  validates :content, file_size: {less_than: 10.megabytes}
 
   validates :content, presence: true, unless: proc { |file| file.do_not_provide_immediately }
   validates :job_application_file_type_id, uniqueness: {scope: :job_application_id} # rubocop:disable Rails/UniqueValidationWithoutIndex

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -28,7 +28,7 @@ class Profile < ApplicationRecord
   accepts_nested_attributes_for :department_profiles, reject_if: :all_blank
 
   mount_uploader :resume, DocumentUploader, mount_on: :resume_file_name
-  validates :resume, file_size: {less_than: 2.megabytes}, if: -> { resume.present? }
+  validates :resume, file_size: {less_than: 10.megabytes}, if: -> { resume.present? }
 
   validate :at_least_one_category_experience_level, on: :profile
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
 
   mount_uploader :photo, PhotoUploader, mount_on: :photo_file_name
 
-  validates :photo, file_size: {less_than: 1.megabyte}
+  validates :photo, file_size: {less_than: 10.megabytes}
   validates :first_name, :last_name, presence: true
   validates_plausible_phone :phone
   validates :phone, :current_position, presence: true, allow_nil: true

--- a/app/views/account/job_application_files/_file_name_upload.html.haml
+++ b/app/views/account/job_application_files/_file_name_upload.html.haml
@@ -17,7 +17,7 @@
               = f.hidden_field :job_application_file_type_id
             - data = { controller: "auto-submit", action: "change->auto-submit#submit", "file-drop-target" => "input" }
             %span= t('buttons.choose_file_drop_zone_html')
-            = f.input :content, label: false, hint: "Seuls les fichiers PDF de taille inférieure à 2Mo sont acceptés.", input_html: { data: data }
+            = f.input :content, label: false, hint: "Seuls les fichiers PDF de taille inférieure à 10Mo sont acceptés.", input_html: { data: data }
 - else
   %h3= file_type.name
   .rf-mb-1w.rf-mb-3w= file_hint(job_application_file)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -118,7 +118,7 @@ fr:
       your_account_creation: "Votre création de compte"
       resume: "CV"
       resume_html: "CV <abbr title='obligatoire'>*</abbr>"
-      cover_letter: "Lettre de motivation (PDF uniquement, max 2Mo)"
+      cover_letter: "Lettre de motivation (PDF uniquement, max 10Mo)"
   job_offers:
     no_bookmarks:
       title: Vous n'avez pas encore d'offres favorites
@@ -250,10 +250,10 @@ fr:
     job_application_files:
       update:
         success: "Le document a bien été modifié"
-        error: "Le fichier n'est pas valide, seuls les fichiers PDF de taille inférieure à 2Mo sont acceptés."
+        error: "Le fichier n'est pas valide, seuls les fichiers PDF de taille inférieure à 10Mo sont acceptés."
       create:
         success: "Le document a bien été modifié"
-        error: "Le fichier n'est pas valide, seuls les fichiers PDF de taille inférieure à 2Mo sont acceptés."
+        error: "Le fichier n'est pas valide, seuls les fichiers PDF de taille inférieure à 10Mo sont acceptés."
     job_applications:
       index:
         title: "Mes candidatures"
@@ -281,8 +281,8 @@ fr:
     profiles:
       edit:
         title: "Mon profil candidat"
-        resume: "CV (PDF uniquement, max 2Mo)"
-        resume_html: "CV (PDF uniquement, max 2Mo) <abbr title='obligatoire'>*</abbr>"
+        resume: "CV (PDF uniquement, max 10Mo)"
+        resume_html: "CV (PDF uniquement, max 10Mo) <abbr title='obligatoire'>*</abbr>"
       update:
         success: "Profil mis à jour !"
     users:
@@ -1233,16 +1233,16 @@ fr:
               dar_unvalidated: 'Une autorité d''emploi affiliée à l''offre doit cocher la case "DAR validée" pour permettre la poursuite du processus de recrutement.'
               immutable_rejected: "Cette candidature a été refusée, son état ne peut pas être modifié"
             cover_letter_content_type:
-              invalid: "PDF uniquement, max 2Mo"
+              invalid: "PDF uniquement, max 10Mo"
             resume_content_type:
-              invalid: "PDF uniquement, max 2Mo"
+              invalid: "PDF uniquement, max 10Mo"
             photo:
               file_size_is_less_than_or_equal_to: "Est trop volumineuse (ne doit pas dépasser %{count})"
               allowed_file_content_types: "au mauvais format (seuls les formats JPG et PNG sont acceptés)"
         job_application_file:
           attributes:
             content:
-              file_size_is_less_than: "Fichier trop volumineux, doit être max. 2Mo"
+              file_size_is_less_than: "Fichier trop volumineux, doit être max. 10Mo"
             base:
               not_authorized_to_validate: "Vous n'êtes pas autorisé(e) à valider ou invalider ce type de pièce"
               cant_unrequest: "Ce document est obligatoire et ne peut pas être retiré"
@@ -1266,7 +1266,7 @@ fr:
               not_allowed_because_suspended: "impossible de supprimer un compte tant qu'il est suspendu"
             current_position: "Poste actuel"
             photo:
-              file_size_is_less_than: "Fichier trop volumineux, doit être max. 2Mo"
+              file_size_is_less_than: "Fichier trop volumineux, doit être max. 10Mo"
     models:
       job_offer: "Offre"
     attributes:

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -245,9 +245,9 @@ fr:
       employer:
         code: "Ce champ est utilisé pour construire l'identifiant unique d'une annonce."
       job_application:
-        photo: "Format JPG ou PNG, max. 2Mo"
-        resume: "Format PDF, max. 2Mo"
-        cover_letter: "Format PDF, max. 2Mo"
+        photo: "Format JPG ou PNG, max. 10Mo"
+        resume: "Format PDF, max. 10Mo"
+        cover_letter: "Format PDF, max. 10Mo"
         website_url: "LinkedIn, Viadeo, portfolio, etc."
       organization:
         privacy_policy_url: "Ce lien est utilisé dans le formulaire de soumission d'une candidature"

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe Administrator do
   let(:administrator) { create(:administrator) }
 
+  describe "photo file size" do
+    subject(:administrator) { build(:administrator, :with_photo) }
+
+    before { allow(administrator.photo).to receive(:size).and_return(size) }
+
+    context "when smaller than 10 megabytes" do
+      let(:size) { 10.megabytes - 1 }
+
+      it { expect(administrator).to be_valid }
+    end
+
+    context "when 10 megabytes or larger" do
+      let(:size) { 10.megabytes }
+
+      it { expect(administrator.tap(&:valid?).errors[:photo]).to be_present }
+    end
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:invitees).inverse_of(:inviter) }
 

--- a/spec/models/job_application_file_spec.rb
+++ b/spec/models/job_application_file_spec.rb
@@ -5,6 +5,24 @@ RSpec.describe JobApplicationFile do
     it { is_expected.to delegate_method(:state).to(:job_application).with_prefix(true) }
   end
 
+  describe "content file size" do
+    subject(:job_application_file) { build(:job_application_file) }
+
+    before { allow(job_application_file.content).to receive(:size).and_return(size) }
+
+    context "when smaller than 10 megabytes" do
+      let(:size) { 10.megabytes - 1 }
+
+      it { expect(job_application_file).to be_valid }
+    end
+
+    context "when 10 megabytes or larger" do
+      let(:size) { 10.megabytes }
+
+      it { expect(job_application_file.tap(&:valid?).errors[:content]).to be_present }
+    end
+  end
+
   describe "#record_by_user" do
     subject(:record_by_user) { job_application_file.record_by_user }
 

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -417,6 +417,26 @@ RSpec.describe JobApplication do
         expect { job_application.valid? }.not_to raise_error
       end
     end
+
+    context "when the cover letter approaches the size limit" do
+      subject(:job_application) { build(:job_application, :with_cover_letter, job_offer:) }
+
+      let(:job_offer) { create(:job_offer, cover_lettre_required: true) }
+
+      before { allow(job_application.cover_letter).to receive(:size).and_return(size) }
+
+      context "when smaller than 10 megabytes" do
+        let(:size) { 10.megabytes - 1 }
+
+        it { expect(job_application).to be_valid }
+      end
+
+      context "when 10 megabytes or larger" do
+        let(:size) { 10.megabytes }
+
+        it { expect(job_application.tap(&:valid?).errors[:cover_letter]).to be_present }
+      end
+    end
   end
 
   describe "#end_user_state_number and #end_user_state" do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Profile do
     end
   end
 
+  describe "resume file size" do
+    subject(:profile) { build(:profile, :with_resume) }
+
+    before { allow(profile.resume).to receive(:size).and_return(size) }
+
+    context "when smaller than 10 megabytes" do
+      let(:size) { 10.megabytes - 1 }
+
+      it { expect(profile).to be_valid }
+    end
+
+    context "when 10 megabytes or larger" do
+      let(:size) { 10.megabytes }
+
+      it { expect(profile.tap(&:valid?).errors[:resume]).to be_present }
+    end
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:profileable) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe User do
     it { expect(user).to be_valid }
   end
 
+  describe "photo file size" do
+    subject(:user) { build(:user, :with_photo) }
+
+    before { allow(user.photo).to receive(:size).and_return(size) }
+
+    context "when smaller than 10 megabytes" do
+      let(:size) { 10.megabytes - 1 }
+
+      it { expect(user).to be_valid }
+    end
+
+    context "when 10 megabytes or larger" do
+      let(:size) { 10.megabytes }
+
+      it { expect(user.tap(&:valid?).errors[:photo]).to be_present }
+    end
+  end
+
   describe "associations" do
     it { is_expected.to have_one(:profile).dependent(:destroy) }
 


### PR DESCRIPTION
# Description

Passe la limite de taille des téléversements à 10 Mo pour tous les types de fichiers (documents PDF et photos). Auparavant les documents étaient limités à 2 Mo et les photos à 1 Mo. Les libellés de formulaires et messages d'erreur sont mis à jour, et des specs couvrent la nouvelle limite.

# Test plan

1. Profil candidat : téléverser un CV (PDF) de ~8 Mo → accepté.
2. Téléverser un CV de plus de 10 Mo → erreur « Format PDF, max. 10Mo ».
3. Joindre une lettre de motivation (PDF) de ~8 Mo à une candidature → acceptée.
4. Ajouter une pièce justificative (PDF) de ~8 Mo → acceptée ; au-delà de 10 Mo → refusée.
5. Téléverser une photo (JPG/PNG) de ~8 Mo sur le compte candidat / administrateur → acceptée.
6. Vérifier que les libellés des formulaires affichent bien « max 10Mo ».

# Review app

https://erecrutement-cvd-staging-pr2171.osc-fr1.scalingo.io

# Links

Closes #2161

