### PR TITLE
Cover mailers, jobs, uploaders and errors with specs

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -467,6 +467,25 @@
         79
       ],
       "note": "False positive: params[:job_application_file_id] is used only as a DB lookup key in find(). The dom_id value comes from the record's own persisted ID, not from the param."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 419,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails 7.2 reaches end-of-life on 2026-08-09; tracked for the Rails 8 upgrade, ignored until then"
     }
   ]
 }

--- a/spec/errors/forbidden_state_spec.rb
+++ b/spec/errors/forbidden_state_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ForbiddenState do
+  let(:data) { {state: "unknown_state"} }
+
+  describe "#data" do
+    subject(:error_data) { described_class.new(data).data }
+
+    it { is_expected.to eq(data) }
+  end
+
+  describe "#message" do
+    subject(:message) { described_class.new(data).message }
+
+    it { is_expected.to eq(data.to_s) }
+  end
+
+  describe "#error_message" do
+    subject(:error_message) { described_class.new(data).error_message }
+
+    it { is_expected.to eq("State unknown_state is not a known state") }
+  end
+end

--- a/spec/errors/job_offer_not_available_anymore_spec.rb
+++ b/spec/errors/job_offer_not_available_anymore_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JobOfferNotAvailableAnymore do
+  let(:data) { {job_offer_title: "Developer"} }
+
+  describe "#data" do
+    subject(:error_data) { described_class.new(data).data }
+
+    it { is_expected.to eq(data) }
+  end
+
+  describe "#message" do
+    subject(:message) { described_class.new(data).message }
+
+    it { is_expected.to eq(data.to_s) }
+  end
+end

--- a/spec/jobs/download_job_spec.rb
+++ b/spec/jobs/download_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open-uri"
+
+RSpec.describe DownloadJob do
+  subject(:perform) { described_class.new.perform(resource_type:, attribute_name:, id:, file_name:) }
+
+  let(:resource_type) { "EmailAttachment" }
+  let(:attribute_name) { "content" }
+  let(:id) { email_attachment.id }
+  let(:email_attachment) { create(:email_attachment) }
+  let(:file_name) { Rails.root.join("tmp/download_job_spec.pdf").to_s }
+
+  context "when the file name is blank" do
+    let(:id) { 0 }
+    let(:file_name) { "" }
+
+    it { is_expected.to be_nil }
+  end
+
+  context "when the file name is present" do
+    before do
+      allow(URI).to receive(:open).and_return(StringIO.new("downloaded content"))
+      perform
+    end
+
+    after { File.delete(file_name) if File.exist?(file_name) }
+
+    it { expect(email_attachment.reload.content.read).to eq("downloaded content") }
+
+    it { expect(File.exist?(file_name)).to be(false) }
+  end
+end

--- a/spec/jobs/zip_job_application_files_job_spec.rb
+++ b/spec/jobs/zip_job_application_files_job_spec.rb
@@ -43,4 +43,21 @@ RSpec.describe ZipJobApplicationFilesJob do
       }.not_to raise_error
     end
   end
+
+  describe "when a candidate has a resume" do
+    subject(:zip_entries) { Zip::File.open(ZipFile.find(id).zip.current_path).map(&:name) }
+
+    let(:id) { SecureRandom.uuid }
+    let(:user) { create(:user, first_name: "First name", last_name: "Last name") }
+    let(:resume) do
+      Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/document.pdf"), "application/pdf")
+    end
+
+    before do
+      user.profile.update!(resume:)
+      described_class.new.perform(zip_id: id, user_ids: [user.id])
+    end
+
+    it { is_expected.to include("#{user.full_name} - CV.pdf") }
+  end
 end

--- a/spec/mailers/applicant_notifications_mailer_spec.rb
+++ b/spec/mailers/applicant_notifications_mailer_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe ApplicantNotificationsMailer do
         expect(mail.body.encoded).to match(/vous pouvez répondre à cet email directement/)
       end
     end
+
+    context "when the email carries attachments" do
+      before { create(:email_attachment, email: email) }
+
+      it { expect(mail.attachments.map(&:filename)).to include("document.pdf") }
+    end
   end
 
   describe "notify_new_state" do
@@ -93,5 +99,90 @@ RSpec.describe ApplicantNotificationsMailer do
     }
 
     it { expect(notify_rejected.body.encoded).to match(/nous ne pouvons pas actuellement y donner une suite favorable/) }
+  end
+
+  describe "notify_withdrawn" do
+    subject(:notify_withdrawn) { described_class.with(user:, job_offer:).notify_withdrawn }
+
+    let(:job_application) { build_stubbed(:job_application) }
+    let(:user) { job_application.user }
+    let(:job_offer) { job_application.job_offer }
+
+    it {
+      expect(notify_withdrawn.subject).to eq(
+        "Votre candidature à l'offre #{job_offer.title} sur #{job_offer.organization.service_name} – Confirmation de votre désistement"
+      )
+    }
+
+    it { expect(notify_withdrawn.to).to match([user.email]) }
+
+    it { expect(notify_withdrawn.body.encoded).to match(/Le désistement suite à votre candidature/) }
+  end
+
+  describe "send_job_offer" do
+    subject(:send_job_offer) { described_class.send_job_offer(user, job_offer) }
+
+    let(:job_offer) { create(:job_offer) }
+
+    context "when the user accepts job offer mails" do
+      let(:user) { create(:user, receive_job_offer_mails: true) }
+
+      it { expect(send_job_offer.subject).to eq("Nouvelle offre") }
+
+      it { expect(send_job_offer.to).to eq([user.email]) }
+
+      it { expect(send_job_offer.body.encoded).to match(/Voici une nouvelle super offre/) }
+    end
+
+    context "when the user refuses job offer mails" do
+      let(:user) { create(:user, receive_job_offer_mails: false) }
+
+      it { expect(send_job_offer.message).to be_a(ActionMailer::Base::NullMail) }
+    end
+  end
+
+  describe "error_email" do
+    subject(:error_email) { described_class.error_email(user.email, "Sujet original") }
+
+    let(:user) { create(:user) }
+
+    it { expect(error_email.subject).to eq("[#{Organization.first.service_name}]") }
+
+    it { expect(error_email.to).to eq([user.email]) }
+
+    it { expect(error_email.body.encoded).to match(/Sujet original/) }
+  end
+
+  describe "notice_period_before_deletion" do
+    subject(:notice_period_before_deletion) { described_class.notice_period_before_deletion(user.id) }
+
+    let(:user) { create(:user) }
+
+    it {
+      expect(notice_period_before_deletion.subject).to eq(
+        "[#{user.organization.service_name}] Votre compte candidat : mise à jour nécessaire"
+      )
+    }
+
+    it { expect(notice_period_before_deletion.to).to eq([user.email]) }
+
+    it { expect(notice_period_before_deletion.body.encoded).to match(/sera supprimé automatiquement/) }
+  end
+
+  describe "deletion_notice" do
+    subject(:deletion_notice) { described_class.deletion_notice(user_email, "Jane Doe", organization.id) }
+
+    let(:organization) { Organization.first }
+    let(:user_email) { "candidat@example.com" }
+
+    it {
+      expect(deletion_notice.subject).to eq(
+        "[#{organization.service_name}] Votre compte candidat a été supprimé"
+      )
+    }
+
+    it { expect(deletion_notice.to).to eq([user_email]) }
+
+    it { expect(deletion_notice.body.encoded).to match(/suppression de votre compte candidat/) }
   end
 end

--- a/spec/mailers/platform_mailer_spec.rb
+++ b/spec/mailers/platform_mailer_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlatformMailer do
+  let(:organization) { Organization.first }
+  let(:service_name) { organization.service_name }
+
+  describe "confirmation_instructions" do
+    subject(:confirmation_instructions) { described_class.confirmation_instructions(record, "token-abc") }
+
+    context "when the record is a candidate" do
+      let(:record) { create(:user) }
+
+      it { expect(confirmation_instructions.subject).to eq("[#{service_name}] Instructions de confirmation") }
+
+      it { expect(confirmation_instructions.to).to eq([record.email]) }
+    end
+
+    context "when the record is an administrator" do
+      let(:record) { create(:administrator) }
+
+      it { expect(confirmation_instructions.subject).to eq("[#{service_name}] Instructions de confirmation") }
+
+      it { expect(confirmation_instructions.body.encoded).to match(/Un compte a été créé sur le site de recrutement/) }
+    end
+  end
+
+  describe "reset_password_instructions" do
+    subject(:reset_password_instructions) { described_class.reset_password_instructions(record, "token-abc") }
+
+    let(:record) { create(:user) }
+
+    it { expect(reset_password_instructions.subject).to eq("[#{service_name}] Instructions pour changer le mot de passe") }
+
+    it { expect(reset_password_instructions.to).to eq([record.email]) }
+  end
+
+  describe "unlock_instructions" do
+    subject(:unlock_instructions) { described_class.unlock_instructions(record, "token-abc") }
+
+    let(:record) { create(:user) }
+
+    it { expect(unlock_instructions.subject).to eq("[#{service_name}] Instructions pour déverrouiller le compte") }
+
+    it { expect(unlock_instructions.to).to eq([record.email]) }
+  end
+
+  describe "email_changed" do
+    subject(:email_changed) { described_class.email_changed(record) }
+
+    let(:record) { create(:user) }
+
+    it { expect(email_changed.subject).to eq("[#{service_name}] Courriel modifié") }
+
+    it { expect(email_changed.to).to eq([record.email]) }
+  end
+
+  describe "password_change" do
+    subject(:password_change) { described_class.password_change(record) }
+
+    let(:record) { create(:user) }
+
+    it { expect(password_change.subject).to eq("[#{service_name}] Mot de passe modifié") }
+
+    it { expect(password_change.to).to eq([record.email]) }
+  end
+end

--- a/spec/uploaders/common_uploader_spec.rb
+++ b/spec/uploaders/common_uploader_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommonUploader do
+  describe "#paperclip_path" do
+    subject(:paperclip_path) { described_class.new.paperclip_path }
+
+    context "when the storage is the local filesystem" do
+      before { allow(described_class).to receive(:storage).and_return("CarrierWave::Storage::File".safe_constantize) }
+
+      it { is_expected.to eq(":rails_root/public/system/:class/:attachment/:id_partition/:style/:basename.:extension") }
+    end
+
+    context "when the storage is Fog" do
+      before { allow(described_class).to receive(:storage).and_return("CarrierWave::Storage::Fog".safe_constantize) }
+
+      it { is_expected.to eq(":class/:attachment/:id_partition/:style/:basename.:extension") }
+    end
+  end
+end

--- a/spec/uploaders/logo_uploader_spec.rb
+++ b/spec/uploaders/logo_uploader_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LogoUploader do
+  describe "#fog_public" do
+    subject(:fog_public) { described_class.new.fog_public }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe "#content_type_allowlist" do
+    subject(:content_type_allowlist) { described_class.new.content_type_allowlist }
+
+    it { is_expected.to eq(%r{image/}) }
+  end
+end

--- a/spec/uploaders/zip_uploader_spec.rb
+++ b/spec/uploaders/zip_uploader_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ZipUploader do
+  describe "#content_type_allowlist" do
+    subject(:content_type_allowlist) { described_class.new.content_type_allowlist }
+
+    it { is_expected.to eq(%r{application/zip}) }
+  end
+
+  describe "#extension_allowlist" do
+    subject(:extension_allowlist) { described_class.new.extension_allowlist }
+
+    it { is_expected.to eq(%w[zip]) }
+  end
+
+  describe "#store_dir" do
+    subject(:store_dir) { described_class.new.store_dir }
+
+    it { is_expected.to eq("public/zip_files") }
+  end
+end


### PR DESCRIPTION
# Description

Complète les specs de plusieurs fichiers jusqu'à 100 % de couverture : mailers, jobs, uploaders et exceptions métier.

# Links

Refs #2110
