### PR TITLE
Bump faraday to 2.14.3 to fix CVE-2026-54297

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.22.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.0)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
# Description

Mise à jour de la gem `faraday` de `2.14.0` vers `2.14.3` pour corriger la faille de sécurité **CVE-2026-54297** (GHSA-98m9-hrrm-r99r, sévérité haute) : une récursion non contrôlée dans le `NestedParamsEncoder` permet un déni de service par épuisement de la pile via des paramètres de requête profondément imbriqués. Dépendance transitive utilisée comme client HTTP sortant (OIDC/OAuth).


# Review app

https://erecrutement-cvd-staging-pr2265.osc-fr1.scalingo.io

# Links

- Alerte Dependabot #267
- CVE-2026-54297 — https://github.com/advisories/GHSA-98m9-hrrm-r99r

