### PR TITLE
Replace manual SQL range conditions with where(column: range)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,13 +70,3 @@ Rails/RootPathnameMethods:
 Rails/SelectMap:
   Exclude:
     - "app/models/user.rb"
-
-# Offense count: 15
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/WhereRange:
-  Exclude:
-    - "app/models/altcha_solution.rb"
-    - "app/models/concerns/deactivation_flow.rb"
-    - "app/models/concerns/deletion_flow.rb"
-    - "app/models/job_application_file_type.rb"
-    - "app/models/page.rb"

--- a/app/models/altcha_solution.rb
+++ b/app/models/altcha_solution.rb
@@ -23,7 +23,7 @@ class AltchaSolution < ApplicationRecord
     # Replay attacks are protected by the time stamp in the salt of the challenge for
     # the duration configured in the timeout. All solutions in the database that older
     # can be deleted.
-    AltchaSolution.where("created_at < ?", Time.now - Altcha.timeout).delete_all # rubocop:disable Rails/TimeZone
+    AltchaSolution.where(created_at: ...(Time.now - Altcha.timeout)).delete_all # rubocop:disable Rails/TimeZone
   end
 end
 

--- a/app/models/concerns/deactivation_flow.rb
+++ b/app/models/concerns/deactivation_flow.rb
@@ -30,25 +30,25 @@ module DeactivationFlow
     end
 
     def inactive_and_marked_for_deactivation_admins
-      where("marked_for_deactivation_on < ?", days_notice_period_before_deactivation.days.ago.to_date)
-        .where("last_sign_in_at < ?", days_inactivity_period_before_deactivation.days.ago)
+      where(marked_for_deactivation_on: ...days_notice_period_before_deactivation.days.ago.to_date)
+        .where(last_sign_in_at: ...days_inactivity_period_before_deactivation.days.ago)
     end
 
     def never_signed_in_and_marked_for_deactivation_admins
-      where("marked_for_deactivation_on < ?", days_notice_period_before_deactivation.days.ago.to_date)
+      where(marked_for_deactivation_on: ...days_notice_period_before_deactivation.days.ago.to_date)
         .where(last_sign_in_at: nil)
-        .where("created_at < ?", days_inactivity_period_before_deactivation.days.ago)
+        .where(created_at: ...days_inactivity_period_before_deactivation.days.ago)
     end
 
     def inactive_and_not_marked_for_deactivation_admin
-      where("last_sign_in_at < ?", notice_period_target_date)
+      where(last_sign_in_at: ...notice_period_target_date)
         .where(marked_for_deactivation_on: nil)
     end
 
     def never_signed_in_and_not_marked_for_deactivation_admins
       where(last_sign_in_at: nil)
         .where(marked_for_deactivation_on: nil)
-        .where("created_at < ?", notice_period_target_date)
+        .where(created_at: ...notice_period_target_date)
     end
 
     def notice_period_target_date

--- a/app/models/concerns/deletion_flow.rb
+++ b/app/models/concerns/deletion_flow.rb
@@ -12,8 +12,8 @@ module DeletionFlow
   module ClassMethods
     def destroy_when_too_old
       target_date = days_notice_period_before_deletion.days.ago.to_date
-      where("marked_for_deletion_on < ?", target_date)
-        .where("last_sign_in_at < ?", days_inactivity_period_before_deletion.days.ago)
+      where(marked_for_deletion_on: ...target_date)
+        .where(last_sign_in_at: ...days_inactivity_period_before_deletion.days.ago)
         .find_each do |user|
           email = user.email
           name = user.full_name
@@ -24,7 +24,7 @@ module DeletionFlow
     end
 
     def mark_for_deletion
-      where("last_sign_in_at < ?", notice_period_target_date)
+      where(last_sign_in_at: ...notice_period_target_date)
         .where(marked_for_deletion_on: nil)
         .find_each do |user|
           user.mark_for_deletion!

--- a/app/models/job_application_file_type.rb
+++ b/app/models/job_application_file_type.rb
@@ -33,8 +33,7 @@ class JobApplicationFileType < ApplicationRecord
   scope :visible_by_user_up_to, ->(state) {
     where(kind: :applicant_provided)
       .joins(:visibility_rules)
-      .where(visibility_rules: {by: :user})
-      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .where(visibility_rules: {by: :user, state: ..JobApplication.states[state]})
       .distinct
   }
 
@@ -50,8 +49,7 @@ class JobApplicationFileType < ApplicationRecord
 
   scope :visible_by, ->(administrator, state) {
     scope = joins(:visibility_rules)
-      .where(visibility_rules: {by: :administrator})
-      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .where(visibility_rules: {by: :administrator, state: ..JobApplication.states[state]})
       .distinct
     scope = scope.manager_provided if administrator.hr_manager? || administrator.payroll_manager?
     scope
@@ -60,8 +58,7 @@ class JobApplicationFileType < ApplicationRecord
   scope :required, ->(state) {
     where(required: true)
       .joins(:visibility_rules)
-      .where(visibility_rules: {by: :administrator})
-      .where("visibility_rules.state <= ?", JobApplication.states[state])
+      .where(visibility_rules: {by: :administrator, state: ..JobApplication.states[state]})
       .reorder(nil)
       .distinct
   }
@@ -71,8 +68,7 @@ class JobApplicationFileType < ApplicationRecord
 
     where(
       required: true,
-      id: VisibilityRule.where(by: :administrator)
-        .where("state <= ?", state_value)
+      id: VisibilityRule.where(by: :administrator, state: ..state_value)
         .select(:job_application_file_type_id)
     ).or(
       where(

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -61,7 +61,7 @@ class Page < ApplicationRecord
 
   def reinsert_previous_child
     previous_child = Page.where(parent_id: parent_id)
-      .where("depth >= ?", 2)
+      .where(depth: 2..)
       .where.not(id: id).first
     previous_child&.move_to_child_of(self)
   end


### PR DESCRIPTION
# Description

Remplace les conditions de plage écrites en SQL brut (`where("created_at < ?", ...)`, `state <= ?`, `depth >= ?`) par la syntaxe native de plage Rails (`where(created_at: ...date)`, `state: ..valeur`, `depth: 2..`), et retire l'entrée `Rails/WhereRange` de `.rubocop_todo.yml`.


Le `having("MAX(state) < ?", ...)` du scope `mandatory` (cité dans le constat du ticket) n'est pas converti : un agrégat dans un `HAVING` n'a pas d'équivalent en syntaxe hash/range (et le cop ne le signale pas).


# Review app

https://erecrutement-cvd-staging-pr2275.osc-fr1.scalingo.io

# Links

Closes #2222
