### PR TITLE
removed all() before find_each() in daily_summary.rb

### DIFF
--- a/app/models/daily_summary.rb
+++ b/app/models/daily_summary.rb
@@ -12,7 +12,7 @@ class DailySummary
   end
 
   def prepare_and_send
-    Organization.all.find_each do |organization|
+    Organization.find_each do |organization|
       prepare(organization)
       send_mail(organization)
     end
@@ -113,7 +113,7 @@ class DailySummary
   def prepare_job_applications(organization)
     %w[accepted contract_received affected].each do |state|
       audits = find_job_applications_by_state(state)
-      audits.all.find_each do |element|
+      audits.find_each do |element|
         job_application = element.auditable
         if job_application.organization_id == organization.id
           add_summary_infos_for_job_application(job_application, state)


### PR DESCRIPTION
# Description
La PR supprime les `.all` redondants dans daily_summary.rb -> `Organization.find_each` et `audits.find_each`.

# Review app

https://erecrutement-cvd-staging-pr2305.osc-fr1.scalingo.io

# Links

Closes #2227 