### PR TITLE
replace order sql string by active_record syntax

### DIFF
--- a/app/controllers/homepages_controller.rb
+++ b/app/controllers/homepages_controller.rb
@@ -11,7 +11,7 @@ class HomepagesController < ApplicationController
     @job_offers_selected = root_rel.where(featured: true)
     @job_offers_last = root_rel.limit(6)
 
-    @categories = Category.order("lft ASC").where(
+    @categories = Category.order(lft: :asc).where(
       "published_job_offers_count > ? AND depth <= ?", 0, 1
     )
 

--- a/app/controllers/job_offers_controller.rb
+++ b/app/controllers/job_offers_controller.rb
@@ -9,7 +9,7 @@ class JobOffersController < ApplicationController
   # GET /job_offers.json
   def index
     @page = current_organization.pages.where(parent_id: nil).first
-    @categories = Category.order("lft ASC").where(
+    @categories = Category.order(lft: :asc).where(
       "published_job_offers_count > ? AND depth = ?", 0, 0
     ).includes(:children)
     @contract_types = ContractType.all


### PR DESCRIPTION
# Description

La PR remplace la chaîne en SQL par la syntaxe conventionnelle d'ActiveRecord dans deux controllers `order("lft ASC") -> order(lft: :asc)`

# Review app

https://erecrutement-cvd-staging-pr2303.osc-fr1.scalingo.io

# Links

Closes #2225 