### PR TITLE
Crudify Account::EmailsController attachment action into a nested RESTful resource

### DIFF
--- a/app/controllers/account/emails/attachments_controller.rb
+++ b/app/controllers/account/emails/attachments_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Account::Emails::AttachmentsController < Account::BaseController
+  before_action :set_job_application
+
+  def show
+    email = @job_application.emails.find(params[:email_id])
+    content = email.email_attachments.find(params[:id]).document_content
+
+    send_data(
+      content.read,
+      filename: content.filename,
+      type: content.content_type
+    )
+  end
+
+  private
+
+  def set_job_application
+    @job_application = current_user.job_applications.find(params[:job_application_id])
+  end
+end

--- a/app/controllers/account/emails_controller.rb
+++ b/app/controllers/account/emails_controller.rb
@@ -39,18 +39,6 @@ class Account::EmailsController < Account::BaseController
     end
   end
 
-  def attachment
-    job_application = current_user.job_applications.find(params[:job_application_id])
-    email = job_application.emails.find(params[:id])
-    content = email.email_attachments.find(params[:email_attachment_id]).document_content
-
-    send_data(
-      content.read,
-      filename: content.filename,
-      type: content.content_type
-    )
-  end
-
   private
 
   def email_params

--- a/app/views/account/emails/_email.html.haml
+++ b/app/views/account/emails/_email.html.haml
@@ -14,7 +14,7 @@
     %span= simple_format(sanitize(email.body, tags: %w()))
     - email.email_attachments.each do |attachment|
       - next if attachment.document_content.blank?
-      = link_to attachment_account_job_application_email_path(email, email_attachment_id: attachment, job_application_id: email.job_application_id), target: "_blank" do
+      = link_to account_job_application_email_attachment_path(email.job_application_id, email, attachment), target: "_blank" do
         = fa_icon('file-lines')
         = attachment.document_content.filename
       %br

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,9 +236,7 @@ Rails.application.routes.draw do
         resource :job_offer, only: :show, path: "offre"
         resources :job_application_files, path: "documents"
         resources :emails, only: %i[index create] do
-          member do
-            get :attachment
-          end
+          resources :attachments, only: :show, module: :emails
         end
         resource :withdrawal, path: "desistement", only: :create
         resource :cover_letter, only: %i[show]

--- a/spec/requests/account/emails/attachments_spec.rb
+++ b/spec/requests/account/emails/attachments_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Account::Emails::Attachments" do
+  let(:user) { create(:confirmed_user) }
+  let(:job_application) { create(:job_application, user:) }
+  let(:email) { create(:email, job_application:) }
+  let(:email_attachment) { create(:email_attachment, email:) }
+
+  describe "GET /espace-candidat/mes-candidatures/:job_application_id/emails/:email_id/attachments/:id" do
+    subject(:show_request) do
+      get account_job_application_email_attachment_path(job_application, email, email_attachment)
+    end
+
+    context "when signed in" do
+      before do
+        sign_in user
+        show_request
+      end
+
+      it { expect(response).to be_successful }
+    end
+
+    context "when signed out" do
+      before { show_request }
+
+      it { expect(response).to redirect_to(new_user_session_path) }
+    end
+  end
+end

--- a/spec/requests/account/emails_spec.rb
+++ b/spec/requests/account/emails_spec.rb
@@ -37,17 +37,4 @@ RSpec.describe "Account::Emails" do
       it { expect(response.body).to include('action="replace"') }
     end
   end
-
-  describe "GET /espace-candidat/mes-candidatures/:job_application_id/emails/:id/attachment" do
-    subject(:attachment_request) do
-      get attachment_account_job_application_email_path(job_application, email, email_attachment_id: email_attachment.id)
-    end
-
-    let(:email) { create(:email, job_application:) }
-    let(:email_attachment) { create(:email_attachment, email:) }
-
-    before { attachment_request }
-
-    it { expect(response).to be_successful }
-  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Refactorisation de `Account::EmailsController` : extraction de l'action non-CRUD `attachment` (téléchargement d'une pièce jointe d'un courriel) vers une ressource RESTful imbriquée.

# Test plan

- Depuis l'espace candidat, ouvrir une candidature puis l'onglet des courriels.
- Sur un courriel comportant une pièce jointe, cliquer sur le lien de la pièce jointe.
- Vérifier que la pièce jointe se télécharge / s'ouvre correctement (bon fichier, bon type).
- Vérifier qu'un utilisateur non connecté est redirigé vers la page de connexion.

# Review app

https://erecrutement-cvd-staging-pr2197.osc-fr1.scalingo.io

# Links

Refs #2109
