### PR TITLE
Crudify administrators resend_confirmation_instructions into ConfirmationInstructionsController

### DIFF
--- a/app/controllers/admin/settings/administrators/confirmation_instructions_controller.rb
+++ b/app/controllers/admin/settings/administrators/confirmation_instructions_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::Settings::Administrators::ConfirmationInstructionsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_administrator
+  before_action :authorize_confirmation_instruction
+
+  def create
+    @administrator.send_confirmation_instructions
+    respond_to do |format|
+      format.html { redirect_to %i[admin settings root], notice: t(".success") }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def set_administrator
+    @administrator = Administrator.find(params[:administrator_id])
+  end
+
+  def authorize_confirmation_instruction
+    authorize! :manage, @administrator
+  end
+end

--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -75,20 +75,6 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
     end
   end
 
-  # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions
-  # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions.json
-  def resend_confirmation_instructions
-    respond_to do |format|
-      @administrator.send_confirmation_instructions
-      format.html { redirect_to %i[admin settings root], notice: t(".success") }
-      format.json do
-        render :resend_confirmation_instructions,
-          status: :ok,
-          location: @administrator
-      end
-    end
-  end
-
   # POST /admin/settings/administrators/1/transfer
   def transfer
     if @administrator.transfer(params[:transfer_email])

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -41,7 +41,7 @@
       - unless administrator.confirmed_at.present?
         - if can?(:manage, administrator) && administrator.active?
           %li.list-inline-item
-            = link_to fa_icon('arrows-rotate'), [:resend_confirmation_instructions, :admin, :settings, administrator], method: :post, title: t('buttons.resend_confirmation_instructions'), data: {confirm: t('buttons.confirm')}
+            = link_to fa_icon('arrows-rotate'), [:admin, :settings, administrator, :confirmation_instruction], method: :post, title: t('buttons.resend_confirmation_instructions'), data: {confirm: t('buttons.confirm')}
       - if can?(:deactivate, administrator) && administrator.active?
         %li.list-inline-item
           = link_to fa_icon('close'), [:admin, :settings, administrator, :activation], method: :post, title: t('buttons.deactivate'), data: {confirm: t('buttons.confirm')}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -726,8 +726,9 @@ fr:
             success: "Compte désactivé"
           destroy:
             success: "Compte réactivé"
-        resend_confirmation_instructions:
-          success: "Invitation renvoyée !"
+        confirmation_instructions:
+          create:
+            success: "Invitation renvoyée !"
         unlock_instructions:
           create:
             success: "Instructions de déblocage envoyées"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,10 +186,10 @@ Rails.application.routes.draw do
           get :inactive
         end
         member do
-          post :resend_confirmation_instructions
           post :transfer
         end
         resource :activation, only: %i[create destroy], module: :administrators
+        resource :confirmation_instruction, only: %i[create], module: :administrators
         resource :unlock_instruction, only: %i[create], module: :administrators
       end
       resources :employers, :categories do

--- a/spec/requests/admin/settings/administrators/confirmation_instructions_spec.rb
+++ b/spec/requests/admin/settings/administrators/confirmation_instructions_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Settings::Administrators::ConfirmationInstructions" do
+  before { sign_in create(:administrator) }
+
+  describe "POST /admin/parametres/administrateurs/:administrator_id/confirmation_instruction" do
+    subject(:create_request) { post admin_settings_administrator_confirmation_instruction_path(administrator) }
+
+    let(:administrator) { create(:administrator) }
+
+    it { expect { create_request }.to change { ActionMailer::Base.deliveries.count }.by(1) }
+
+    it { is_expected.to redirect_to(admin_settings_root_path) }
+  end
+end

--- a/spec/requests/admin/settings/administrators_spec.rb
+++ b/spec/requests/admin/settings/administrators_spec.rb
@@ -156,22 +156,6 @@ RSpec.describe "Admin::Settings::Administrators" do
     end
   end
 
-  describe "POST /admin/parametres/administrateurs/:id/resend_confirmation_instructions" do
-    subject(:resend_confirmation_instructions_request) {
-      post resend_confirmation_instructions_admin_settings_administrator_path(administrator)
-    }
-
-    let(:administrator) { create(:administrator) }
-
-    it "sends the unlock instructions" do
-      expect { resend_confirmation_instructions_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
-
-    it "redirects to admin settings" do
-      expect(resend_confirmation_instructions_request).to redirect_to(admin_settings_root_path)
-    end
-  end
-
   describe "POST /admin/parametres/administrateurs/:id/transfer" do
     subject(:transfer_request) do
       post transfer_admin_settings_administrator_path(administrator), params: {transfer_email:}


### PR DESCRIPTION
# Description

Crudification de l'action custom `resend_confirmation_instructions` de `Admin::Settings::AdministratorsController` : elle devient une ressource RESTful dédiée `Admin::Settings::Administrators::ConfirmationInstructionsController#create`.

# Test plan

1. Se connecter en admin et ouvrir les paramètres → administrateurs (`/admin/parametres/administrateurs`).
2. Pour un administrateur **non confirmé** (et actif), cliquer sur l'icône « Renvoyer le courriel d'activation ».
3. Confirmer la boîte de dialogue.
4. Vérifier la redirection vers les paramètres avec « Invitation renvoyée ! » et la réception du courriel de confirmation.

# Review app

https://erecrutement-cvd-staging-pr2231.osc-fr1.scalingo.io

# Links

Refs #2109
