### PR TITLE
Fix malformed RuboCop cop directive (Lint/CopDirectiveSyntax)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-Lint/CopDirectiveSyntax:
-  Exclude:
-    - "app/controllers/account/users_controller.rb"
-    - "app/controllers/users/registrations_controller.rb"
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/MapCompact:

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :configure_sign_up_params, only: [:create] # rubocop:disable Rails/LexicallyScopedActionFilter: change_password
+  before_action :configure_sign_up_params, only: [:create] # rubocop:disable Rails/LexicallyScopedActionFilter -- create is inherited from Devise::RegistrationsController
 
   def success
     @email = params[:email]


### PR DESCRIPTION
# Description

Corrige la directive RuboCop mal formée de `Users::RegistrationsController`. Le bloc d'exclusions `Lint/CopDirectiveSyntax` du `.rubocop_todo.yml` est supprimé.

À noter : la partie du ticket concernant `Account::UsersController` est déjà réglée : la PR #2192 a supprimé les actions custom et leurs directives.


# Review app

https://erecrutement-cvd-staging-pr2287.osc-fr1.scalingo.io

# Links

Closes #2223
