### PR TITLE
Upgrade Scalingo stack to scalingo-26

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -11,5 +11,5 @@
   "scripts": {
     "first-deploy": "rails db:schema:load && rails db:seed"
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-24"
 }


### PR DESCRIPTION
# Description

On met à jour la stack Scalingo vers la dernière version (26).

Il y a peu de changement. Dans le code, seulement la modification du `scalingo.json` pour piloter les review apps. La review app permet de vérifier qu'il n'y a pas d'anomalie, et donc qu'on va pouvoir jouer la commande ci-dessous sereinement pour migrer les instances courantes.

# Après review

- [x] scalingo --app erecrutement-cvd-staging stacks-set scalingo-26
- [x] scalingo --app erecrutement-dga-staging stacks-set scalingo-26
- [x] scalingo --app erecrutement-cvd-production stacks-set scalingo-26
- [x] scalingo --app erecrutement-dga-production stacks-set scalingo-26





# Review app

https://erecrutement-cvd-staging-pr2234.osc-fr1.scalingo.io

# Links

https://doc.scalingo.com/platform/internals/stacks/stacks
https://doc.scalingo.com/platform/internals/stacks/scalingo-26-stack
https://doc.scalingo.com/platform/internals/stacks/stacks#migrating-to-a-new-stack

Closes #2180

