### PR TITLE
Crudify send_job_offer on users into JobOfferSendingsController#create

### DIFF
--- a/app/controllers/admin/users/job_offer_sendings_controller.rb
+++ b/app/controllers/admin/users/job_offer_sendings_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Admin::Users::JobOfferSendingsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_user
+  before_action :authorize_job_offer_sending
+
+  def create
+    job_offer = JobOffer.find_by(identifier: params[:job_offer_identifier])
+
+    if job_offer&.send_to_users([@user])
+      redirect_back_or_to([:admin, @user], notice: t(".success"))
+    else
+      redirect_back_or_to([:admin, @user], notice: t(".error"))
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def authorize_job_offer_sending
+    authorize! :send_job_offer, @user
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -85,17 +85,6 @@ class Admin::UsersController < Admin::InheritedResourcesController
     end
   end
 
-  def send_job_offer
-    user = User.find(params[:id])
-    job_offer = JobOffer.find_by(identifier: params["job_offer_identifier"])
-
-    if job_offer&.send_to_users([user])
-      redirect_back_or_to([:admin, user], notice: t(".success"))
-    else
-      redirect_back_or_to([:admin, user], notice: t(".error"))
-    end
-  end
-
   protected
 
   def permitted_params_listing

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/app/views/admin/users/_actions.html.haml
+++ b/app/views/admin/users/_actions.html.haml
@@ -2,7 +2,7 @@
   = fa_icon('gear', class: 'text-secondary')
   = t('.title')
 - if user.receive_job_offer_mails
-  = form_tag [:send_job_offer, :admin, user] do
+  = form_tag [:admin, user, :job_offer_sending] do
     .form-group.input-group
       .row
         .col-12

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -589,9 +589,10 @@ fr:
         account: "Mon compte"
         logout: "Déconnexion"
     users:
-      send_job_offer:
-        success: "Offre envoyée au candidat"
-        error: "L'offre n'a pa pu être envoyé, veuillez vérifier la référence"
+      job_offer_sendings:
+        create:
+          success: "Offre envoyée au candidat"
+          error: "L'offre n'a pa pu être envoyé, veuillez vérifier la référence"
       multi_select:
         success: "Offre envoyée aux candidats"
         error: "L'offre n'a pa pu être envoyé, veuillez vérifier la référence"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,9 +126,9 @@ Rails.application.routes.draw do
         get :listing
         get :photo
         put :update_listing
-        post :send_job_offer
       end
       resource :suspension, only: %i[create destroy], module: :users
+      resource :job_offer_sending, only: %i[create], module: :users
     end
     resources :job_applications, path: "candidatures", only: %i[index show update] do
       member do

--- a/spec/requests/admin/users/job_offer_sendings_spec.rb
+++ b/spec/requests/admin/users/job_offer_sendings_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Users::JobOfferSendings" do
+  let(:admin) { create(:administrator) }
+  let(:user) { create(:confirmed_user) }
+
+  before { sign_in admin }
+
+  describe "POST /admin/candidats/:user_id/job_offer_sending" do
+    subject(:create_request) {
+      post admin_user_job_offer_sending_path(user, job_offer_identifier: job_offer&.identifier)
+    }
+
+    context "when the job offer is present" do
+      let(:job_offer) { create(:job_offer) }
+
+      it { expect { create_request }.to change { ActionMailer::Base.deliveries.count }.by(1) }
+
+      it { is_expected.to redirect_to(admin_user_path(user)) }
+    end
+
+    context "when the job offer is missing" do
+      let(:job_offer) { nil }
+
+      it { is_expected.to redirect_to(admin_user_path(user)) }
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -383,30 +383,4 @@ RSpec.describe "Admin::Users" do
       expect(response).to redirect_to(admin_users_path)
     end
   end
-
-  describe "POST /admin/candidats/:id/send_job_offer" do
-    context "when the job offer is present" do
-      subject(:send_job_offer_request) {
-        post send_job_offer_admin_user_path(user, job_offer_identifier: job_offer.identifier)
-      }
-
-      let!(:job_offer) { create(:job_offer) }
-
-      it "sends the job offer to the user" do
-        expect { send_job_offer_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-
-      it "redirects to user" do
-        expect(send_job_offer_request).to redirect_to(admin_user_path(user))
-      end
-    end
-
-    context "when the job offer is missing" do
-      subject(:send_job_offer_request) { post send_job_offer_admin_user_path(user) }
-
-      it "redirects to user" do
-        expect(send_job_offer_request).to redirect_to(admin_user_path(user))
-      end
-    end
-  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Crudification de l'action custom membre `send_job_offer` de `Admin::UsersController` : elle devient une ressource RESTful dédiée `Admin::Users::JobOfferSendingsController#create`.

- Route : `POST /admin/candidats/:id/send_job_offer` → `POST /admin/candidats/:user_id/job_offer_sending`
- Nouveau controller calqué sur `Admin::Users::SuspensionsController`
- i18n déplacée sous `admin.users.job_offer_sendings.create`
- L'envoi groupé via `multi_select` (clés `admin.users.multi_select.*`) reste inchangé
- Comportement inchangé (`ability.rb` et `en.yml` non modifiés ; autorisation `:send_job_offer` réutilisée)

Suite du lot « envois » de la campagne de crudification (après `preferred_users_lists`).

# Test plan

1. Se connecter en admin et ouvrir la fiche d'un candidat (`/admin/candidats/:id`) acceptant de recevoir des offres.
2. Dans le bloc « Actions », saisir une référence d'offre valide et cliquer sur « Envoyer ».
3. Vérifier le message « Offre envoyée au candidat » et la réception de l'email par le candidat.
4. Recommencer avec une référence inconnue : message d'erreur, aucun email envoyé.

# Review app

https://erecrutement-cvd-staging-pr2229.osc-fr1.scalingo.io

# Links

Refs #2109
