### PR TITLE
Move force_ssl config to the production environment file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,10 +49,6 @@ module Civilsdeladefense
         "Cache-Control" => "max-age=#{1.year.to_i}",
         "Expires" => 1.year.from_now.httpdate
       }
-
-      # Setup HSTS to ensure https
-      config.force_ssl = true
-      config.ssl_options = {hsts: {subdomains: false, preload: true, expires: 1.year}}
     end
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,10 +43,15 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # Deliberately left disabled: Scalingo's router terminates TLS and forwards
+  # X-Forwarded-Proto, which force_ssl already honors. Enabling assume_ssl would make
+  # every request look like HTTPS, suppressing the HTTP -> HTTPS redirect for requests
+  # that genuinely reach the app in plain HTTP.
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.ssl_options = {hsts: {subdomains: false, preload: true, expires: 1.year}}
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
# Description

Le forçage HTTPS était déjà actif en production depuis 2018, mais configuré dans `config/application.rb` sous une garde `Rails.env.production?` — ce qui le rendait invisible lors de l'audit de `config/environments/production.rb` (constat de #2214, où les options apparaissent commentées).

Cette PR déplace `config.force_ssl` et `config.ssl_options` vers `config/environments/production.rb`, leur emplacement idiomatique.

Un commentaire explique également pourquoi `assume_ssl` reste volontairement désactivé : le routeur Scalingo termine le TLS et transmet `X-Forwarded-Proto`, que `force_ssl` exploite déjà ; l'activer ferait passer toute requête pour du HTTPS et supprimerait la redirection pour une requête arrivant réellement en clair.

# Test plan

Sur la review app :

- accéder au site en HTTP (`curl -I http://erecrutement-cvd-staging-pr2274.osc-fr1.scalingo.io`) : la réponse est une redirection 301 vers l'URL en `https://` ;
- accéder au site en HTTPS : la réponse contient l'en-tête `Strict-Transport-Security` ;
- naviguer sur la review app (connexion, pages publiques) : aucune régression.

# Review app

https://erecrutement-cvd-staging-pr2274.osc-fr1.scalingo.io

# Links

Closes #2214
