### PR TITLE
Extract the job application's job offer page into a RESTful resource

### DIFF
--- a/app/controllers/account/job_applications_controller.rb
+++ b/app/controllers/account/job_applications_controller.rb
@@ -10,10 +10,6 @@ class Account::JobApplicationsController < Account::BaseController
     @job_applications_finished = job_applications.rejecteds
   end
 
-  def job_offer
-    render layout: "account/job_application_display"
-  end
-
   # GET /account/job_applications/1
   # GET /account/job_applications/1.json
   def show

--- a/app/controllers/account/job_offers_controller.rb
+++ b/app/controllers/account/job_offers_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Account::JobOffersController < Account::BaseController
+  before_action :set_job_application
+
+  def show
+    @job_offer = @job_application.job_offer
+    render layout: "account/job_application_display"
+  end
+
+  private
+
+  def set_job_application
+    @job_application = current_user.job_applications.find(params[:job_application_id])
+  end
+end

--- a/app/controllers/account/withdrawals_controller.rb
+++ b/app/controllers/account/withdrawals_controller.rb
@@ -8,7 +8,7 @@ class Account::WithdrawalsController < Account::BaseController
   def create
     @job_application.reject!(rejection_reason:, from_user: true)
     respond_to do |format|
-      format.html { redirect_to job_offer_account_job_application_path(@job_application), notice: t(".success") }
+      format.html { redirect_to account_job_application_job_offer_path(@job_application), notice: t(".success") }
     end
   end
 

--- a/app/views/account/job_offers/show.html.haml
+++ b/app/views/account/job_offers/show.html.haml
@@ -2,17 +2,17 @@
 - unless @job_application.affected? || @job_application.rejected?
   .rf-input-group.rf-grid-row.justify-content-center.rf-mt-3w{data: {controller: "modal"}}
     %button.btn.rf-btn{data: {action: "modal#open"}}
-      = t('account.job_applications.job_offer.withdraw')
+      = t('.withdraw')
     %dialog.rf-modal{"data-modal-target" => "dialog", aria: {labelledby: "withdraw-modal-title"}, role: :dialog}
       .rf-container.rf-container--fluid.rf-grid-row.rf-grid-row--center
         .rf-col-12.rf-col-md-8.rf-col-lg-6
           .rf-modal__body
             .rf-modal__header
-              %button.rf-link.rf-fi-close-line.rf-link--close{data: {action: "modal#close"}, title: t('account.job_applications.job_offer.cancel')}
-                = t('account.job_applications.job_offer.cancel')
+              %button.rf-link.rf-fi-close-line.rf-link--close{data: {action: "modal#close"}, title: t('.cancel')}
+                = t('.cancel')
             .rf-modal__content.text-center
-              %p#withdraw-modal-title= t('account.job_applications.job_offer.withdraw_confirmation')
+              %p#withdraw-modal-title= t('.withdraw_confirmation')
             .rf-modal__footer.justify-content-center
-              = button_to t('account.job_applications.job_offer.confirm'), account_job_application_withdrawal_path(@job_application), class: "btn rf-btn rf-mr-6w", data: {turbo: false}
+              = button_to t('.confirm'), account_job_application_withdrawal_path(@job_application), class: "btn rf-btn rf-mr-6w", data: {turbo: false}
               %button.btn.rf-btn.rf-btn--secondary{data: {action: "modal#close"}}
-                = t('account.job_applications.job_offer.cancel')
+                = t('.cancel')

--- a/app/views/layouts/account/job_application_display.html.haml
+++ b/app/views/layouts/account/job_application_display.html.haml
@@ -24,8 +24,8 @@
               = t('.nav_files', count: 0)
 
           %li{role: "presentation"}
-            - job_offer_tab = controller.controller_name == 'job_applications' && controller.action_name  == 'job_offer'
-            = link_to [:job_offer, :account, @job_application], class: 'rf-tabs__tab', aria: {controls: 'tabpanel-job-offer', selected: job_offer_tab}, role: 'tab', tabindex: job_offer_tab ? 0 : -1, title: t('.nav_offer') do
+            - job_offer_tab = controller.controller_name == 'job_offers' && controller.action_name == 'show'
+            = link_to [:account, @job_application, :job_offer], class: 'rf-tabs__tab', aria: {controls: 'tabpanel-job-offer', selected: job_offer_tab}, role: 'tab', tabindex: job_offer_tab ? 0 : -1, title: t('.nav_offer') do
               = t('.nav_offer')
 
         - if emails_tab

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -266,7 +266,8 @@ fr:
         ongoing_none: "Aucune candidature en cours"
       job_application:
         created_at: "Candidaté il y a %{time_ago_in_words}"
-      job_offer:
+    job_offers:
+      show:
         withdraw: "Retirer ma candidature"
         withdraw_confirmation: "Souhaitez-vous retirer votre candidature ?"
         confirm: "Confirmer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,9 +233,7 @@ Rails.application.routes.draw do
         end
       end
       resources :job_applications, path: "mes-candidatures" do
-        member do
-          get :job_offer, path: "offre"
-        end
+        resource :job_offer, only: :show, path: "offre"
         resources :job_application_files, path: "documents"
         resources :emails, only: %i[index create] do
           member do

--- a/spec/requests/account/job_applications_spec.rb
+++ b/spec/requests/account/job_applications_spec.rb
@@ -34,19 +34,4 @@ RSpec.describe "Account::JobApplications" do
       expect(show_request).to render_template(:show)
     end
   end
-
-  describe "GET /espace-candidat/mes-candidatures/:id/offre" do
-    subject(:job_offer_request) { get job_offer_account_job_application_path(job_application) }
-
-    let(:job_application) { create(:job_application, user: user) }
-
-    it "is successful" do
-      job_offer_request
-      expect(response).to be_successful
-    end
-
-    it "renders the template" do
-      expect(job_offer_request).to render_template(:job_offer)
-    end
-  end
 end

--- a/spec/requests/account/job_offers_spec.rb
+++ b/spec/requests/account/job_offers_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Account::JobOffers" do
+  subject(:show_request) { get account_job_application_job_offer_path(job_application) }
+
+  let(:user) { create(:confirmed_user) }
+  let(:job_application) { create(:job_application, user:) }
+
+  before do
+    sign_in user
+    show_request
+  end
+
+  it { expect(response).to be_successful }
+
+  it { expect(response).to render_template(:show) }
+end

--- a/spec/requests/account/withdrawals_spec.rb
+++ b/spec/requests/account/withdrawals_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Account::Withdrawals" do
 
       it "redirects to job application page" do
         withdrawal_request
-        expect(response).to redirect_to(job_offer_account_job_application_path(job_application))
+        expect(response).to redirect_to(account_job_application_job_offer_path(job_application))
       end
 
       it "enqueues a notify_withdrawn email" do


### PR DESCRIPTION
# Description

Crudification de l'action non-CRUD `job_offer` de `Account::JobApplicationsController`. La page qui affiche l'offre liée à une candidature (espace candidat) devient le `show` d'une ressource RESTful imbriquée. L'URL publique `…/offre` est conservée.


# Review app

https://erecrutement-cvd-staging-pr2190.osc-fr1.scalingo.io

# Links

Refs #2109

