### PR TITLE
bug fix nested form in admin job_offers index and partial

### DIFF
--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -1,7 +1,7 @@
 .row
   - if defined?(list)
     .col-auto.align-self-center.text-center
-      = check_box_tag "job_offer_ids[]", job_offer.id, false, data: {action: "change->subcheckbox#propagate_upward", "subcheckbox-target": "downcheckbox", "selectall-target": "item"}
+      = check_box_tag "job_offer_ids[]", job_offer.id, false, data: {action: "change->subcheckbox#propagate_upward", "subcheckbox-target": "downcheckbox", "selectall-target": "item"}, form: "export_job_offers"
   .col
     .card.job-offer.mt-3{class: "card-state-#{job_offer.state}", id: dom_id(job_offer)}
       - notifications_count = job_offer.notifications_count

--- a/app/views/admin/job_offers/index.html.haml
+++ b/app/views/admin/job_offers/index.html.haml
@@ -13,7 +13,9 @@
             = fa_icon 'plus', class: 'mr-1'
             = t('.new_job_offer')
     = render partial: 'search'
-    = form_tag(exports_admin_job_offers_url, target: "_blank", data: {controller: "selectall", turbo: false}) do
+    = form_tag(exports_admin_job_offers_url, id: "export_job_offers", target: "_blank", data: {turbo: false}) do
+      -# inputs associated via form="export_job_offers"
+    %div{data: {controller: "selectall"}}
       .d-flex.align-items-end{data: { controller: 'subcheckbox'}}
         %label.h5.text-primary.mr-auto
           = t('.job_offers_filtered', count: @job_offers_filtered.count)
@@ -28,7 +30,7 @@
       .row
         .col-12
           %label
-            = check_box_tag "select_all", nil, nil, data: {action: "change->selectall#change"}, class: 'mr-2'
+            = check_box_tag "select_all", nil, nil, data: {action: "change->selectall#change"}, class: 'mr-2', form: "export_job_offers"
             Tout sélectionner
 
       .row{data: { controller: 'subcheckbox'}}
@@ -37,11 +39,11 @@
             .row
               .col-auto.align-self-center.text-center
                 %label
-                  = check_box_tag nil, nil, nil, data: {action: "change->subcheckbox#propagate_downward", "subcheckbox-target": "upcheckbox", "selectall-target": "page"}, class: 'mr-2'
+                  = check_box_tag nil, nil, nil, data: {action: "change->subcheckbox#propagate_downward", "subcheckbox-target": "upcheckbox", "selectall-target": "page"}, class: 'mr-2', form: "export_job_offers"
                   Sélectionner la page
             .row
               .col-auto.invisible
-                = check_box_tag "invisible checkbox used to get things aligned", "id", false
+                = check_box_tag "invisible checkbox used to get things aligned", "id", false, form: "export_job_offers"
               .col
                 .card.bg-transparent
                   .card-body
@@ -64,6 +66,6 @@
             .mt-5
               = will_paginate @job_offers_filtered, params: { controller: 'job_offers', action: controller.action_name }
             .text-right
-              = button_tag 'Exporter', type: "submit", class: "btn btn-primary btn-raised"
+              = button_tag 'Exporter', type: "submit", class: "btn btn-primary btn-raised", form: "export_job_offers"
           - else
             %em Aucun résultat


### PR DESCRIPTION
# Description

Le bouton "dupliquer" de la première offre d'emploi dans le BO exporte l'offre au lieu de le dupliquer. La PR vise à fixer ce problème. 

# Explication technique:
Sur la page index des offres d'emploi (/admin/offresdemploi), le bouton "Dupliquer" de la première offre de la liste déclenchait un export PDF au lieu de créer une copie de l'offre.

Cette page enveloppe l'ensemble des offres dans un `<form>` destiné à l'export (form_tag exports_admin_job_offers_url). En même temps, le bouton "Dupliquer" est généré par un button_to, ce qui produit aussi un `<form>` dans le rendu HTML.

Le HTML ne permet pas d'imbriquer des formulaires. Quand le navigateur rencontre un `<form>` à l'intérieur d'un autre `<form>` déjà ouvert, il ignore la balise ouvrante du formulaire intérieur — mais interprète sa balise fermante `</form>`, ce qui ferme le formulaire extérieur.
Le résultat c'est que le bouton "Dupliquer" de la première offre de la liste -> `<button type="submit">` appartient au formulaire d'export (formulaire extérieur). Le click sur ce bouton envoyait la requête poste du formulaire d'export. 

Comme le navigateur interprète la balise fermante du formulaire intérieur, le formulaire d'export est considéré fermé après la première offre et du coup toutes les offres suivantes fonctionnent correctement.

**Correction**
Le formulaire d'export est désormais un élément vide avec un id (export_job_offers). Les cases à cocher et le bouton "Exporter" lui sont rattachés via l'attribut HTML5 form="export_job_offers", sans être imbriqués dedans. Le `button_to` de chaque offre génère ainsi son propre formulaire indépendant.

# Test plan
Cliquer sur le bouton "dupliquer" de la première offre d'emploi côté admin (BO) pour dupliquer l'offre. Le bouton ne doit pas déclencher un export 

# Review app

https://erecrutement-cvd-staging-pr2185.osc-fr1.scalingo.io

# Links

Closes #2132

# Screenshots
<img width="2762" height="1388" alt="image" src="https://github.com/user-attachments/assets/c1135263-bd6c-4dbf-8ceb-b79fbd3eb7c3" />
