### PR TITLE
Fix candidate profile crash in cvlm view (nil @job_application)

### DIFF
--- a/app/views/admin/job_applications/cvlm.html.haml
+++ b/app/views/admin/job_applications/cvlm.html.haml
@@ -15,8 +15,8 @@
     .card-subheader.bg-secondary
     %div
       %object{data: admin_user_resume_path(user), type: "application/pdf", width: "100%", height: "500px"}
-- if @job_application.cover_letter.present?
-  - cover_letter_url = admin_job_application_cover_letter_path(@job_application)
+- if job_application.cover_letter.present?
+  - cover_letter_url = admin_job_application_cover_letter_path(job_application)
   .card
     .card-header.with-subheader.bg-white.font-weight-bold.text-secondary.d-flex.align-items-center.justify-content-between
       %div

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe "Admin::Users" do
     it "redirects to the user index when the user is not found" do
       expect(get(admin_user_path(-1))).to redirect_to(admin_users_path)
     end
+
+    context "when the user has a job application" do
+      before { create(:job_application, user:) }
+
+      it { expect(get(admin_user_path(user))).to render_template(:show) }
+    end
   end
 
   describe "GET /admin/candidats/:id/photo" do


### PR DESCRIPTION
# Description

Sur la fiche candidat (`/admin/candidats/:id`), l'ouverture plante avec `undefined method 'cover_letter' for nil` dès que le candidat a au moins une candidature.

`app/views/admin/job_applications/cvlm.html.haml` est rendu avec un **local** `job_application` depuis `Admin::UsersController#show` **et** `Admin::JobApplicationsController#show`. Or le bloc « lettre de motivation » utilisait la variable d'instance `@job_application`, jamais définie dans `users#show`.

Correctif : utiliser le local `job_application`.

# Test plan

1. Se connecter en admin.
2. Ouvrir la fiche d'un candidat ayant au moins une candidature (`/admin/candidats/:id`).
3. La page s'affiche sans erreur (avant : 500 `undefined method 'cover_letter' for nil`).

# Review app

https://erecrutement-cvd-staging-pr2233.osc-fr1.scalingo.io
