### PR TITLE
Crudify send_job_offer on preferred users lists into JobOfferSendingsController#create

### DIFF
--- a/app/controllers/admin/preferred_users_lists/job_offer_sendings_controller.rb
+++ b/app/controllers/admin/preferred_users_lists/job_offer_sendings_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Admin::PreferredUsersLists::JobOfferSendingsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_preferred_users_list
+  before_action :authorize_job_offer_sending
+
+  def create
+    job_offer = JobOffer.find_by(identifier: params[:job_offer_identifier])
+
+    if job_offer&.send_to_users(@preferred_users_list.users)
+      redirect_back_or_to([:admin, @preferred_users_list], notice: t(".success"))
+    else
+      redirect_back_or_to([:admin, @preferred_users_list], notice: t(".error"))
+    end
+  end
+
+  private
+
+  def set_preferred_users_list
+    @preferred_users_list = PreferredUsersList.find(params[:preferred_users_list_id])
+  end
+
+  def authorize_job_offer_sending
+    authorize! :send_job_offer, @preferred_users_list
+  end
+end

--- a/app/controllers/admin/preferred_users_lists_controller.rb
+++ b/app/controllers/admin/preferred_users_lists_controller.rb
@@ -82,17 +82,6 @@ class Admin::PreferredUsersListsController < Admin::InheritedResourcesController
     redirect_to %i[admin users]
   end
 
-  def send_job_offer
-    preferred_users_list = PreferredUsersList.find(params[:id])
-    job_offer = JobOffer.find_by(identifier: params["job_offer_identifier"])
-
-    if job_offer&.send_to_users(preferred_users_list.users)
-      redirect_back_or_to([:admin, preferred_users_list], notice: t(".success"))
-    else
-      redirect_back_or_to([:admin, preferred_users_list], notice: t(".error"))
-    end
-  end
-
   protected
 
   def permitted_fields

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/app/views/admin/preferred_users_lists/show.html.haml
+++ b/app/views/admin/preferred_users_lists/show.html.haml
@@ -14,7 +14,7 @@
         = t('buttons.delete')
     = render partial: 'search'
 
-    = form_tag [:send_job_offer, :admin, @preferred_users_list] do
+    = form_tag [:admin, @preferred_users_list, :job_offer_sending] do
       .row.mt-2.mb-3
         .col-4
           = label_tag "job_offer_identifier", "Envoyer une offre par email aux candidats", class: "form-control-label"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1149,9 +1149,10 @@ fr:
         success: "Candidat·e retiré·e avec succès"
         error: "Une erreur s'est produite"
     preferred_users_lists:
-      send_job_offer:
-        success: "Offre envoyée aux candidats"
-        error: "L'offre n'a pa pu être envoyé, veuillez vérifier la référence"
+      job_offer_sendings:
+        create:
+          success: "Offre envoyée aux candidats"
+          error: "L'offre n'a pa pu être envoyé, veuillez vérifier la référence"
       form:
         title_new: "Ajout d'une nouvelle liste de candidats"
         title_edit: "Édition d'une liste de candidats"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,8 +113,8 @@ Rails.application.routes.draw do
     resources :preferred_users_lists, path: "liste-candidats" do
       member do
         get :export
-        post :send_job_offer
       end
+      resource :job_offer_sending, only: %i[create], module: :preferred_users_lists
       resources :preferred_users
     end
     resources :users, path: "candidats", except: %i[create update] do

--- a/spec/requests/admin/preferred_users_lists/job_offer_sendings_spec.rb
+++ b/spec/requests/admin/preferred_users_lists/job_offer_sendings_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::PreferredUsersLists::JobOfferSendings" do
+  let(:administrator) { create(:administrator) }
+  let(:preferred_users_list) { create(:preferred_users_list, :with_users, administrator:) }
+
+  before { sign_in administrator }
+
+  describe "POST /admin/liste-candidats/:preferred_users_list_id/job_offer_sending" do
+    subject(:create_request) {
+      post admin_preferred_users_list_job_offer_sending_path(preferred_users_list, job_offer_identifier: job_offer.identifier)
+    }
+
+    context "when the job offer exists" do
+      let(:job_offer) { create(:job_offer) }
+
+      it "sends the job offer to the users of the list" do
+        expect_any_instance_of(JobOffer).to receive(:send_to_users).with(preferred_users_list.users)
+        create_request
+      end
+
+      it { is_expected.to redirect_to(admin_preferred_users_list_path(preferred_users_list)) }
+    end
+
+    context "when the job offer does not exist" do
+      let(:job_offer) { instance_double(JobOffer, identifier: "unknown job offer") }
+
+      it "does not send the job offer to the users of the list" do
+        expect_any_instance_of(JobOffer).not_to receive(:send_to_users)
+        create_request
+      end
+
+      it { is_expected.to redirect_to(admin_preferred_users_list_path(preferred_users_list)) }
+    end
+  end
+end

--- a/spec/requests/admin/preferred_users_lists_spec.rb
+++ b/spec/requests/admin/preferred_users_lists_spec.rb
@@ -181,36 +181,4 @@ RSpec.describe "Admin::PreferredUsersLists" do
       end
     end
   end
-
-  describe "POST /admin/liste-candidats/:id/send_job_offer" do
-    subject(:send_job_offer_request) {
-      post send_job_offer_admin_preferred_users_list_path(preferred_users_list, job_offer_identifier: job_offer.identifier)
-    }
-
-    context "when the job offer exists" do
-      let(:job_offer) { create(:job_offer) }
-
-      it "sends the job offer to the users of the list" do
-        expect_any_instance_of(JobOffer).to receive(:send_to_users).with(preferred_users_list.users)
-        send_job_offer_request
-      end
-
-      it "redirects to the preferred users list" do
-        expect(send_job_offer_request).to redirect_to(admin_preferred_users_list_path(preferred_users_list))
-      end
-    end
-
-    context "when the job offer does not exist" do
-      let(:job_offer) { instance_double(JobOffer, identifier: "unknown job offer") }
-
-      it "doesn't send the job offer to the users of the list" do
-        expect_any_instance_of(JobOffer).not_to receive(:send_to_users)
-        send_job_offer_request
-      end
-
-      it "redirects to the preferred users list" do
-        expect(send_job_offer_request).to redirect_to(admin_preferred_users_list_path(preferred_users_list))
-      end
-    end
-  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Crudification de l'action custom `send_job_offer` de `Admin::PreferredUsersListsController`, qui devient une ressource RESTful dédiée.


# Test plan

1. Se connecter en admin et ouvrir une liste de candidats (`/admin/liste-candidats/:id`).
2. Dans le bloc « Envoyer une offre par email aux candidats », saisir une référence d'offre valide et cliquer sur « Envoyer ».
3. Vérifier le message de succès « Offre envoyée aux candidats » et que les candidat·es de la liste reçoivent l'email.
4. Recommencer avec une référence inconnue : message d'erreur affiché, aucun email envoyé.

# Review app

https://erecrutement-cvd-staging-pr2228.osc-fr1.scalingo.io

# Links

Refs #2109
