### PR TITLE
Bump minimatch from 3.1.2 to 3.1.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,9 +1261,9 @@ minifill@^0.0.8:
   integrity sha512-DOw02Fev6xB40wyie/YJtnIhY0eI+iQ7aBQlSVkOy5OKlFAxob6uG301uvJyMT7F1OeMGfbDexOTabL3uLid1g==
 
 minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
# Description

Mise à jour de minimatch 3.1.2 → 3.1.5 (dépendance transitive de nodemon, le watcher CSS de dev) pour corriger trois alertes Dependabot de sévérité haute, toutes des ReDoS : 
- CVE-2026-26996
- CVE-2026-27904
- CVE-2026-27903

# Test plan

- Ouvrir la review app et vérifier que le site s'affiche normalement (styles et JS chargés : accueil, navigation, mise en page).

# Review app

https://erecrutement-cvd-staging-pr2283.osc-fr1.scalingo.io

# Links

- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/192
- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/193
- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/194
