### PR TITLE
Crudify administrators send_unlock_instructions into UnlockInstructionsController

### DIFF
--- a/app/controllers/admin/settings/administrators/unlock_instructions_controller.rb
+++ b/app/controllers/admin/settings/administrators/unlock_instructions_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::Settings::Administrators::UnlockInstructionsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_administrator
+  before_action :authorize_unlock_instruction
+
+  def create
+    @administrator.send_unlock_instructions
+    respond_to do |format|
+      format.html { redirect_to %i[admin settings root], notice: t(".success") }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def set_administrator
+    @administrator = Administrator.find(params[:administrator_id])
+  end
+
+  def authorize_unlock_instruction
+    authorize! :manage, @administrator
+  end
+end

--- a/app/controllers/admin/settings/administrators_controller.rb
+++ b/app/controllers/admin/settings/administrators_controller.rb
@@ -75,16 +75,6 @@ class Admin::Settings::AdministratorsController < Admin::Settings::BaseControlle
     end
   end
 
-  # POST /admin/settings/administrators/1/send_unlock_instructions
-  # POST /admin/settings/administrators/1/send_unlock_instructions.json
-  def send_unlock_instructions
-    @administrator.send_unlock_instructions
-    respond_to do |format|
-      format.html { redirect_to %i[admin settings root], notice: t(".success") }
-      format.json { head :no_content }
-    end
-  end
-
   # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions
   # PATCH/PUT /admin/settings/administrators/1/resend_confirmation_instructions.json
   def resend_confirmation_instructions

--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/app/views/admin/settings/administrators/_administrator.html.haml
+++ b/app/views/admin/settings/administrators/_administrator.html.haml
@@ -30,7 +30,7 @@
       - if can?(:send_unlock_instructions, administrator) && administrator.access_locked?
         %small
           %em{style: 'line-height:1;'}= t('.lock_explanation')
-        = link_to [:send_unlock_instructions, :admin, :settings, administrator], method: :post, data: {confirm: t('buttons.confirm')}, class: 'btn btn-danger' do
+        = link_to [:admin, :settings, administrator, :unlock_instruction], method: :post, data: {confirm: t('buttons.confirm')}, class: 'btn btn-danger' do
           = fa_icon('arrows-rotate')
           = t('buttons.send_unlock_instructions')
   %td.text-right

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -719,6 +719,9 @@ fr:
             success: "Compte réactivé"
         resend_confirmation_instructions:
           success: "Invitation renvoyée !"
+        unlock_instructions:
+          create:
+            success: "Instructions de déblocage envoyées"
       cmgs:
         index:
           title: "Liste des CMG"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,10 +192,10 @@ Rails.application.routes.draw do
         end
         member do
           post :resend_confirmation_instructions
-          post :send_unlock_instructions
           post :transfer
         end
         resource :activation, only: %i[create destroy], module: :administrators
+        resource :unlock_instruction, only: %i[create], module: :administrators
       end
       resources :employers, :categories do
         member do

--- a/spec/requests/admin/settings/administrators/unlock_instructions_spec.rb
+++ b/spec/requests/admin/settings/administrators/unlock_instructions_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Settings::Administrators::UnlockInstructions" do
+  before { sign_in create(:administrator) }
+
+  describe "POST /admin/parametres/administrateurs/:administrator_id/unlock_instruction" do
+    subject(:create_request) { post admin_settings_administrator_unlock_instruction_path(administrator) }
+
+    let(:administrator) { create(:administrator) }
+
+    it { expect { create_request }.to change { ActionMailer::Base.deliveries.count }.by(1) }
+
+    it { is_expected.to redirect_to(admin_settings_root_path) }
+  end
+end

--- a/spec/requests/admin/settings/administrators_spec.rb
+++ b/spec/requests/admin/settings/administrators_spec.rb
@@ -156,22 +156,6 @@ RSpec.describe "Admin::Settings::Administrators" do
     end
   end
 
-  describe "POST /admin/parametres/administrateurs/:id/send_unlock_instructions" do
-    subject(:send_unlock_instructions_request) {
-      post send_unlock_instructions_admin_settings_administrator_path(administrator)
-    }
-
-    let(:administrator) { create(:administrator) }
-
-    it "sends the unlock instructions" do
-      expect { send_unlock_instructions_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
-
-    it "redirects to admin settings" do
-      expect(send_unlock_instructions_request).to redirect_to(admin_settings_root_path)
-    end
-  end
-
   describe "POST /admin/parametres/administrateurs/:id/resend_confirmation_instructions" do
     subject(:resend_confirmation_instructions_request) {
       post resend_confirmation_instructions_admin_settings_administrator_path(administrator)

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Crudification de l'action custom `send_unlock_instructions` de `Admin::Settings::AdministratorsController` : elle devient une ressource RESTful dédiée `Admin::Settings::Administrators::UnlockInstructionsController#create`.

# Test plan

1. Se connecter en admin et ouvrir les paramètres → administrateurs (`/admin/parametres/administrateurs`).
2. Pour un administrateur dont le compte est **verrouillé** (access locked), cliquer sur « Envoyer les instructions de déblocage ».
3. Confirmer la boîte de dialogue.
4. Vérifier la redirection vers les paramètres avec le message « Instructions de déblocage envoyées » et la réception du courriel de déblocage.

# Review app

https://erecrutement-cvd-staging-pr2232.osc-fr1.scalingo.io

# Links

Refs #2109
