### PR TITLE
Bump picomatch from 2.3.1 to 2.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,9 +1409,9 @@ picocolors@^1.0.0:
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
# Description

Mise à jour de picomatch 2.3.1 → 2.3.2 (dépendance transitive de chokidar et micromatch, outillage front) pour corriger une alerte Dependabot de sévérité haute : CVE-2026-33671, un ReDoS via des motifs extglob. Seul le `yarn.lock` change.

# Test plan

- Ouvrir la review app et vérifier que le site s'affiche normalement (styles et JS chargés : accueil, navigation, mise en page).

# Review app

https://erecrutement-cvd-staging-pr2285.osc-fr1.scalingo.io

# Links

- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/209
