### PR TITLE
Extract the admin email attachment download into a dedicated RESTful controller

### DIFF
--- a/app/controllers/admin/emails/attachments_controller.rb
+++ b/app/controllers/admin/emails/attachments_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Admin::Emails::AttachmentsController < Admin::BaseController
+  skip_load_and_authorize_resource
+  load_and_authorize_resource :job_application
+  load_and_authorize_resource :email, through: :job_application
+
+  def show
+    content = @email.email_attachments.find(params[:id]).document_content
+
+    send_data(
+      content.read,
+      filename: content.filename,
+      type: content.content_type
+    )
+  end
+end

--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -33,15 +33,6 @@ class Admin::EmailsController < Admin::BaseController
     end
   end
 
-  def attachment
-    content = @email.email_attachments.find(params[:email_attachment_id]).document_content
-    send_data(
-      content.read,
-      filename: content.filename,
-      type: content.content_type
-    )
-  end
-
   private
 
   def email_params

--- a/app/views/admin/emails/_email.html.haml
+++ b/app/views/admin/emails/_email.html.haml
@@ -39,6 +39,6 @@
           - email.email_attachments.each do |attachment|
             - next if attachment.document_content.blank?
             %li
-              = link_to attachment_admin_job_application_email_path(email, email_attachment_id: attachment, job_application_id: email.job_application_id), target: "_blank" do
+              = link_to admin_job_application_email_attachment_path(email.job_application_id, email, attachment), target: "_blank" do
                 = fa_icon('file-lines')
                 = attachment.document_content.filename

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,9 +142,7 @@ Rails.application.routes.draw do
       resource :dar, only: %i[update]
       resources :messages, only: %i[create]
       resources :emails, only: %i[create] do
-        member do
-          get :attachment
-        end
+        resources :attachments, only: :show, module: :emails
         resource :reading, only: %i[create destroy], module: :emails
       end
     end

--- a/spec/requests/admin/emails/attachments_spec.rb
+++ b/spec/requests/admin/emails/attachments_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Emails::Attachments" do
+  let(:job_application) { create(:job_application) }
+  let(:email) { create(:email, job_application:) }
+  let(:email_attachment) { create(:email_attachment, email:) }
+
+  before { sign_in create(:administrator) }
+
+  describe "GET /admin/candidatures/:job_application_id/emails/:email_id/attachments/:id" do
+    subject(:show_request) do
+      get admin_job_application_email_attachment_path(job_application, email, email_attachment)
+    end
+
+    before { show_request }
+
+    it { expect(response).to be_successful }
+  end
+end

--- a/spec/requests/admin/emails_spec.rb
+++ b/spec/requests/admin/emails_spec.rb
@@ -76,17 +76,4 @@ RSpec.describe "Admin::Emails" do
       end
     end
   end
-
-  describe "GET /admin/candidatures/:job_application_id/emails/:id/attachment" do
-    subject(:attachment_request) do
-      get attachment_admin_job_application_email_path(job_application, email, email_attachment_id: email_attachment.id)
-    end
-
-    let(:email) { create(:email, job_application:) }
-    let(:email_attachment) { create(:email_attachment, email:) }
-
-    before { attachment_request }
-
-    it { expect(response).to be_successful }
-  end
 end


### PR DESCRIPTION
# Description

Extraction de l'action non-CRUD `attachment` de `Admin::EmailsController` vers un contrôleur RESTful dédié `Admin::Emails::AttachmentsController` (action `show`).


# Test plan

Depuis le back-office, sur la fiche d'une candidature comportant un email avec pièce(s) jointe(s) :

- [x] cliquer sur le lien d'une pièce jointe → le téléchargement / l'ouverture du fichier démarre dans un nouvel onglet.

# Review app

https://erecrutement-cvd-staging-pr2268.osc-fr1.scalingo.io

# Links

Closes #2244
