### PR TITLE
Bump net-imap to 0.6.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.3.7)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
# Description

Mise à jour de la gem `net-imap` de `0.3.7` vers `0.6.4.1` (dernière version publiée). Dépendance transitive de `mail`, mise à jour pour bénéficier des correctifs de sécurité et de maintenance. 

# Test plan

- [x] Créer un compte candidat et vérifier la bonne réception de l'email de confirmation.
- [x] Demander une réinitialisation de mot de passe et vérifier la réception de l'email correspondant.
- [x] Vérifier qu'une candidature à une offre déclenche bien les emails de notification attendus.

# Review app

https://erecrutement-cvd-staging-pr2264.osc-fr1.scalingo.io

# Links
https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/231