### PR TITLE
Bump puma from 6.4.3 to 8.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.4.3)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)


### PR DESCRIPTION
# Description

Mise à jour de Puma 6.4.3 → 8.0.2 pour corriger deux alertes Dependabot de sévérité haute touchant le parseur PROXY protocol v1 : 
- CVE-2026-47737 (spoofing d'IP source) 
- CVE-2026-47736 (épuisement mémoire à distance)

L'application n'utilise pas ce protocole (`set_remote_address`), elle n'était donc pas exploitable en l'état

# Test plan

- Ouvrir la review app et vérifier que le site répond normalement (accueil, navigation entre les pages, connexion).

# Review app

https://erecrutement-cvd-staging-pr2282.osc-fr1.scalingo.io

# Links

- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/241
- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/240
