### PR TITLE
Crudify job_offers new_send/send_to_list into JobOffers::DispatchesController

### DIFF
--- a/app/controllers/admin/job_offers/dispatches_controller.rb
+++ b/app/controllers/admin/job_offers/dispatches_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Admin::JobOffers::DispatchesController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_job_offer
+  before_action :authorize_dispatch
+  layout "admin/job_offer_single"
+
+  def new
+  end
+
+  def create
+    preferred_users_lists = PreferredUsersList.where(id: params[:preferred_users_lists])
+    preferred_users_lists.each do |list|
+      @job_offer.send_to_users(list.users)
+    end
+
+    redirect_to %i[admin job_offers], notice: t(".success")
+  end
+
+  private
+
+  def set_job_offer
+    @job_offer = JobOffer.find(params[:job_offer_id])
+  end
+
+  def authorize_dispatch
+    authorize! :manage, @job_offer
+  end
+end

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -131,26 +131,6 @@ class Admin::JobOffersController < Admin::BaseController
     end
   end
 
-  # GET /admin/job_offers/1/new_send
-  # GET /admin/job_offers/1/new_send.json
-  def new_send
-  end
-
-  # POST /admin/job_offers/1/send_to_list
-  # POST /admin/job_offers/1/send_to_list.json
-  def send_to_list
-    preferred_users_lists = PreferredUsersList.where(
-      id: params[:preferred_users_lists]
-    )
-    preferred_users_lists.each do |list|
-      @job_offer.send_to_users(list.users)
-    end
-
-    respond_to do |format|
-      format.html { redirect_to %i[admin job_offers], notice: t(".success") }
-    end
-  end
-
   # DELETE /admin/job_offers/1
   # DELETE /admin/job_offers/1.json
   def destroy

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/app/views/admin/job_offers/_job_offer_nav.html.haml
+++ b/app/views/admin/job_offers/_job_offer_nav.html.haml
@@ -17,8 +17,8 @@
         = job_offer.job_applications_count
   %li.mr-3.nav-item
     - klasses = base_link_klasses.dup
-    - klasses << :active if active_tab[:action_name] == 'new_send'
-    = link_to "Envoyer", [:new_send, :admin, job_offer], class: klasses
+    - klasses << :active if active_tab[:controller_name] == 'dispatches'
+    = link_to "Envoyer", [:new, :admin, job_offer, :dispatch], class: klasses
   - if can? :transfer, job_offer
     %li.mr-3.nav-item
       - klasses = base_link_klasses.dup

--- a/app/views/admin/job_offers/dispatches/new.html.haml
+++ b/app/views/admin/job_offers/dispatches/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :card_inner do
   .card.mt-3
     .card-body
-      = form_with url: [:send_to_list, :admin, @job_offer] do |f|
+      = form_with url: [:admin, @job_offer, :dispatch] do |f|
         .form-inputs
           .row
             .col-12.col-md-6
@@ -18,4 +18,3 @@
                         = list.preferred_users_count
           .form-actions.text-right.mt-4
             = f.submit 'Envoyer', class: 'btn btn-primary btn-raised'
-

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -90,50 +90,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "3f5b56f0ff7076416959e23faf00c09ac8844ba6df57cc9e214c29ea28431c6e",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/admin/job_offers/_job_offer.html.haml",
-      "line": 6,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_class(true, \"card job-offer mt-3\", \"card-state-#{(Unresolved Model).new.state}\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::JobOffersController",
-          "method": "featured",
-          "line": 27,
-          "file": "app/controllers/admin/job_offers_controller.rb",
-          "rendered": {
-            "name": "admin/job_offers/featured",
-            "file": "app/views/admin/job_offers/featured.html.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "admin/job_offers/featured",
-          "line": 33,
-          "file": "app/views/admin/job_offers/featured.html.haml",
-          "rendered": {
-            "name": "admin/job_offers/_job_offer",
-            "file": "app/views/admin/job_offers/_job_offer.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "admin/job_offers/_job_offer"
-      },
-      "user_input": "(Unresolved Model).new.state",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
       "fingerprint": "59a781da5fbac07c57920f89dc6292587d989662e510f8f72043195261ee4643",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -309,50 +265,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "cd7f0d0004a2530f84271cccd2c9427b215c3d2e55b702875b41332d9ff5adbc",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/admin/job_offers/_job_offer.html.haml",
-      "line": 34,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_class(true, \"badge text-white text-uppercase text-nowrap mr-1\", badge_class((Unresolved Model).new.state.to_sym))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::JobOffersController",
-          "method": "featured",
-          "line": 27,
-          "file": "app/controllers/admin/job_offers_controller.rb",
-          "rendered": {
-            "name": "admin/job_offers/featured",
-            "file": "app/views/admin/job_offers/featured.html.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "admin/job_offers/featured",
-          "line": 33,
-          "file": "app/views/admin/job_offers/featured.html.haml",
-          "rendered": {
-            "name": "admin/job_offers/_job_offer",
-            "file": "app/views/admin/job_offers/_job_offer.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "admin/job_offers/_job_offer"
-      },
-      "user_input": "(Unresolved Model).new.state",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
       "fingerprint": "cea9afa6a109a8df16eb36f243cbf838a384189d69f753d805f60534d64822db",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -415,23 +327,166 @@
       "note": "False positive: params[:job_application_file_id] is used only as a DB lookup key in find(). The dom_id value comes from the record's own persisted ID, not from the param."
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
-      "file": "Gemfile.lock",
-      "line": 419,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "9334360b9407fbc8630c9a9398d35c05ac6bddf57145994683f39c5aff699171",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/job_offers/_job_offer.html.haml",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_class(true, \"card job-offer mt-3\", \"card-state-#{JobOffer.find(params[:job_offer_id]).state}\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::JobOffers::DispatchesController",
+          "method": "new",
+          "line": 10,
+          "file": "app/controllers/admin/job_offers/dispatches_controller.rb",
+          "rendered": {
+            "name": "layouts/admin/job_offer_single",
+            "file": "app/views/layouts/admin/job_offer_single.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "layouts/admin/job_offer_single",
+          "line": 11,
+          "file": "app/views/layouts/admin/job_offer_single.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_navbar_job_offer",
+            "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "admin/job_offers/_navbar_job_offer",
+          "line": 5,
+          "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_job_offer",
+            "file": "app/views/admin/job_offers/_job_offer.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/job_offers/_job_offer"
+      },
+      "user_input": "JobOffer.find(params[:job_offer_id]).state",
       "confidence": "Weak",
       "cwe_id": [
-        1104
+        79
       ],
-      "note": "Rails 7.2 reaches end-of-life on 2026-08-09; tracked for the Rails 8 upgrade, ignored until then"
+      "note": "False positive: the card class interpolates the record AASM state (a constrained enum). The job offer is loaded via find(params[:job_offer_id]); the param is only a DB lookup key, not reflected user input. Re-fingerprinted from 3f5b56f0 after JobOffers::DispatchesController started rendering this partial."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "cf25687fb2c4a07dd38547ea22202984dbe246f8efd12839d06f0b1fd31069b7",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/job_offers/_job_offer.html.haml",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_class(true, \"badge text-white text-uppercase text-nowrap mr-1\", badge_class(JobOffer.find(params[:job_offer_id]).state.to_sym))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::JobOffers::DispatchesController",
+          "method": "new",
+          "line": 10,
+          "file": "app/controllers/admin/job_offers/dispatches_controller.rb",
+          "rendered": {
+            "name": "layouts/admin/job_offer_single",
+            "file": "app/views/layouts/admin/job_offer_single.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "layouts/admin/job_offer_single",
+          "line": 11,
+          "file": "app/views/layouts/admin/job_offer_single.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_navbar_job_offer",
+            "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "admin/job_offers/_navbar_job_offer",
+          "line": 5,
+          "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_job_offer",
+            "file": "app/views/admin/job_offers/_job_offer.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/job_offers/_job_offer"
+      },
+      "user_input": "JobOffer.find(params[:job_offer_id]).state",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: badge_class maps the record AASM state (a constrained enum) to a CSS class. The job offer is loaded via find(params[:job_offer_id]); the param is only a DB lookup key, not reflected user input. Re-fingerprinted from cd7f0d00 after JobOffers::DispatchesController started rendering this partial."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "87e967e67ff3a7f8240363b571ff9bfb62dffc9a1d0a4fa96013b4ee1376180f",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/job_offers/_job_offer_nav.html.haml",
+      "line": 2,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_id(true, dom_id(JobOffer.find(params[:job_offer_id]), \"nav\"))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::JobOffers::DispatchesController",
+          "method": "new",
+          "line": 10,
+          "file": "app/controllers/admin/job_offers/dispatches_controller.rb",
+          "rendered": {
+            "name": "layouts/admin/job_offer_single",
+            "file": "app/views/layouts/admin/job_offer_single.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "layouts/admin/job_offer_single",
+          "line": 11,
+          "file": "app/views/layouts/admin/job_offer_single.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_navbar_job_offer",
+            "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "admin/job_offers/_navbar_job_offer",
+          "line": 4,
+          "file": "app/views/admin/job_offers/_navbar_job_offer.html.haml",
+          "rendered": {
+            "name": "admin/job_offers/_job_offer_nav",
+            "file": "app/views/admin/job_offers/_job_offer_nav.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/job_offers/_job_offer_nav"
+      },
+      "user_input": "JobOffer.find(params[:job_offer_id])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "False positive: dom_id is built from the record persisted integer id (find by params[:job_offer_id] is only a DB lookup key), not from raw user input."
     }
   ]
 }

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -436,8 +436,9 @@ fr:
       transfer:
         success: "Annonce transférée !"
         error: "L'annonce n'a pas pu être transférée, veuillez vérifier l'email du nouveau propriétaire"
-      send_to_list:
-        success: "Annonce diffusées !"
+      dispatches:
+        create:
+          success: "Annonce diffusées !"
       features:
         create:
           success: "Annonce mise à la une"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,9 +83,7 @@ Rails.application.routes.draw do
         get :board
         get :stats
         get :new_transfer
-        get :new_send
         post :transfer
-        post :send_to_list
         JobOffer.aasm.events.map(&:name).each do |event_name|
           patch(event_name.to_sym)
           action_name = :"update_and_#{event_name}"
@@ -96,6 +94,7 @@ Rails.application.routes.draw do
         end
       end
       resource :feature, only: %i[create destroy], module: :job_offers
+      resource :dispatch, only: %i[new create], module: :job_offers
       resources :job_applications, path: "candidatures" do
         member do
           get :cvlm

--- a/spec/requests/admin/job_offers/dispatches_spec.rb
+++ b/spec/requests/admin/job_offers/dispatches_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::JobOffers::Dispatches" do
+  before { sign_in create(:administrator) }
+
+  let(:job_offer) { create(:job_offer) }
+
+  describe "GET /admin/offresdemploi/:job_offer_id/dispatch/new" do
+    subject(:new_request) { get new_admin_job_offer_dispatch_path(job_offer) }
+
+    before { new_request }
+
+    it { expect(response).to be_successful }
+  end
+
+  describe "POST /admin/offresdemploi/:job_offer_id/dispatch" do
+    subject(:create_request) {
+      post admin_job_offer_dispatch_path(job_offer), params: {preferred_users_lists: [preferred_users_list.id]}
+    }
+
+    let(:preferred_users_list) { create(:preferred_users_list, :with_users) }
+
+    it { expect(create_request).to redirect_to(admin_job_offers_path) }
+
+    it "sends the job offer to the list users" do
+      expect { create_request }.to change { ActionMailer::Base.deliveries.size }.by(3)
+    end
+  end
+end

--- a/spec/requests/admin/job_offers_spec.rb
+++ b/spec/requests/admin/job_offers_spec.rb
@@ -274,22 +274,6 @@ RSpec.describe "Admin::Job_Offers" do
     end
   end
 
-  describe "POST /admin/offresdemploi/:id/send_to_list" do
-    subject(:send_to_list_request) do
-      post send_to_list_admin_job_offer_path(job_offer),
-        params: {preferred_users_lists: [preferred_users_list.id]}
-    end
-
-    let(:job_offer) { create(:job_offer) }
-    let(:preferred_users_list) { create(:preferred_users_list, :with_users) }
-
-    it { expect(send_to_list_request).to redirect_to(admin_job_offers_path) }
-
-    it "sends the job offer to the list users" do
-      expect { send_to_list_request }.to change { ActionMailer::Base.deliveries.size }.by(3)
-    end
-  end
-
   describe "POST /admin/offresdemploi (create_and_publish with an administrator actor)" do
     subject(:create_and_publish_request) do
       post admin_job_offers_path, params: {job_offer: attributes, commit: "create_and_publish"}

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Crudification des actions custom `new_send` + `send_to_list` de `Admin::JobOffersController`.

# Test plan

1. Se connecter en admin et ouvrir une offre (`/admin/offresdemploi/:id`).
2. Cliquer sur l'onglet « Envoyer » : le formulaire de diffusion s'affiche (onglet actif).
3. Cocher une ou plusieurs listes de candidats puis cliquer « Envoyer ».
4. Vérifier la redirection vers la liste des offres avec le message « Annonce diffusées ! » et la réception de l'offre par les candidat·es des listes.

# Review app

https://erecrutement-cvd-staging-pr2230.osc-fr1.scalingo.io

# Links

Refs #2109
