### PR TITLE
Extract the preferred users list export into a dedicated RESTful controller

### DIFF
--- a/app/controllers/admin/preferred_users_lists/exports_controller.rb
+++ b/app/controllers/admin/preferred_users_lists/exports_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Admin::PreferredUsersLists::ExportsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  before_action :set_preferred_users_list
+  before_action :authorize_export
+
+  def show
+    respond_to do |format|
+      format.xlsx do
+        file = Exporter::Users.new(
+          @preferred_users_list.users,
+          current_administrator,
+          name: @preferred_users_list.name
+        ).generate
+        send_data file.read, filename: "#{Time.zone.today}_e-recrutement_vivers.xlsx"
+      end
+      format.zip do
+        zip_id = SecureRandom.uuid
+        ZipJobApplicationFilesJob.perform_later(zip_id: zip_id, user_ids: @preferred_users_list.users.pluck(:id))
+        redirect_to admin_zip_file_path(zip_id)
+      end
+    end
+  end
+
+  private
+
+  def set_preferred_users_list
+    @preferred_users_list = PreferredUsersList.find(params[:preferred_users_list_id])
+  end
+
+  def authorize_export
+    authorize! :export, @preferred_users_list
+  end
+end

--- a/app/controllers/admin/preferred_users_lists_controller.rb
+++ b/app/controllers/admin/preferred_users_lists_controller.rb
@@ -58,24 +58,6 @@ class Admin::PreferredUsersListsController < Admin::InheritedResourcesController
     end
   end
 
-  def export
-    respond_to do |format|
-      format.xlsx do
-        file = Exporter::Users.new(
-          @preferred_users_list.users,
-          current_administrator,
-          name: @preferred_users_list.name
-        ).generate
-        send_data file.read, filename: "#{Time.zone.today}_e-recrutement_vivers.xlsx"
-      end
-      format.zip do
-        zip_id = SecureRandom.uuid
-        ZipJobApplicationFilesJob.perform_later(zip_id: zip_id, user_ids: @preferred_users_list.users.pluck(:id))
-        redirect_to admin_zip_file_path(zip_id)
-      end
-    end
-  end
-
   def destroy
     @preferred_users_list.destroy
 

--- a/app/views/admin/preferred_users_lists/show.html.haml
+++ b/app/views/admin/preferred_users_lists/show.html.haml
@@ -4,9 +4,9 @@
     .d-flex.align-items-center
       .h4.text-primary.d-md-flex.align-items-center.mr-auto
         = t('.preferred_users_html', count: @preferred_users.count, list_name: @preferred_users_list.name)
-      = link_to export_admin_preferred_users_list_path(@preferred_users_list, format: :xlsx), class: 'btn btn-primary btn-raised', target: "_blank" do
+      = link_to admin_preferred_users_list_export_path(@preferred_users_list, format: :xlsx), class: 'btn btn-primary btn-raised', target: "_blank" do
         = "Exporter XLSX"
-      = link_to export_admin_preferred_users_list_path(@preferred_users_list, format: :zip), class: 'btn btn-primary btn-raised ml-4', target: "_blank" do
+      = link_to admin_preferred_users_list_export_path(@preferred_users_list, format: :zip), class: 'btn btn-primary btn-raised ml-4', target: "_blank" do
         = "Exporter PDF"
       = link_to [:edit, :admin, :preferred_users_list], class: 'btn btn-primary btn-raised ml-4' do
         = t('buttons.edit')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,9 +110,7 @@ Rails.application.routes.draw do
     end
     resources :preferred_users, only: :destroy
     resources :preferred_users_lists, path: "liste-candidats" do
-      member do
-        get :export
-      end
+      resource :export, only: %i[show], module: :preferred_users_lists
       resource :job_offer_sending, only: %i[create], module: :preferred_users_lists
       resources :preferred_users
     end

--- a/spec/requests/admin/preferred_users_lists/exports_spec.rb
+++ b/spec/requests/admin/preferred_users_lists/exports_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::PreferredUsersLists::Exports" do
+  let(:administrator) { create(:administrator) }
+  let(:preferred_users_list) { create(:preferred_users_list, :with_users, administrator:) }
+
+  before { sign_in administrator }
+
+  describe "GET /admin/liste-candidats/:preferred_users_list_id/export" do
+    subject(:export_request) { get admin_preferred_users_list_export_path(preferred_users_list, format:) }
+
+    context "when the format is XLSX" do
+      let(:format) { :xlsx }
+
+      before { export_request }
+
+      it { expect(response).to be_successful }
+
+      it "returns an XLSX file" do
+        expect(response.headers["Content-Type"]).to eq(
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+      end
+    end
+
+    context "when the format is ZIP" do
+      let(:format) { :zip }
+      let(:zip_id) { "randomly generated uuid" }
+
+      before { allow(SecureRandom).to receive(:uuid).and_return(zip_id) }
+
+      it "enqueues a job to zip the candidates' files" do
+        expect { export_request }.to have_enqueued_job(ZipJobApplicationFilesJob).with(
+          zip_id:,
+          user_ids: preferred_users_list.users.pluck(:id)
+        )
+      end
+
+      it { is_expected.to redirect_to(admin_zip_file_path(zip_id)) }
+    end
+  end
+end

--- a/spec/requests/admin/preferred_users_lists_spec.rb
+++ b/spec/requests/admin/preferred_users_lists_spec.rb
@@ -145,40 +145,4 @@ RSpec.describe "Admin::PreferredUsersLists" do
       expect { preferred_users_list.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
-
-  describe "GET /admin/liste-candidats/:id/export" do
-    subject(:export_request) {
-      get export_admin_preferred_users_list_path(preferred_users_list, format: format)
-    }
-
-    context "when format is XLSX" do
-      let(:format) { :xlsx }
-
-      it "downloads the list as an XLSX file" do
-        export_request
-        expect(response).to be_successful
-        expect(response.headers["Content-Type"]).to eq(
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
-      end
-    end
-
-    context "when format is ZIP" do
-      let(:format) { :zip }
-
-      it "starts a background job to zip the files and redirects to zip file" do
-        uuid = "randomly generated uuid"
-        allow(SecureRandom).to receive(:uuid).and_return(uuid)
-
-        expect {
-          export_request
-        }.to have_enqueued_job(ZipJobApplicationFilesJob).with(
-          zip_id: uuid,
-          user_ids: preferred_users_list.users.pluck(:id)
-        )
-
-        expect(response).to redirect_to(admin_zip_file_path(uuid))
-      end
-    end
-  end
 end


### PR DESCRIPTION
# Description

Extraction de l'action non-CRUD `export` de `Admin::PreferredUsersListsController` vers un contrôleur RESTful dédié `Admin::PreferredUsersLists::ExportsController` (action `show`). Le contrôleur d'origine ne conserve désormais que les actions CRUD standard.


# Test plan

Depuis le back-office, ouvrir un vivier (liste de candidats) :

- [x] cliquer sur « Exporter XLSX » → le téléchargement du fichier `.xlsx` des candidats démarre ;
- [x] cliquer sur « Exporter PDF » → redirection vers la page de génération de l'archive ZIP des pièces des candidats.

# Review app

https://erecrutement-cvd-staging-pr2267.osc-fr1.scalingo.io

# Links

Closes #2240
