### PR TITLE
Lower inactive candidate purge threshold from 2 years to 1 year

### DIFF
--- a/lib/tasks/maintenance/inactive_candidates.rake
+++ b/lib/tasks/maintenance/inactive_candidates.rake
@@ -1,7 +1,7 @@
 require "csv"
 
 namespace :maintenance do
-  desc "Output inactive candidate accounts as CSV (no activity since INACTIVE_SINCE, default 2024-07-01)"
+  desc "Output inactive candidate accounts as CSV (no activity since INACTIVE_SINCE, default 2025-07-01)"
   task inactive_candidates_csv: :environment do
     cutoff = inactivity_cutoff
     format_time = ->(time) { time&.strftime("%Y-%m-%d %H:%M:%S") }
@@ -73,7 +73,7 @@ private
 # Cutoff before which an account is considered inactive.
 # Overridable through the INACTIVE_SINCE environment variable.
 def inactivity_cutoff
-  Time.zone.parse(ENV["INACTIVE_SINCE"].presence || "2024-07-01")
+  Time.zone.parse(ENV["INACTIVE_SINCE"].presence || "2025-07-01")
 end
 
 # Candidate accounts without any activity since the given cutoff:


### PR DESCRIPTION
# Description

La demande initiale (#2166, réalisée dans #2170) visait à purger les comptes candidats inactifs depuis **plus de 2 ans**. Elle a évolué : on cible désormais les comptes inactifs depuis **plus de 1 an**.

La logique de purge repose sur une date de coupure fixe : un compte est inactif s'il est inscrit avant cette date et n'a aucune connexion, session ni candidature depuis. Pour la purge cible de juillet 2026, cette date par défaut passe de `2024-07-01` à `2025-07-01`.

La variable d'environnement `INACTIVE_SINCE` permet toujours de surcharger la date à l'exécution.

# Test plan

- Lancer l'export : `bin/rake maintenance:inactive_candidates_csv`
- Vérifier que le message de fin mentionne bien le seuil `2025-07-01` (et non plus `2024-07-01`)
- Lancer la purge en simulation : `bin/rake maintenance:purge_inactive_candidates`
- Vérifier que le dry-run annonce le nombre de comptes inactifs depuis le `2025-07-01` et invite à relancer avec `CONFIRM=yes`

# Review app

https://erecrutement-cvd-staging-pr2259.osc-fr1.scalingo.io

# Links

Closes #2166
Fait suite à #2170

# Screenshots
