### PR TITLE
Improve model spec coverage

### DIFF
--- a/spec/models/daily_summary_concerned_administrator_spec.rb
+++ b/spec/models/daily_summary_concerned_administrator_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DailySummaryConcernedAdministrator do
+  describe "#add_summary_info" do
+    subject(:add_summary_info) { concerned_administrator.add_summary_info(info) }
+
+    let(:concerned_administrator) { described_class.new }
+    let(:info) { {kind: "NewJobOffer"} }
+
+    it { expect { add_summary_info }.to change(concerned_administrator.summary_infos, :size).by(1) }
+
+    it { expect(add_summary_info).to eq([info]) }
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -11,6 +11,40 @@ RSpec.describe Organization do
   it { is_expected.to validate_presence_of(:service_name) }
   it { is_expected.to validate_presence_of(:brand_name) }
   it { is_expected.to validate_presence_of(:prefix_article) }
+
+  describe "#name" do
+    subject(:name) { described_class.new(service_name: "DGSE").name }
+
+    it { is_expected.to eq("DGSE") }
+  end
+
+  describe "#possessive_article" do
+    subject(:possessive_article) { described_class.new(prefix_article:).possessive_article }
+
+    context "when the prefix article is \"le\"" do
+      let(:prefix_article) { "le" }
+
+      it { is_expected.to eq("du ") }
+    end
+
+    context "when the prefix article is \"la\"" do
+      let(:prefix_article) { "la" }
+
+      it { is_expected.to eq("de la ") }
+    end
+
+    context "when the prefix article is \"l'\"" do
+      let(:prefix_article) { "l'" }
+
+      it { is_expected.to eq("de l'") }
+    end
+
+    context "when the prefix article is unknown" do
+      let(:prefix_article) { "les" }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Description

Complète la couverture de tests de deux modèles existants, sans aucun changement de comportement : le résumé quotidien et l'organisation.

# Links

Refs #2110

