### PR TITLE
Pin PostgreSQL image version in CI and Docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:16.9
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     tty: true
 
   db:
-    image: postgres:16-alpine
+    image: postgres:16.9-alpine
     environment:
       - POSTGRES_PASSWORD=password
     ports:


### PR DESCRIPTION
# Description

Verrouille l'image PostgreSQL sur la version patch exacte utilisée en production (`16.9`), afin que l'environnement de test soit déterministe et reproductible.


# Review app

https://erecrutement-cvd-staging-pr2247.osc-fr1.scalingo.io

# Links

Closes #2208

