### PR TITLE
back office access reserved to funtional admin only

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::BaseController < ApplicationController
   before_action :authenticate_administrator!
+  before_action :ensure_back_office_access
   load_and_authorize_resource
   layout "admin"
 
@@ -13,5 +14,18 @@ class Admin::BaseController < ApplicationController
 
   def authenticated_user_or_administrator
     current_administrator || "unknown"
+  end
+
+  private
+
+  # sign out logged in admins
+  # unless they are functional_administrator
+  # when BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY
+  def ensure_back_office_access
+    return if current_administrator.authorized_for_back_office?
+
+    sign_out(current_administrator)
+    flash[:alert] = I18n.t("devise.failure.inactive")
+    redirect_to new_administrator_session_path
   end
 end

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -128,7 +128,13 @@ class Administrator < ApplicationRecord
 
   # ensure user account is active
   def active_for_authentication?
-    super && !deleted_at
+    super && !deleted_at && authorized_for_back_office?
+  end
+
+  def authorized_for_back_office?
+    return true unless ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] == "true"
+
+    functional_administrator?
   end
 
   def password_required?

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -131,6 +131,7 @@ class Administrator < ApplicationRecord
     super && !deleted_at && authorized_for_back_office?
   end
 
+  # TODO: @msharififr remove this check in septembre 2026
   def authorized_for_back_office?
     return true unless ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] == "true"
 

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -400,6 +400,38 @@ RSpec.describe Administrator do
     end
   end
 
+  describe "#authorized_for_back_office?" do
+    subject(:authorized_for_back_office?) { administrator.authorized_for_back_office? }
+
+    let(:administrator) { build(:administrator, roles:) }
+
+    after { ENV.delete("BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY") }
+
+    context "when the BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY flag is disabled" do
+      before { ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] = "false" }
+
+      let(:roles) { [:hr_manager] }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY flag is enabled" do
+      before { ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] = "true" }
+
+      context "when the administrator is a functional administrator" do
+        let(:roles) { [:functional_administrator] }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the administrator is not a functional administrator" do
+        let(:roles) { [:hr_manager] }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe "#transfer" do
     subject(:transfer) { administrator.transfer(email) }
 

--- a/spec/requests/admin/base_controller_spec.rb
+++ b/spec/requests/admin/base_controller_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::BaseController" do
+  subject(:search_cities) { get admin_cities_path, params: {q: "Paris"}, as: :turbo_stream }
+
+  before do
+    sign_in administrator
+    allow(Net::HTTP).to receive(:get).and_return({"features" => []}.to_json)
+  end
+
+  after { ENV.delete("BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY") }
+
+  context "when the BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY flag is disabled" do
+    let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+
+    before do
+      ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] = "false"
+      search_cities
+    end
+
+    it { expect(response).to be_successful }
+  end
+
+  context "when the BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY flag is enabled" do
+    before { ENV["BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY"] = "true" }
+
+    context "when the administrator is a functional administrator" do
+      let(:administrator) { create(:administrator, roles: [:functional_administrator]) }
+
+      before { search_cities }
+
+      it { expect(response).to be_successful }
+    end
+
+    context "when the administrator is not a functional administrator" do
+      let(:administrator) { create(:administrator, roles: [:hr_manager]) }
+
+      before { search_cities }
+
+      it { expect(response).to redirect_to(new_administrator_session_path) }
+    end
+  end
+end


### PR DESCRIPTION
# Description
La PR permettra de donner accès au BO uniquement aux utilisateurs admins ayant le rôle `functional_administrator`. La restriction sera activée via une variable d'environnement -> `BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY` 
Si cette variable est égale à `true`: 
- le front office fonctionne normalement
- la partie admin sera accessible uniquement par les admins avec le rôle `functional_administrator`
- si des admins avec d'autres rôles sont connectés au moment de l'activation de cette option, ils seront déconnectés

# Test plan
Se connecter avec un admin user qui n'a pas le bon rôle. Activer la var d'env. Redémarrer le container web. Cliquer sur n'importe quel lien/bouton. L'utilisateur doit être déconnecté. 

Avec la var d'env `BACK_OFFICE_FUNCTIONAL_ADMIN_ONLY=true`, essayer de se connecter avec un admin user ayant le rôle functional_administrator. L'authentification (et toute l'app) doit fonctionner normalement. Essayer de se connecter avec un autre admin user, l'authentification doit afficher un message d'erreur. La partie candidat doit fonctionner normalement. 

# Review app

https://erecrutement-cvd-staging-pr2258.osc-fr1.scalingo.io

# Links

Closes #2198 