### PR TITLE
replace select(:job_offer_id).map(&:job_offer_id) by pluck

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ApplicationRecord
   end
 
   def already_applied?(job_offer)
-    job_applications.select(:job_offer_id).map(&:job_offer_id).include?(job_offer.id)
+    job_applications.pluck(:job_offer_id).include?(job_offer.id)
   end
 
   def job_applications_active


### PR DESCRIPTION
# Description

La PR remplace `select(:job_offer_id).map(&:job_offer_id)` par `job_applications.pluck(:job_offer_id).include?(job_offer.id)` -> `pluck` interroge directement la colonne et retourne un tableau de valeurs, sans instancier les modèles ActiveRecord.

# Review app

https://erecrutement-cvd-staging-pr2304.osc-fr1.scalingo.io

# Links

Closes #2226