### PR TITLE
Add nkf gem so letter_opener can load kconv on Ruby 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ end
 
 group :development do
   gem "letter_opener"
+  gem "nkf" # Provides `kconv`, required by letter_opener and removed from Ruby's default gems in 3.4+
   gem "annotate"
 
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.3)
+    nkf (0.2.0)
     nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -684,6 +685,7 @@ DEPENDENCIES
   mail
   maintenance_tasks
   mini_magick
+  nkf
   omniauth-rails_csrf_protection
   omniauth_openid_connect (~> 0.8.0)
   ostruct


### PR DESCRIPTION
# Description

Sous Ruby 4.0, l'envoi d'e-mails en environnement de développement échouait (erreur 500) : la bibliothèque `kconv`, retirée des _default gems_ depuis Ruby 3.4, n'était plus chargée. Cette PR ajoute la gem `nkf` (qui la fournit). Changement limité au développement, sans impact en production.
