### PR TITLE
chore(deps): bump webrick from 1.8.1 to 1.9.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -625,7 +625,7 @@ GEM
       activesupport
       faraday (~> 2.0)
       faraday-follow_redirects
-    webrick (1.8.1)
+    webrick (1.9.2)
     websocket (1.2.10)
     websocket-driver (0.8.1)
       base64


### PR DESCRIPTION
# Description

Met à jour `webrick` de 1.8.1 vers 1.9.2 (montée de dépendance, dans la continuité de la mise à niveau Rails 8). La contrainte du `Gemfile` (`~> 1.8`) reste satisfaite.

# Test plan

- L'application démarre correctement en local (`bundle install` puis lancement du serveur).
- La CI passe au vert.

# Review app

https://erecrutement-cvd-staging-pr2235.osc-fr1.scalingo.io

# Links
Refs #2116 