### PR TITLE
Disable RorVsWild on review apps

### DIFF
--- a/config/initializers/rorvswild.rb
+++ b/config/initializers/rorvswild.rb
@@ -1,4 +1,4 @@
-if Rails.application.credentials.rorvswild_api_key.present?
+if Rails.application.credentials.rorvswild_api_key.present? && ENV["IS_REVIEW_APP"].blank?
   RorVsWild.start(
     api_key: Rails.application.credentials.rorvswild_api_key,
     ignore_exceptions: ["ActionController::RoutingError"],


### PR DESCRIPTION
# Description

Les review apps oscillent autour du seuil de 80 % de RAM, ce qui déclenche des mails d'alerte RorVsWild à répétition (🟩 / 🟥 `RAM < 80% on erecrutement-cvd-staging-prXXXX-web-1`). RorVsWild n'a pas d'utilité sur les review apps : on ne démarre plus l'agent quand `IS_REVIEW_APP` est défini.

