### PR TITLE
Bump brace-expansion from 1.1.11 to 1.1.16

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -370,9 +370,9 @@ bootstrap@^4.3.1:
   integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
# Description

Mise à jour de brace-expansion 1.1.11 → 1.1.16 (dépendance transitive de minimatch via nodemon, outillage front) pour corriger une alerte Dependabot de sévérité haute : CVE-2026-13149, un DoS par expansion en temps exponentiel. Seul le `yarn.lock` change.

# Test plan

- Ouvrir la review app et vérifier que le site s'affiche normalement (styles et JS chargés : accueil, navigation, mise en page).

# Review app

https://erecrutement-cvd-staging-pr2286.osc-fr1.scalingo.io

# Links

- https://github.com/Bureau-Systeme-d-Information-BSI/civilsdeladefense/security/dependabot/272

# Screenshots

N/A
