### PR TITLE
chore(deps): bump immutable from 4.3.5 to 4.3.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,10 @@ image-size@^0.5.1:
   resolved "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
 
-immutable@^4.0.0:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz"
-  integrity sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==
+immutable@4.3.8, immutable@^4.0.0:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
 
 inherits@^2.0.1, inherits@^2.0.3:
   version "2.0.4"


### PR DESCRIPTION
# Description

Montée de version du package npm `immutable` de 4.3.5 vers 4.3.8 (dernière version 4.x). Dépendance transitive tirée par `sass` (contrainte `^4.0.0`) ; seul le `yarn.lock` change.

# Test plan

- `yarn install --frozen-lockfile` passe sans modifier le lockfile.
- `yarn build:css` compile les feuilles de style sans erreur (sass utilise immutable).
- Vérifier que le rendu CSS du front et du back-office est inchangé.

# Review app

https://erecrutement-cvd-staging-pr2196.osc-fr1.scalingo.io

# Links

Reprend le bump de la PR Dependabot #2195 dans la série d'upgrades empilée sur `rails-upgrade-base-branch`.
