### PR TITLE
Extract the job offer exports into a dedicated RESTful controller

### DIFF
--- a/app/controllers/admin/job_offers/exports_controller.rb
+++ b/app/controllers/admin/job_offers/exports_controller.rb
@@ -4,8 +4,16 @@ class Admin::JobOffers::ExportsController < Admin::BaseController
   include JobOfferStats
 
   skip_load_and_authorize_resource
-  before_action :set_job_offer
-  before_action :authorize_export
+  before_action :authorize_exports, only: :index
+  before_action :set_job_offer, only: :show
+  before_action :authorize_export, only: :show
+
+  def index
+    job_offers = params[:select_all].present? ? JobOffer.all : JobOffer.where(id: params[:job_offer_ids])
+    file = Exporter::JobOffers.new(job_offers, current_administrator).generate
+
+    send_data file.read, filename: "#{Time.zone.today}_e-recrutement_offres.xlsx"
+  end
 
   def show
     file = Exporter::JobOffer.new({stats: export_data, job_offer: @job_offer}, current_administrator).generate
@@ -21,5 +29,9 @@ class Admin::JobOffers::ExportsController < Admin::BaseController
 
   def authorize_export
     authorize! :export, @job_offer
+  end
+
+  def authorize_exports
+    authorize! :exports, JobOffer
   end
 end

--- a/app/controllers/admin/job_offers/exports_controller.rb
+++ b/app/controllers/admin/job_offers/exports_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::JobOffers::ExportsController < Admin::BaseController
+  include JobOfferStats
+
+  skip_load_and_authorize_resource
+  before_action :set_job_offer
+  before_action :authorize_export
+
+  def show
+    file = Exporter::JobOffer.new({stats: export_data, job_offer: @job_offer}, current_administrator).generate
+
+    send_data file.read, filename: "#{Time.zone.today}_e-recrutement_offre.xlsx"
+  end
+
+  private
+
+  def set_job_offer
+    @job_offer = JobOffer.find(params[:job_offer_id])
+  end
+
+  def authorize_export
+    authorize! :export, @job_offer
+  end
+end

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -21,13 +21,6 @@ class Admin::JobOffersController < Admin::BaseController
     end
   end
 
-  def exports
-    job_offers = params[:select_all].present? ? JobOffer.all : JobOffer.where(id: params[:job_offer_ids])
-    file = Exporter::JobOffers.new(job_offers, current_administrator).generate
-
-    send_data file.read, filename: "#{Time.zone.today}_e-recrutement_offres.xlsx"
-  end
-
   # GET /admin/job_offers/1
   # GET /admin/job_offers/1.json
   def show

--- a/app/controllers/admin/job_offers_controller.rb
+++ b/app/controllers/admin/job_offers_controller.rb
@@ -21,13 +21,6 @@ class Admin::JobOffersController < Admin::BaseController
     end
   end
 
-  def export
-    job_offer = JobOffer.find(params[:id])
-    file = Exporter::JobOffer.new({stats: export_data, job_offer: job_offer}, current_administrator).generate
-
-    send_data file.read, filename: "#{Time.zone.today}_e-recrutement_offre.xlsx"
-  end
-
   def exports
     job_offers = params[:select_all].present? ? JobOffer.all : JobOffer.where(id: params[:job_offer_ids])
     file = Exporter::JobOffers.new(job_offers, current_administrator).generate

--- a/app/views/admin/job_offers/_job_offer.html.haml
+++ b/app/views/admin/job_offers/_job_offer.html.haml
@@ -55,7 +55,7 @@
               = fa_icon 'eye'
               = t('buttons.preview')
           %li.list-inline-item
-            = link_to [:export, :admin, job_offer], target: '_blank' do
+            = link_to admin_job_offer_export_path(job_offer), target: '_blank' do
               = fa_icon 'arrow-down'
               = t('buttons.export')
           - if can? :manage, job_offer

--- a/app/views/admin/job_offers/index.html.haml
+++ b/app/views/admin/job_offers/index.html.haml
@@ -13,7 +13,7 @@
             = fa_icon 'plus', class: 'mr-1'
             = t('.new_job_offer')
     = render partial: 'admin/job_offers/search'
-    = form_tag(exports_admin_job_offers_url, id: "export_job_offers", target: "_blank", data: {turbo: false}) do
+    = form_tag(admin_job_offers_exports_url, method: :get, id: "export_job_offers", target: "_blank", data: {turbo: false}) do
       -# inputs associated via form="export_job_offers"
     %div{data: {controller: "selectall"}}
       .d-flex.align-items-end{data: { controller: 'subcheckbox'}}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -306,6 +306,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 8.0.5 ends on 2026-10-07",
+      "file": "Gemfile.lock",
+      "line": 420,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "a47870d6886183992ffa4ffc8f9bb41f73ef1aa8d899abe01d8f0186a772b0e0",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,6 @@ Rails.application.routes.draw do
         end
       end
       member do
-        get :export
         get :board
         get :stats
         get :new_transfer
@@ -91,6 +90,7 @@ Rails.application.routes.draw do
           resources :readings, only: :create
         end
       end
+      resource :export, only: :show, module: :job_offers
       resource :feature, only: %i[create destroy], module: :job_offers
       resource :dispatch, only: %i[new create], module: :job_offers
       resources :job_applications, path: "candidatures" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,11 +64,11 @@ Rails.application.routes.draw do
     resources :job_offer_terms, only: %i[index]
     resources :job_offers, path: "offresdemploi" do
       collection do
-        post :exports
         post :feature, to: "job_offers/features#create"
         post :init, to: "job_offers#new"
         get :init, to: "job_offer_terms#index"
         get :add_actor
+        resources :exports, only: :index, controller: "job_offers/exports", as: :job_offers_exports
         resources :features, only: :index, controller: "job_offers/features", as: :job_offers_features
         resources :archives, only: :index, controller: "job_offers/archives", as: :job_offers_archives
         JobOffer.aasm.events.map(&:name).each do |event_name|

--- a/spec/requests/admin/job_offers/exports_spec.rb
+++ b/spec/requests/admin/job_offers/exports_spec.rb
@@ -5,6 +5,36 @@ require "rails_helper"
 RSpec.describe "Admin::JobOffers::Exports" do
   before { sign_in create(:administrator) }
 
+  describe "GET /admin/offresdemploi/exports" do
+    before { exports_request }
+
+    context "when a job_offer_ids list is provided" do
+      subject(:exports_request) { get admin_job_offers_exports_path, params: {job_offer_ids:} }
+
+      let(:job_offer_ids) { create_list(:job_offer, 2).map(&:id) }
+
+      it { expect(response).to be_successful }
+
+      it {
+        expect(response.headers["Content-Type"]).to eq(
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+      }
+    end
+
+    context "when selecting all job offers" do
+      subject(:exports_request) { get admin_job_offers_exports_path, params: {select_all: "on"} }
+
+      it { expect(response).to be_successful }
+
+      it {
+        expect(response.headers["Content-Type"]).to eq(
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+      }
+    end
+  end
+
   describe "GET /admin/offresdemploi/:job_offer_id/export" do
     subject(:export_request) { get admin_job_offer_export_path(job_offer) }
 

--- a/spec/requests/admin/job_offers/exports_spec.rb
+++ b/spec/requests/admin/job_offers/exports_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::JobOffers::Exports" do
+  before { sign_in create(:administrator) }
+
+  describe "GET /admin/offresdemploi/:job_offer_id/export" do
+    subject(:export_request) { get admin_job_offer_export_path(job_offer) }
+
+    let(:job_offer) { create(:published_job_offer) }
+
+    before do
+      create(:job_application, job_offer:)
+      export_request
+    end
+
+    it { expect(response).to be_successful }
+
+    it {
+      expect(response.headers["Content-Type"]).to eq(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      )
+    }
+  end
+end

--- a/spec/requests/admin/job_offers_spec.rb
+++ b/spec/requests/admin/job_offers_spec.rb
@@ -5,30 +5,6 @@ require "rails_helper"
 RSpec.describe "Admin::Job_Offers" do
   before { sign_in create(:administrator) }
 
-  describe "POST /admin/offresdemploi/exports" do
-    let(:job_offer_ids) { create_list(:job_offer, 2) }
-
-    context "when a job_offer_ids list is provided" do
-      it "export the job offers" do
-        post exports_admin_job_offers_path, params: {job_offer_ids: job_offer_ids}
-        expect(response).to be_successful
-        expect(response.headers["Content-Type"]).to eq(
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
-      end
-    end
-
-    context "when selecting all job offers" do
-      it "export the job offers" do
-        post exports_admin_job_offers_path, params: {select_all: "on"}
-        expect(response).to be_successful
-        expect(response.headers["Content-Type"]).to eq(
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
-      end
-    end
-  end
-
   describe "PATCH /admin/offresdemploi/:id/publish" do
     context "when the job offer can be published" do
       let(:job_offer) { create(:job_offer) }

--- a/spec/requests/admin/job_offers_spec.rb
+++ b/spec/requests/admin/job_offers_spec.rb
@@ -195,25 +195,6 @@ RSpec.describe "Admin::Job_Offers" do
     it { expect(response).to be_successful }
   end
 
-  describe "GET /admin/offresdemploi/:id/export" do
-    subject(:export_request) { get export_admin_job_offer_path(job_offer) }
-
-    let(:job_offer) { create(:published_job_offer) }
-
-    before do
-      create(:job_application, job_offer:)
-      export_request
-    end
-
-    it { expect(response).to be_successful }
-
-    it {
-      expect(response.headers["Content-Type"]).to eq(
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      )
-    }
-  end
-
   describe "GET /admin/offresdemploi/new" do
     subject(:new_request) do
       get new_admin_job_offer_path, headers: {"HTTP_REFERER" => referer}


### PR DESCRIPTION
# Description

Dans le cadre de #2237 (épuration des actions non CRUD de `Admin::JobOffersController`), cette PR extrait les deux actions d'export XLSX vers un contrôleur RESTful dédié `Admin::JobOffers::ExportsController` :

- `export` (GET member) → `show` : export d'une offre ;
- `exports` (POST collection) → `index`, transformée en GET : export des offres sélectionnées.

Les permissions sont inchangées : l'export unitaire reste ouvert à qui peut lire l'offre, l'export multiple reste réservé aux profils avec droits de gestion.

# Test plan

Se connecter au back-office avec un compte administrateur fonctionnel, puis aller sur la liste des offres.

**Export d'une offre**

1. Sur une ligne d'offre, cliquer sur « Exporter » (icône flèche vers le bas).
2. Un fichier `AAAA-MM-JJ_e-recrutement_offre.xlsx` se télécharge dans un nouvel onglet.
3. L'ouvrir et vérifier qu'il contient les informations de l'offre et les statistiques de ses candidatures (répartitions par état, genre, âge…).

**Export de plusieurs offres sélectionnées**

1. Cocher deux ou trois offres dans la liste (cases à cocher en début de ligne).
2. Cliquer sur le bouton « Exporter » en bas de la liste.
3. Un fichier `AAAA-MM-JJ_e-recrutement_offres.xlsx` se télécharge ; vérifier qu'il contient uniquement les offres cochées.

**Export de toutes les offres**

1. Cocher la case « tout sélectionner » en tête de liste.
2. Cliquer sur « Exporter ».
3. Vérifier que le fichier téléchargé contient l'ensemble des offres.

# Review app

https://erecrutement-cvd-staging-pr2317.osc-fr1.scalingo.io

# Links

Réf. #2237
